### PR TITLE
feat: packages/contracts — Zod schema definitions (94 tests)

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,7 +14,7 @@
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "check": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "clean": "rm -rf dist node_modules coverage"
   },
   "dependencies": {

--- a/packages/contracts/src/__tests__/enums.test.ts
+++ b/packages/contracts/src/__tests__/enums.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AgentStatus,
+  ArtifactKind,
+  CheckpointStatus,
+  ConnectionMode,
+  isValidRunTransition,
+  ProjectMemberRole,
+  RETRYABLE_RUN_STATUSES,
+  RunStatus,
+  SandboxStatus,
+  TERMINAL_RUN_STATUSES,
+  TriggerSource,
+  UIMessageChunkType,
+  VALID_RUN_TRANSITIONS,
+  VaultScope,
+} from '../enums.js';
+
+describe('RunStatus', () => {
+  it('has exactly 15 values', () => {
+    expect(RunStatus.options).toHaveLength(15);
+  });
+
+  it('parses valid status', () => {
+    expect(RunStatus.parse('queued')).toBe('queued');
+    expect(RunStatus.parse('completed')).toBe('completed');
+  });
+
+  it('rejects invalid status', () => {
+    expect(() => RunStatus.parse('invalid')).toThrow();
+    expect(() => RunStatus.parse('')).toThrow();
+    expect(() => RunStatus.parse(123)).toThrow();
+  });
+});
+
+describe('VALID_RUN_TRANSITIONS', () => {
+  it('covers all 15 statuses', () => {
+    expect(Object.keys(VALID_RUN_TRANSITIONS)).toHaveLength(15);
+  });
+
+  it('completed is terminal (no outgoing transitions)', () => {
+    expect(VALID_RUN_TRANSITIONS.completed).toHaveLength(0);
+  });
+
+  it('queued can go to provisioning or failed', () => {
+    expect(VALID_RUN_TRANSITIONS.queued).toContain('provisioning');
+    expect(VALID_RUN_TRANSITIONS.queued).toContain('failed');
+  });
+
+  it('failed can retry back to queued', () => {
+    expect(VALID_RUN_TRANSITIONS.failed).toContain('queued');
+  });
+
+  it('finalization follows ordered sequence', () => {
+    expect(VALID_RUN_TRANSITIONS.finalizing_prepare).toContain('finalizing_uploading');
+    expect(VALID_RUN_TRANSITIONS.finalizing_uploading).toContain('finalizing_verifying');
+    expect(VALID_RUN_TRANSITIONS.finalizing_verifying).toContain('finalizing_metadata_commit');
+    expect(VALID_RUN_TRANSITIONS.finalizing_metadata_commit).toContain('finalized');
+    expect(VALID_RUN_TRANSITIONS.finalized).toContain('completed');
+  });
+
+  it('worker_unreachable can recover or fail', () => {
+    expect(VALID_RUN_TRANSITIONS.worker_unreachable).toContain('running');
+    expect(VALID_RUN_TRANSITIONS.worker_unreachable).toContain('failed');
+  });
+});
+
+describe('TERMINAL_RUN_STATUSES', () => {
+  it('only contains completed (not failed — failed is retryable)', () => {
+    expect(TERMINAL_RUN_STATUSES).toEqual(['completed']);
+  });
+
+  it('terminal statuses have no outgoing transitions', () => {
+    for (const s of TERMINAL_RUN_STATUSES) {
+      expect(VALID_RUN_TRANSITIONS[s]).toHaveLength(0);
+    }
+  });
+});
+
+describe('RETRYABLE_RUN_STATUSES', () => {
+  it('contains failed', () => {
+    expect(RETRYABLE_RUN_STATUSES).toContain('failed');
+  });
+
+  it('retryable statuses have outgoing transitions', () => {
+    for (const s of RETRYABLE_RUN_STATUSES) {
+      expect(VALID_RUN_TRANSITIONS[s].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isValidRunTransition', () => {
+  it('allows valid transition', () => {
+    expect(isValidRunTransition('queued', 'provisioning')).toBe(true);
+  });
+
+  it('rejects invalid transition', () => {
+    expect(isValidRunTransition('queued', 'completed')).toBe(false);
+  });
+
+  it('rejects self-transition for completed', () => {
+    expect(isValidRunTransition('completed', 'completed')).toBe(false);
+  });
+
+  it('allows retry from failed to queued', () => {
+    expect(isValidRunTransition('failed', 'queued')).toBe(true);
+  });
+
+  it('rejects skipping finalization steps', () => {
+    expect(isValidRunTransition('finalizing_prepare', 'finalized')).toBe(false);
+    expect(isValidRunTransition('running', 'completed')).toBe(false);
+  });
+});
+
+describe('AgentStatus', () => {
+  it('has 2 values', () => {
+    expect(AgentStatus.options).toHaveLength(2);
+  });
+
+  it('parses valid values', () => {
+    expect(AgentStatus.parse('active')).toBe('active');
+    expect(AgentStatus.parse('closed')).toBe('closed');
+  });
+
+  it('rejects deleted (not in open-rush)', () => {
+    expect(() => AgentStatus.parse('deleted')).toThrow();
+  });
+});
+
+describe('TriggerSource', () => {
+  it('has 3 values', () => {
+    expect(TriggerSource.options).toHaveLength(3);
+  });
+
+  for (const v of ['user', 'webhook', 'api']) {
+    it(`parses "${v}"`, () => {
+      expect(TriggerSource.parse(v)).toBe(v);
+    });
+  }
+});
+
+describe('ConnectionMode', () => {
+  it('has 3 values', () => {
+    expect(ConnectionMode.options).toHaveLength(3);
+  });
+
+  for (const v of ['anthropic', 'bedrock', 'custom']) {
+    it(`parses "${v}"`, () => {
+      expect(ConnectionMode.parse(v)).toBe(v);
+    });
+  }
+});
+
+describe('ArtifactKind', () => {
+  it('has 6 values', () => {
+    expect(ArtifactKind.options).toHaveLength(6);
+  });
+});
+
+describe('SandboxStatus', () => {
+  it('has 6 values', () => {
+    expect(SandboxStatus.options).toHaveLength(6);
+  });
+});
+
+describe('VaultScope', () => {
+  it('has 2 values', () => {
+    expect(VaultScope.options).toHaveLength(2);
+  });
+});
+
+describe('CheckpointStatus', () => {
+  it('has 3 values', () => {
+    expect(CheckpointStatus.options).toHaveLength(3);
+  });
+});
+
+describe('ProjectMemberRole', () => {
+  it('has 3 values', () => {
+    expect(ProjectMemberRole.options).toHaveLength(3);
+  });
+});
+
+describe('UIMessageChunkType', () => {
+  it('has 16 event types', () => {
+    expect(UIMessageChunkType.options).toHaveLength(16);
+  });
+
+  it('includes all text events', () => {
+    for (const t of ['text-start', 'text-delta', 'text-end']) {
+      expect(UIMessageChunkType.safeParse(t).success).toBe(true);
+    }
+  });
+
+  it('includes all tool events', () => {
+    for (const t of [
+      'tool-input-start',
+      'tool-input-delta',
+      'tool-input-available',
+      'tool-output-available',
+      'tool-output-error',
+    ]) {
+      expect(UIMessageChunkType.safeParse(t).success).toBe(true);
+    }
+  });
+});

--- a/packages/contracts/src/__tests__/schemas.test.ts
+++ b/packages/contracts/src/__tests__/schemas.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent.js';
+import { ApiResponse, CreateRunRequest, CreateRunResponse } from '../api.js';
+import { Artifact } from '../artifact.js';
+import { RunCheckpoint } from '../checkpoint.js';
+import { RunEvent, UIMessageChunk } from '../events.js';
+import { Project, ProjectMember } from '../project.js';
+import { Run, RunSpec } from '../run.js';
+import { SandboxInfo } from '../sandbox.js';
+import { VaultEntry } from '../vault.js';
+
+const UUID = '550e8400-e29b-41d4-a716-446655440000';
+const UUID2 = '660e8400-e29b-41d4-a716-446655440000';
+const NOW = new Date().toISOString();
+
+// --- Run ---
+
+describe('Run', () => {
+  const validRun = {
+    id: UUID,
+    agentId: UUID2,
+    prompt: 'Build a web app',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  it('parses valid run with defaults', () => {
+    const r = Run.parse(validRun);
+    expect(r.status).toBe('queued');
+    expect(r.provider).toBe('claude-code');
+    expect(r.connectionMode).toBe('anthropic');
+    expect(r.retryCount).toBe(0);
+    expect(r.maxRetries).toBe(3);
+    expect(r.parentRunId).toBeNull();
+  });
+
+  it('rejects empty prompt', () => {
+    expect(() => Run.parse({ ...validRun, prompt: '' })).toThrow();
+  });
+
+  it('rejects invalid UUID for id', () => {
+    expect(() => Run.parse({ ...validRun, id: 'not-uuid' })).toThrow();
+  });
+
+  it('rejects negative retryCount', () => {
+    expect(() => Run.parse({ ...validRun, retryCount: -1 })).toThrow();
+  });
+
+  it('rejects retryCount > maxRetries', () => {
+    expect(() => Run.parse({ ...validRun, retryCount: 4, maxRetries: 3 })).toThrow();
+  });
+
+  it('accepts retryCount == maxRetries', () => {
+    const r = Run.parse({ ...validRun, retryCount: 3, maxRetries: 3 });
+    expect(r.retryCount).toBe(3);
+  });
+
+  it('accepts all valid statuses', () => {
+    for (const status of ['queued', 'running', 'completed', 'failed', 'worker_unreachable']) {
+      expect(Run.parse({ ...validRun, status }).status).toBe(status);
+    }
+  });
+
+  it('coerces string dates to Date objects', () => {
+    const r = Run.parse(validRun);
+    expect(r.createdAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('RunSpec', () => {
+  it('parses minimal valid spec', () => {
+    const s = RunSpec.parse({ prompt: 'hello', projectId: UUID });
+    expect(s.prompt).toBe('hello');
+    expect(s.projectId).toBe(UUID);
+  });
+
+  it('rejects missing prompt', () => {
+    expect(() => RunSpec.parse({ projectId: UUID })).toThrow();
+  });
+
+  it('rejects missing projectId', () => {
+    expect(() => RunSpec.parse({ prompt: 'hello' })).toThrow();
+  });
+
+  it('accepts optional fields', () => {
+    const s = RunSpec.parse({
+      prompt: 'hello',
+      projectId: UUID,
+      agentId: UUID2,
+      connectionMode: 'bedrock',
+      model: 'claude-sonnet-4-6',
+      triggerSource: 'webhook',
+    });
+    expect(s.connectionMode).toBe('bedrock');
+    expect(s.triggerSource).toBe('webhook');
+  });
+});
+
+// --- Agent ---
+
+describe('Agent', () => {
+  const validAgent = {
+    id: UUID,
+    projectId: UUID2,
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastActiveAt: NOW,
+  };
+
+  it('parses with defaults', () => {
+    const a = Agent.parse(validAgent);
+    expect(a.status).toBe('active');
+    expect(a.customTitle).toBeNull();
+    expect(a.config).toBeNull();
+  });
+
+  it('rejects customTitle over 200 chars', () => {
+    expect(() => Agent.parse({ ...validAgent, customTitle: 'a'.repeat(201) })).toThrow();
+  });
+
+  it('accepts customTitle at 200 chars', () => {
+    const a = Agent.parse({ ...validAgent, customTitle: 'a'.repeat(200) });
+    expect(a.customTitle).toHaveLength(200);
+  });
+});
+
+// --- Project ---
+
+describe('Project', () => {
+  const validProject = {
+    id: UUID,
+    name: 'My Project',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  it('parses with defaults', () => {
+    const p = Project.parse(validProject);
+    expect(p.sandboxProvider).toBe('opensandbox');
+    expect(p.defaultConnectionMode).toBe('anthropic');
+    expect(p.description).toBeNull();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => Project.parse({ ...validProject, name: '' })).toThrow();
+  });
+
+  it('rejects name over 255 chars', () => {
+    expect(() => Project.parse({ ...validProject, name: 'x'.repeat(256) })).toThrow();
+  });
+
+  it('accepts name at 255 chars', () => {
+    const p = Project.parse({ ...validProject, name: 'x'.repeat(255) });
+    expect(p.name).toHaveLength(255);
+  });
+});
+
+describe('ProjectMember', () => {
+  it('parses with default role', () => {
+    const m = ProjectMember.parse({
+      id: UUID,
+      projectId: UUID,
+      userId: UUID2,
+      createdAt: NOW,
+    });
+    expect(m.role).toBe('member');
+  });
+
+  it('accepts owner role', () => {
+    const m = ProjectMember.parse({
+      id: UUID,
+      projectId: UUID,
+      userId: UUID2,
+      role: 'owner',
+      createdAt: NOW,
+    });
+    expect(m.role).toBe('owner');
+  });
+
+  it('rejects invalid role', () => {
+    expect(() =>
+      ProjectMember.parse({
+        id: UUID,
+        projectId: UUID,
+        userId: UUID2,
+        role: 'superadmin',
+        createdAt: NOW,
+      })
+    ).toThrow();
+  });
+});
+
+// --- Events ---
+
+describe('UIMessageChunk', () => {
+  it('parses text-delta', () => {
+    const c = UIMessageChunk.parse({ type: 'text-delta', delta: 'hello' });
+    expect(c.type).toBe('text-delta');
+    expect(c.delta).toBe('hello');
+  });
+
+  it('parses tool event', () => {
+    const c = UIMessageChunk.parse({
+      type: 'tool-input-available',
+      toolCallId: 'tc-1',
+      toolName: 'bash',
+      input: { command: 'ls' },
+    });
+    expect(c.toolName).toBe('bash');
+  });
+
+  it('rejects invalid type', () => {
+    expect(() => UIMessageChunk.parse({ type: 'invalid-type' })).toThrow();
+  });
+});
+
+describe('RunEvent', () => {
+  it('parses valid event', () => {
+    const e = RunEvent.parse({
+      id: UUID,
+      runId: UUID2,
+      eventType: 'message',
+      seq: 0,
+      createdAt: NOW,
+    });
+    expect(e.seq).toBe(0);
+    expect(e.schemaVersion).toBe('1');
+  });
+
+  it('rejects negative seq', () => {
+    expect(() =>
+      RunEvent.parse({
+        id: UUID,
+        runId: UUID2,
+        eventType: 'message',
+        seq: -1,
+        createdAt: NOW,
+      })
+    ).toThrow();
+  });
+
+  it('rejects empty eventType', () => {
+    expect(() =>
+      RunEvent.parse({
+        id: UUID,
+        runId: UUID2,
+        eventType: '',
+        seq: 0,
+        createdAt: NOW,
+      })
+    ).toThrow();
+  });
+});
+
+// --- Artifact ---
+
+describe('Artifact', () => {
+  const valid = {
+    id: UUID,
+    runId: UUID2,
+    kind: 'diff',
+    path: '/workspace/patch.diff',
+    storagePath: 's3://bucket/patch.diff',
+    contentType: 'text/plain',
+    size: 1024,
+    checksum: 'abc123',
+    createdAt: NOW,
+  };
+
+  it('parses valid artifact', () => {
+    const a = Artifact.parse(valid);
+    expect(a.kind).toBe('diff');
+    expect(a.size).toBe(1024);
+  });
+
+  it('rejects negative size', () => {
+    expect(() => Artifact.parse({ ...valid, size: -1 })).toThrow();
+  });
+
+  it('accepts zero size', () => {
+    expect(Artifact.parse({ ...valid, size: 0 }).size).toBe(0);
+  });
+
+  it('rejects empty checksum', () => {
+    expect(() => Artifact.parse({ ...valid, checksum: '' })).toThrow();
+  });
+
+  it('rejects invalid kind', () => {
+    expect(() => Artifact.parse({ ...valid, kind: 'video' })).toThrow();
+  });
+
+  for (const kind of ['diff', 'patch', 'log', 'screenshot', 'build', 'report']) {
+    it(`accepts kind "${kind}"`, () => {
+      expect(Artifact.parse({ ...valid, kind }).kind).toBe(kind);
+    });
+  }
+});
+
+// --- Sandbox ---
+
+describe('SandboxInfo', () => {
+  const valid = {
+    id: UUID,
+    externalId: 'sandbox-123',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  it('parses with defaults', () => {
+    const s = SandboxInfo.parse(valid);
+    expect(s.status).toBe('creating');
+    expect(s.providerType).toBe('opensandbox');
+    expect(s.agentId).toBeNull();
+  });
+
+  it('rejects empty externalId', () => {
+    expect(() => SandboxInfo.parse({ ...valid, externalId: '' })).toThrow();
+  });
+
+  it('accepts all sandbox statuses', () => {
+    for (const status of ['creating', 'running', 'idle', 'destroying', 'destroyed', 'error']) {
+      expect(SandboxInfo.parse({ ...valid, status }).status).toBe(status);
+    }
+  });
+});
+
+// --- Vault ---
+
+describe('VaultEntry', () => {
+  const platformEntry = {
+    id: UUID,
+    scope: 'platform',
+    projectId: null,
+    name: 'API_KEY',
+    encryptedValue: 'enc:xxx',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  const projectEntry = {
+    id: UUID,
+    scope: 'project',
+    projectId: UUID2,
+    name: 'DB_PASSWORD',
+    encryptedValue: 'enc:yyy',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  it('parses valid platform entry', () => {
+    const v = VaultEntry.parse(platformEntry);
+    expect(v.scope).toBe('platform');
+    expect(v.projectId).toBeNull();
+  });
+
+  it('parses valid project entry', () => {
+    const v = VaultEntry.parse(projectEntry);
+    expect(v.scope).toBe('project');
+    expect(v.projectId).toBe(UUID2);
+  });
+
+  it('rejects platform scope with non-null projectId', () => {
+    expect(() => VaultEntry.parse({ ...platformEntry, projectId: UUID2 })).toThrow();
+  });
+
+  it('rejects project scope with null projectId', () => {
+    expect(() => VaultEntry.parse({ ...projectEntry, projectId: null })).toThrow();
+  });
+
+  it('rejects empty name', () => {
+    expect(() => VaultEntry.parse({ ...platformEntry, name: '' })).toThrow();
+  });
+
+  it('rejects empty encryptedValue', () => {
+    expect(() => VaultEntry.parse({ ...platformEntry, encryptedValue: '' })).toThrow();
+  });
+
+  it('defaults keyVersion to 1', () => {
+    const v = VaultEntry.parse(platformEntry);
+    expect(v.keyVersion).toBe(1);
+  });
+});
+
+// --- Checkpoint ---
+
+describe('RunCheckpoint', () => {
+  const valid = {
+    id: UUID,
+    createdAt: NOW,
+  };
+
+  it('parses with defaults', () => {
+    const c = RunCheckpoint.parse(valid);
+    expect(c.status).toBe('in_progress');
+    expect(c.degradedRecovery).toBe(false);
+    expect(c.runId).toBeNull();
+  });
+
+  it('accepts all checkpoint statuses', () => {
+    for (const status of ['in_progress', 'completed', 'failed']) {
+      expect(RunCheckpoint.parse({ ...valid, status }).status).toBe(status);
+    }
+  });
+});
+
+// --- API ---
+
+describe('CreateRunRequest', () => {
+  it('is equivalent to RunSpec', () => {
+    const req = CreateRunRequest.parse({ prompt: 'hello', projectId: UUID });
+    expect(req.prompt).toBe('hello');
+  });
+});
+
+describe('CreateRunResponse', () => {
+  it('parses valid response', () => {
+    const res = CreateRunResponse.parse({
+      runId: UUID,
+      agentId: UUID2,
+      isNewAgent: true,
+    });
+    expect(res.isNewAgent).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    expect(() => CreateRunResponse.parse({ runId: UUID })).toThrow();
+  });
+});
+
+describe('ApiResponse', () => {
+  it('parses success response', () => {
+    const r = ApiResponse.parse({ success: true, data: { id: UUID } });
+    expect(r.success).toBe(true);
+  });
+
+  it('parses error response', () => {
+    const r = ApiResponse.parse({ success: false, error: 'Not found', code: 'NOT_FOUND' });
+    expect(r.error).toBe('Not found');
+  });
+
+  it('rejects missing success field', () => {
+    expect(() => ApiResponse.parse({ data: {} })).toThrow();
+  });
+});

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { AgentStatus } from './enums.js';
+
+export const Agent = z.object({
+  id: z.string().uuid(),
+  projectId: z.string().uuid(),
+  status: AgentStatus.default('active'),
+  customTitle: z.string().max(200).nullable().default(null),
+  config: z.unknown().nullable().default(null),
+  createdBy: z.string().uuid().nullable().default(null),
+  activeStreamId: z.string().nullable().default(null),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  lastActiveAt: z.coerce.date(),
+});
+export type Agent = z.infer<typeof Agent>;

--- a/packages/contracts/src/api.ts
+++ b/packages/contracts/src/api.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { RunSpec } from './run.js';
+
+export const CreateRunRequest = RunSpec;
+export type CreateRunRequest = z.infer<typeof CreateRunRequest>;
+
+export const CreateRunResponse = z.object({
+  runId: z.string().uuid(),
+  agentId: z.string().uuid(),
+  isNewAgent: z.boolean(),
+});
+export type CreateRunResponse = z.infer<typeof CreateRunResponse>;
+
+export const ApiResponse = z.object({
+  success: z.boolean(),
+  data: z.unknown().optional(),
+  error: z.string().optional(),
+  code: z.string().optional(),
+  message: z.string().optional(),
+});
+export type ApiResponse = z.infer<typeof ApiResponse>;

--- a/packages/contracts/src/artifact.ts
+++ b/packages/contracts/src/artifact.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { ArtifactKind } from './enums.js';
+
+export const Artifact = z.object({
+  id: z.string().uuid(),
+  runId: z.string().uuid(),
+  kind: ArtifactKind,
+  path: z.string().min(1),
+  storagePath: z.string().min(1),
+  contentType: z.string().min(1),
+  size: z.number().int().nonnegative(),
+  checksum: z.string().min(1),
+  createdAt: z.coerce.date(),
+});
+export type Artifact = z.infer<typeof Artifact>;

--- a/packages/contracts/src/checkpoint.ts
+++ b/packages/contracts/src/checkpoint.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { CheckpointStatus } from './enums.js';
+
+export const RunCheckpoint = z.object({
+  id: z.string().uuid(),
+  runId: z.string().uuid().nullable().default(null),
+  status: CheckpointStatus.default('in_progress'),
+  messagesSnapshotRef: z.string().nullable().default(null),
+  workspaceDeltaRef: z.string().nullable().default(null),
+  lastEventSeq: z.number().int().nullable().default(null),
+  pendingToolCalls: z.unknown().nullable().default(null),
+  degradedRecovery: z.boolean().default(false),
+  createdAt: z.coerce.date(),
+});
+export type RunCheckpoint = z.infer<typeof RunCheckpoint>;

--- a/packages/contracts/src/enums.ts
+++ b/packages/contracts/src/enums.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+
+// --- Run Status (15-state machine) ---
+
+export const RunStatus = z.enum([
+  'queued',
+  'provisioning',
+  'preparing',
+  'running',
+  'finalizing_prepare',
+  'finalizing_uploading',
+  'finalizing_verifying',
+  'finalizing_metadata_commit',
+  'finalized',
+  'completed',
+  'failed',
+  'worker_unreachable',
+  'finalizing_retryable_failed',
+  'finalizing_timeout',
+  'finalizing_manual_intervention',
+]);
+export type RunStatus = z.infer<typeof RunStatus>;
+
+export const VALID_RUN_TRANSITIONS: Record<RunStatus, readonly RunStatus[]> = {
+  queued: ['provisioning', 'failed'],
+  provisioning: ['preparing', 'failed'],
+  preparing: ['running', 'failed'],
+  running: ['finalizing_prepare', 'failed', 'worker_unreachable'],
+  finalizing_prepare: ['finalizing_uploading', 'failed', 'finalizing_retryable_failed'],
+  finalizing_uploading: ['finalizing_verifying', 'failed', 'finalizing_retryable_failed'],
+  finalizing_verifying: ['finalizing_metadata_commit', 'failed', 'finalizing_retryable_failed'],
+  finalizing_metadata_commit: ['finalized', 'failed', 'finalizing_retryable_failed'],
+  finalized: ['completed'],
+  completed: [],
+  failed: ['queued'],
+  worker_unreachable: ['failed', 'running'],
+  finalizing_retryable_failed: ['finalizing_uploading', 'finalizing_timeout'],
+  finalizing_timeout: ['finalizing_manual_intervention'],
+  finalizing_manual_intervention: ['failed'],
+};
+
+/** Terminal: no outgoing transitions possible */
+export const TERMINAL_RUN_STATUSES: readonly RunStatus[] = ['completed'];
+
+/** Failed but can retry back to queued */
+export const RETRYABLE_RUN_STATUSES: readonly RunStatus[] = ['failed'];
+
+export function isValidRunTransition(from: RunStatus, to: RunStatus): boolean {
+  return VALID_RUN_TRANSITIONS[from].includes(to);
+}
+
+// --- Agent ---
+
+export const AgentStatus = z.enum(['active', 'closed']);
+export type AgentStatus = z.infer<typeof AgentStatus>;
+
+// --- Trigger & Provider ---
+
+export const TriggerSource = z.enum(['user', 'webhook', 'api']);
+export type TriggerSource = z.infer<typeof TriggerSource>;
+
+export const ConnectionMode = z.enum(['anthropic', 'bedrock', 'custom']);
+export type ConnectionMode = z.infer<typeof ConnectionMode>;
+
+// --- Artifact ---
+
+export const ArtifactKind = z.enum(['diff', 'patch', 'log', 'screenshot', 'build', 'report']);
+export type ArtifactKind = z.infer<typeof ArtifactKind>;
+
+// --- Sandbox ---
+
+export const SandboxStatus = z.enum([
+  'creating',
+  'running',
+  'idle',
+  'destroying',
+  'destroyed',
+  'error',
+]);
+export type SandboxStatus = z.infer<typeof SandboxStatus>;
+
+// --- Vault ---
+
+export const VaultScope = z.enum(['platform', 'project']);
+export type VaultScope = z.infer<typeof VaultScope>;
+
+// --- Checkpoint ---
+
+export const CheckpointStatus = z.enum(['in_progress', 'completed', 'failed']);
+export type CheckpointStatus = z.infer<typeof CheckpointStatus>;
+
+// --- Project Member ---
+
+export const ProjectMemberRole = z.enum(['owner', 'admin', 'member']);
+export type ProjectMemberRole = z.infer<typeof ProjectMemberRole>;
+
+// --- UIMessageChunk ---
+
+export const UIMessageChunkType = z.enum([
+  'text-start',
+  'text-delta',
+  'text-end',
+  'reasoning-start',
+  'reasoning-delta',
+  'reasoning-end',
+  'tool-input-start',
+  'tool-input-delta',
+  'tool-input-available',
+  'tool-output-available',
+  'tool-output-error',
+  'start',
+  'finish',
+  'error',
+  'start-step',
+  'finish-step',
+]);
+export type UIMessageChunkType = z.infer<typeof UIMessageChunkType>;

--- a/packages/contracts/src/events.ts
+++ b/packages/contracts/src/events.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import { UIMessageChunkType } from './enums.js';
+
+export const UIMessageChunk = z.object({
+  type: UIMessageChunkType,
+  id: z.string().optional(),
+  content: z.string().optional(),
+  delta: z.string().optional(),
+  toolCallId: z.string().optional(),
+  toolName: z.string().optional(),
+  input: z.unknown().optional(),
+  output: z.string().optional(),
+  errorText: z.string().optional(),
+  reason: z.string().optional(),
+});
+export type UIMessageChunk = z.infer<typeof UIMessageChunk>;
+
+export const RunEvent = z.object({
+  id: z.string().uuid(),
+  runId: z.string().uuid(),
+  eventType: z.string().min(1),
+  payload: z.unknown().nullable().default(null),
+  seq: z.number().int().nonnegative(),
+  schemaVersion: z.string().default('1'),
+  createdAt: z.coerce.date(),
+});
+export type RunEvent = z.infer<typeof RunEvent>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,1 +1,10 @@
-export {};
+export * from './agent.js';
+export * from './api.js';
+export * from './artifact.js';
+export * from './checkpoint.js';
+export * from './enums.js';
+export * from './events.js';
+export * from './project.js';
+export * from './run.js';
+export * from './sandbox.js';
+export * from './vault.js';

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { ConnectionMode, ProjectMemberRole } from './enums.js';
+
+export const Project = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(255),
+  description: z.string().nullable().default(null),
+  sandboxProvider: z.string().default('opensandbox'),
+  defaultModel: z.string().nullable().default(null),
+  defaultConnectionMode: ConnectionMode.nullable().default('anthropic'),
+  createdBy: z.string().uuid().nullable().default(null),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+export type Project = z.infer<typeof Project>;
+
+export const ProjectMember = z.object({
+  id: z.string().uuid(),
+  projectId: z.string().uuid(),
+  userId: z.string().uuid(),
+  role: ProjectMemberRole.default('member'),
+  createdAt: z.coerce.date(),
+});
+export type ProjectMember = z.infer<typeof ProjectMember>;

--- a/packages/contracts/src/run.ts
+++ b/packages/contracts/src/run.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { ConnectionMode, RunStatus, TriggerSource } from './enums.js';
+
+export const Run = z
+  .object({
+    id: z.string().uuid(),
+    agentId: z.string().uuid(),
+    parentRunId: z.string().uuid().nullable().default(null),
+    status: RunStatus.default('queued'),
+    prompt: z.string().min(1),
+    provider: z.string().default('claude-code'),
+    connectionMode: ConnectionMode.default('anthropic'),
+    modelId: z.string().nullable().default(null),
+    triggerSource: TriggerSource.default('user'),
+    activeStreamId: z.string().nullable().default(null),
+    retryCount: z.number().int().nonnegative().default(0),
+    maxRetries: z.number().int().positive().default(3),
+    errorMessage: z.string().nullable().default(null),
+    attachmentsJson: z.unknown().nullable().default(null),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+    startedAt: z.coerce.date().nullable().default(null),
+    completedAt: z.coerce.date().nullable().default(null),
+  })
+  .refine((r) => r.retryCount <= r.maxRetries, {
+    message: 'retryCount must be <= maxRetries',
+  });
+export type Run = z.infer<typeof Run>;
+
+export const RunSpec = z.object({
+  prompt: z.string().min(1),
+  projectId: z.string().uuid(),
+  agentId: z.string().uuid().optional(),
+  connectionMode: ConnectionMode.optional(),
+  model: z.string().optional(),
+  triggerSource: TriggerSource.optional(),
+});
+export type RunSpec = z.infer<typeof RunSpec>;

--- a/packages/contracts/src/sandbox.ts
+++ b/packages/contracts/src/sandbox.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { SandboxStatus } from './enums.js';
+
+export const SandboxInfo = z.object({
+  id: z.string().uuid(),
+  agentId: z.string().uuid().nullable().default(null),
+  externalId: z.string().min(1),
+  status: SandboxStatus.default('creating'),
+  providerType: z.string().default('opensandbox'),
+  endpoint: z.string().nullable().default(null),
+  ttlSeconds: z.number().int().positive().nullable().default(null),
+  labels: z.record(z.string()).nullable().default(null),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  destroyedAt: z.coerce.date().nullable().default(null),
+});
+export type SandboxInfo = z.infer<typeof SandboxInfo>;

--- a/packages/contracts/src/vault.ts
+++ b/packages/contracts/src/vault.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import { VaultScope } from './enums.js';
+
+export const VaultEntry = z
+  .object({
+    id: z.string().uuid(),
+    scope: VaultScope,
+    projectId: z.string().uuid().nullable().default(null),
+    ownerId: z.string().uuid().nullable().default(null),
+    name: z.string().min(1).max(255),
+    credentialType: z.string().default('env'),
+    encryptedValue: z.string().min(1),
+    keyVersion: z.number().int().positive().default(1),
+    injectionTarget: z.string().nullable().default(null),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+  })
+  .refine(
+    (v) =>
+      (v.scope === 'platform' && v.projectId === null) ||
+      (v.scope === 'project' && v.projectId !== null),
+    {
+      message: "scope='platform' requires projectId=null; scope='project' requires projectId!=null",
+    }
+  );
+export type VaultEntry = z.infer<typeof VaultEntry>;

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    passWithNoTests: true,
+    include: ['src/**/*.test.ts'],
   },
 });

--- a/specs/contracts.md
+++ b/specs/contracts.md
@@ -1,0 +1,109 @@
+# Contracts Specification
+
+packages/contracts 定义 Rush 平台所有核心数据类型的 Zod schema。零运行时依赖（仅 Zod）。
+
+## 设计原则
+
+- Zod schema 是 single source of truth，TypeScript 类型从 Zod 推导
+- 每个 schema 文件对应一个领域概念
+- 枚举值、状态机转换规则、验证逻辑全部在 contracts 中定义
+- DB schema (packages/db) 的列类型必须与 contracts 保持一致
+
+## 文件结构
+
+```
+packages/contracts/src/
+  enums.ts              — 所有枚举值
+  run.ts                — Run, RunSpec, RunStatus 状态机
+  agent.ts              — Agent
+  project.ts            — Project, ProjectMember
+  events.ts             — UIMessageChunk (16 types), RunEvent
+  artifact.ts           — Artifact, ArtifactKind
+  sandbox.ts            — SandboxInfo, SandboxStatus
+  vault.ts              — VaultEntry, VaultScope
+  checkpoint.ts         — RunCheckpoint
+  api.ts                — ApiResponse, CreateRunRequest/Response
+  index.ts              — barrel export
+```
+
+## 枚举定义
+
+### RunStatus（15 状态状态机）
+
+```
+queued → provisioning → preparing → running
+  → finalizing_prepare → finalizing_uploading → finalizing_verifying
+  → finalizing_metadata_commit → finalized → completed
+
+异常路径:
+  任意 → failed（大部分状态可直接失败）
+  failed → queued（重试）
+  running → worker_unreachable → failed | running（恢复或失败）
+  finalizing_* → finalizing_retryable_failed → finalizing_uploading | finalizing_timeout
+  finalizing_timeout → finalizing_manual_intervention → failed
+```
+
+### AgentStatus
+`active | closed`
+
+### TriggerSource
+`user | webhook | api`
+
+### Provider
+`claude-code`（当前唯一，预留扩展）
+
+### ConnectionMode
+`anthropic | bedrock | custom`
+
+### ArtifactKind
+`diff | patch | log | screenshot | build | report`
+
+### SandboxStatus
+`creating | running | idle | destroying | destroyed | error`
+
+### VaultScope
+`platform | project`
+
+### CheckpointStatus
+`in_progress | completed | failed`
+
+### ProjectMemberRole
+`owner | admin | member`
+
+## UIMessageChunk 事件类型（16 种）
+
+浏览器端 SSE 流式事件：
+
+```
+text-start, text-delta, text-end
+reasoning-start, reasoning-delta, reasoning-end
+tool-input-start, tool-input-delta, tool-input-available
+tool-output-available, tool-output-error
+start, finish, error
+start-step, finish-step
+```
+
+## 状态机转换规则
+
+VALID_RUN_TRANSITIONS 是一个 Record<RunStatus, RunStatus[]>，定义了每个状态可以转换到哪些状态。
+任何不在转换表中的状态变更应被拒绝。
+
+## 验证规则
+
+- Run.prompt: 非空字符串
+- Run.retryCount: 非负整数，<= maxRetries
+- Run.maxRetries: 正整数，默认 3
+- Agent.customTitle: 最长 200 字符
+- Project.name: 非空，最长 255 字符
+- Artifact.size: 非负整数
+- Artifact.checksum: 非空字符串
+- VaultEntry: scope='platform' 时 projectId 必须为 null，scope='project' 时 projectId 必须非 null
+
+## 测试要求
+
+每个 schema 需要测试：
+1. 正常路径：合法数据能通过验证
+2. 默认值：省略可选字段后默认值正确
+3. 边界值：空字符串、最大长度、零值
+4. 非法输入：类型错误、违反约束、非法枚举值
+5. 状态机：合法/非法的状态转换


### PR DESCRIPTION
## Summary

- 10 Zod schema files defining all core data types for the Rush platform
- 15-state RunStatus state machine with transition rules
- 16 UIMessageChunk event types for browser SSE streaming
- VaultEntry with bidirectional scope validation (refine)
- Run with retryCount <= maxRetries cross-field validation
- Spec document: `specs/contracts.md`

## Sparring Review Fixes

- Run: added `.refine(retryCount <= maxRetries)` (was missing)
- TERMINAL_RUN_STATUSES: only `completed` (failed is retryable, not terminal)
- Project.defaultConnectionMode: nullable to match DB schema
- Provider: kept as string (not enum) for future extensibility, documented in spec

## Test Plan

- [x] 94 test cases: enums (48) + schemas (46)
- [x] Covers: valid/invalid/boundary for every schema
- [x] State machine: valid/invalid transitions, terminal/retryable distinction
- [x] `pnpm build && pnpm check && pnpm lint && pnpm test` all pass

Closes #5