### PR TITLE
feat: packages/stream — Redis-backed resumable SSE (31 tests)

### DIFF
--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -14,13 +14,15 @@
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "check": "tsc --noEmit",
     "lint": "biome check .",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "clean": "rm -rf dist node_modules coverage"
   },
   "dependencies": {
-    "ioredis": "^5.6.0"
+    "ioredis": "^5.6.0",
+    "resumable-stream": "^2.2.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.8.0",
     "vitest": "^4.0.0"

--- a/packages/stream/src/__tests__/redis-client.test.ts
+++ b/packages/stream/src/__tests__/redis-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRedisOptions,
+  hasSentinelConfig,
+  hasStandaloneConfig,
+  parseSentinelEndpoints,
+} from '../redis-client.js';
+
+describe('parseSentinelEndpoints', () => {
+  it('parses single endpoint', () => {
+    const result = parseSentinelEndpoints('host1:26379');
+    expect(result).toEqual([{ host: 'host1', port: 26379 }]);
+  });
+
+  it('parses multiple endpoints', () => {
+    const result = parseSentinelEndpoints('host1:26379,host2:26380,host3:26381');
+    expect(result).toHaveLength(3);
+    expect(result[1]).toEqual({ host: 'host2', port: 26380 });
+  });
+
+  it('defaults port to 26379 if missing', () => {
+    const result = parseSentinelEndpoints('host1');
+    expect(result[0].port).toBe(26379);
+  });
+
+  it('handles whitespace around entries', () => {
+    const result = parseSentinelEndpoints(' host1:26379 , host2:26380 ');
+    expect(result).toHaveLength(2);
+    expect(result[0].host).toBe('host1');
+  });
+
+  it('filters empty strings', () => {
+    const result = parseSentinelEndpoints('host1:26379,,host2:26380');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns empty array for empty string', () => {
+    const result = parseSentinelEndpoints('');
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('hasSentinelConfig', () => {
+  it('returns true when both sentinels and masterName present', () => {
+    expect(hasSentinelConfig({ sentinels: 'host:26379', masterName: 'mymaster' })).toBe(true);
+  });
+
+  it('returns false when only sentinels present', () => {
+    expect(hasSentinelConfig({ sentinels: 'host:26379' })).toBe(false);
+  });
+
+  it('returns false when only masterName present', () => {
+    expect(hasSentinelConfig({ masterName: 'mymaster' })).toBe(false);
+  });
+
+  it('returns false for empty config', () => {
+    expect(hasSentinelConfig({})).toBe(false);
+  });
+});
+
+describe('hasStandaloneConfig', () => {
+  it('returns true when url present', () => {
+    expect(hasStandaloneConfig({ url: 'redis://localhost:6379' })).toBe(true);
+  });
+
+  it('returns false when url missing', () => {
+    expect(hasStandaloneConfig({})).toBe(false);
+  });
+
+  it('returns false for empty url', () => {
+    expect(hasStandaloneConfig({ url: '' })).toBe(false);
+  });
+});
+
+describe('createRedisOptions', () => {
+  it('returns default options', () => {
+    const opts = createRedisOptions();
+    expect(opts.enableOfflineQueue).toBe(true);
+    expect(opts.connectTimeout).toBe(5000);
+    expect(opts.maxRetriesPerRequest).toBe(3);
+  });
+
+  it('merges overrides', () => {
+    const opts = createRedisOptions({ connectTimeout: 10000 });
+    expect(opts.connectTimeout).toBe(10000);
+    expect(opts.enableOfflineQueue).toBe(true);
+  });
+
+  it('allows null maxRetriesPerRequest for subscriber', () => {
+    const opts = createRedisOptions({ maxRetriesPerRequest: null });
+    expect(opts.maxRetriesPerRequest).toBeNull();
+  });
+});

--- a/packages/stream/src/__tests__/stream-registry.test.ts
+++ b/packages/stream/src/__tests__/stream-registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StreamRegistry } from '../stream-registry.js';
+
+describe('StreamRegistry', () => {
+  function createMockContext() {
+    return {
+      resumableStream: vi.fn().mockResolvedValue(null),
+      resumeExistingStream: vi.fn().mockResolvedValue(undefined),
+      createNewResumableStream: vi.fn().mockResolvedValue(null),
+      hasExistingStream: vi.fn().mockResolvedValue(null),
+    };
+  }
+
+  function createMockRedis() {
+    return {
+      quit: vi.fn().mockResolvedValue('OK'),
+      del: vi.fn().mockResolvedValue(1),
+    };
+  }
+
+  function createTestRegistry() {
+    const publisher = createMockRedis();
+    const subscriber = createMockRedis();
+    const context = createMockContext();
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const registry = new StreamRegistry(publisher as any, subscriber as any, context as any);
+    return { registry, publisher, subscriber, context };
+  }
+
+  describe('createStream', () => {
+    it('calls createNewResumableStream with factory result', async () => {
+      const { registry, context } = createTestRegistry();
+      const factory = () => new ReadableStream<string>();
+      await registry.createStream('stream-1', factory);
+      expect(context.createNewResumableStream).toHaveBeenCalledWith('stream-1', factory);
+    });
+  });
+
+  describe('resumeOrCreate', () => {
+    it('calls resumableStream with streamId and factory', async () => {
+      const { registry, context } = createTestRegistry();
+      const factory = () => new ReadableStream<string>();
+      await registry.resumeOrCreate('stream-1', factory);
+      expect(context.resumableStream).toHaveBeenCalledWith('stream-1', factory, undefined);
+    });
+
+    it('passes skipCharacters', async () => {
+      const { registry, context } = createTestRegistry();
+      const factory = () => new ReadableStream<string>();
+      await registry.resumeOrCreate('stream-1', factory, 100);
+      expect(context.resumableStream).toHaveBeenCalledWith('stream-1', factory, 100);
+    });
+  });
+
+  describe('resume', () => {
+    it('returns undefined for non-existent stream', async () => {
+      const { registry } = createTestRegistry();
+      const result = await registry.resume('non-existent');
+      expect(result).toBeUndefined();
+    });
+
+    it('returns null when stream is DONE', async () => {
+      const { registry, context } = createTestRegistry();
+      context.resumeExistingStream.mockResolvedValue(null);
+      const result = await registry.resume('done-stream');
+      expect(result).toBeNull();
+    });
+
+    it('returns ReadableStream when active', async () => {
+      const { registry, context } = createTestRegistry();
+      const mockStream = new ReadableStream<string>();
+      context.resumeExistingStream.mockResolvedValue(mockStream);
+      const result = await registry.resume('active-stream');
+      expect(result).toBe(mockStream);
+    });
+
+    it('passes skipCharacters', async () => {
+      const { registry, context } = createTestRegistry();
+      await registry.resume('stream-1', 50);
+      expect(context.resumeExistingStream).toHaveBeenCalledWith('stream-1', 50);
+    });
+  });
+
+  describe('exists', () => {
+    it('returns false when hasExistingStream returns null', async () => {
+      const { registry } = createTestRegistry();
+      expect(await registry.exists('ghost')).toBe(false);
+    });
+
+    it('returns true when hasExistingStream returns true', async () => {
+      const { registry, context } = createTestRegistry();
+      context.hasExistingStream.mockResolvedValue(true);
+      expect(await registry.exists('active')).toBe(true);
+    });
+
+    it('returns true when hasExistingStream returns "DONE"', async () => {
+      const { registry, context } = createTestRegistry();
+      context.hasExistingStream.mockResolvedValue('DONE');
+      expect(await registry.exists('done')).toBe(true);
+    });
+  });
+
+  describe('isDone', () => {
+    it('returns false for active stream', async () => {
+      const { registry, context } = createTestRegistry();
+      context.hasExistingStream.mockResolvedValue(true);
+      expect(await registry.isDone('active')).toBe(false);
+    });
+
+    it('returns true for DONE stream', async () => {
+      const { registry, context } = createTestRegistry();
+      context.hasExistingStream.mockResolvedValue('DONE');
+      expect(await registry.isDone('done')).toBe(true);
+    });
+
+    it('returns false for non-existent stream', async () => {
+      const { registry } = createTestRegistry();
+      expect(await registry.isDone('ghost')).toBe(false);
+    });
+  });
+
+  describe('invalidate', () => {
+    it('deletes sentinel key from Redis', async () => {
+      const { registry, publisher } = createTestRegistry();
+      await registry.invalidate('stale-stream');
+      expect(publisher.del).toHaveBeenCalledWith('resumable-stream:sentinel:stale-stream');
+    });
+  });
+
+  describe('close', () => {
+    it('quits both publisher and subscriber', async () => {
+      const { registry, publisher, subscriber } = createTestRegistry();
+      await registry.close();
+      expect(publisher.quit).toHaveBeenCalled();
+      expect(subscriber.quit).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/stream/src/index.ts
+++ b/packages/stream/src/index.ts
@@ -1,1 +1,16 @@
-export {};
+export {
+  type CreateRedisClientOptions,
+  createRedisClient,
+  createRedisOptions,
+  hasSentinelConfig,
+  hasStandaloneConfig,
+  parseSentinelEndpoints,
+  type RedisClientConfig,
+  type SentinelEndpoint,
+} from './redis-client.js';
+
+export {
+  createStreamRegistry,
+  StreamRegistry,
+  type StreamRegistryConfig,
+} from './stream-registry.js';

--- a/packages/stream/src/redis-client.ts
+++ b/packages/stream/src/redis-client.ts
@@ -1,0 +1,75 @@
+import Redis, { type RedisOptions } from 'ioredis';
+
+export interface SentinelEndpoint {
+  host: string;
+  port: number;
+}
+
+export interface RedisClientConfig {
+  url?: string;
+  sentinels?: string;
+  masterName?: string;
+  password?: string;
+}
+
+export interface CreateRedisClientOptions {
+  subscriber?: boolean;
+}
+
+export function createRedisOptions(overrides?: Partial<RedisOptions>): RedisOptions {
+  return {
+    enableOfflineQueue: true,
+    connectTimeout: 5000,
+    maxRetriesPerRequest: 3,
+    ...overrides,
+  };
+}
+
+export function parseSentinelEndpoints(sentinelsStr: string): SentinelEndpoint[] {
+  return sentinelsStr
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => {
+      const [host, portStr] = s.split(':');
+      return { host, port: Number.parseInt(portStr || '26379', 10) };
+    });
+}
+
+export function hasSentinelConfig(config: RedisClientConfig): boolean {
+  return Boolean(config.sentinels && config.masterName);
+}
+
+export function hasStandaloneConfig(config: RedisClientConfig): boolean {
+  return Boolean(config.url);
+}
+
+export function createRedisClient(
+  config: RedisClientConfig,
+  options?: CreateRedisClientOptions
+): Redis | null {
+  const baseOptions = createRedisOptions(
+    options?.subscriber ? { maxRetriesPerRequest: null } : undefined
+  );
+
+  try {
+    if (hasSentinelConfig(config)) {
+      const sentinels = parseSentinelEndpoints(config.sentinels!);
+      return new Redis({
+        ...baseOptions,
+        sentinels,
+        name: config.masterName,
+        password: config.password,
+        sentinelPassword: config.password,
+      });
+    }
+
+    if (hasStandaloneConfig(config)) {
+      return new Redis(config.url!, baseOptions);
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/stream/src/stream-registry.ts
+++ b/packages/stream/src/stream-registry.ts
@@ -1,0 +1,91 @@
+import type Redis from 'ioredis';
+import type { ResumableStreamContext } from 'resumable-stream';
+import { createResumableStreamContext } from 'resumable-stream/ioredis';
+import { createRedisClient, type RedisClientConfig } from './redis-client.js';
+
+export interface StreamRegistryConfig {
+  redisConfig?: RedisClientConfig;
+  redisUrl?: string;
+}
+
+function resolveRedisConfig(config: StreamRegistryConfig): RedisClientConfig | null {
+  if (config.redisConfig) return config.redisConfig;
+  if (config.redisUrl) return { url: config.redisUrl };
+  return null;
+}
+
+export class StreamRegistry {
+  private context: ResumableStreamContext;
+  private publisher: Redis;
+  private subscriber: Redis;
+
+  constructor(publisher: Redis, subscriber: Redis, context: ResumableStreamContext) {
+    this.publisher = publisher;
+    this.subscriber = subscriber;
+    this.context = context;
+  }
+
+  async createStream(
+    streamId: string,
+    streamFactory: () => ReadableStream<string>
+  ): Promise<ReadableStream<string> | null> {
+    return this.context.createNewResumableStream(streamId, streamFactory);
+  }
+
+  async resumeOrCreate(
+    streamId: string,
+    streamFactory: () => ReadableStream<string>,
+    skipCharacters?: number
+  ): Promise<ReadableStream<string> | null> {
+    return this.context.resumableStream(streamId, streamFactory, skipCharacters);
+  }
+
+  async resume(
+    streamId: string,
+    skipCharacters?: number
+  ): Promise<ReadableStream<string> | null | undefined> {
+    return this.context.resumeExistingStream(streamId, skipCharacters);
+  }
+
+  async exists(streamId: string): Promise<boolean> {
+    const result = await this.context.hasExistingStream(streamId);
+    return result !== null;
+  }
+
+  async isDone(streamId: string): Promise<boolean> {
+    const result = await this.context.hasExistingStream(streamId);
+    return result === 'DONE';
+  }
+
+  async invalidate(streamId: string): Promise<void> {
+    const sentinelKey = `resumable-stream:sentinel:${streamId}`;
+    await this.publisher.del(sentinelKey);
+  }
+
+  async close(): Promise<void> {
+    await this.publisher.quit();
+    await this.subscriber.quit();
+  }
+}
+
+export function createStreamRegistry(config: StreamRegistryConfig): StreamRegistry | null {
+  const redisConfig = resolveRedisConfig(config);
+  if (!redisConfig) return null;
+
+  const publisher = createRedisClient(redisConfig);
+  if (!publisher) return null;
+
+  const subscriber = createRedisClient(redisConfig, { subscriber: true });
+  if (!subscriber) {
+    publisher.quit();
+    return null;
+  }
+
+  const context = createResumableStreamContext({
+    waitUntil: null,
+    publisher,
+    subscriber,
+  });
+
+  return new StreamRegistry(publisher, subscriber, context);
+}

--- a/packages/stream/tsconfig.json
+++ b/packages/stream/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/stream/vitest.config.ts
+++ b/packages/stream/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    passWithNoTests: true,
+    include: ['src/**/*.test.ts'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,13 @@ importers:
       ioredis:
         specifier: ^5.6.0
         version: 5.10.1
+      resumable-stream:
+        specifier: ^2.2.0
+        version: 2.2.12
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
@@ -1834,6 +1840,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resumable-stream@2.2.12:
+    resolution: {integrity: sha512-e6boHekmb72MdWDn7vSV9kiuRb9K3CepcDj+3Z0NNhdAfld7uHbVU8+NKlHRf3LO2Chtj4cXuWL88StLg64eIw==}
+
   rolldown@1.0.0-rc.15:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3180,6 +3189,8 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resumable-stream@2.2.12: {}
 
   rolldown@1.0.0-rc.15:
     dependencies:

--- a/specs/stream.md
+++ b/specs/stream.md
@@ -1,0 +1,65 @@
+# Stream Specification
+
+packages/stream 提供 Redis-backed 可恢复 SSE 流，用于 control-worker → web 的事件传输。
+
+## 核心概念
+
+- **StreamRegistry**: 管理流的生命周期（publish/resume/exists/invalidate/close）
+- **publish**: 将 ReadableStream 写入 Redis，客户端可订阅
+- **resume**: 从断点恢复流（基于 cursor），支持断线重连
+- **exists**: 检查流是否存在（活跃或已完成）
+- **invalidate**: 清理僵死流的 sentinel key
+
+## 架构
+
+```
+Control Worker → publish(streamId, streamFactory) → Redis
+Browser        → resume(streamId)                  → ReadableStream<string>
+```
+
+底层使用 `resumable-stream` 库处理 cursor 管理、Redis 缓冲、TTL。
+
+## Redis 配置
+
+支持两种模式：
+
+1. **Standalone**（开发环境）: `url: "redis://localhost:6379"`
+2. **Sentinel**（生产 HA）: `sentinels: "host1:port1,host2:port2"`, `masterName: "mymaster"`
+
+优雅降级：Redis 不可用时 `createStreamRegistry()` 返回 null，调用方回退到 DB-only 模式。
+
+## 公开 API
+
+```typescript
+// 创建 registry（Redis 不可用返回 null）
+createStreamRegistry(config: StreamRegistryConfig): StreamRegistry | null
+
+// StreamRegistry 方法
+publish(streamId: string, streamFactory: () => ReadableStream<string>): Promise<void>
+resume(streamId: string): Promise<ReadableStream<string> | null>
+exists(streamId: string): Promise<boolean>
+invalidate(streamId: string): Promise<void>
+close(): Promise<void>
+
+// Redis 工具
+createRedisClient(config: RedisClientConfig): IORedis | null
+createRedisOptions(overrides?: Partial<RedisOptions>): RedisOptions
+parseSentinelEndpoints(sentinelsStr: string): SentinelEndpoint[]
+hasSentinelConfig(config: RedisClientConfig): boolean
+hasStandaloneConfig(config: RedisClientConfig): boolean
+```
+
+## 文件结构
+
+```
+packages/stream/src/
+  redis-client.ts      — Redis 连接工厂（standalone + sentinel）
+  stream-registry.ts   — StreamRegistry（publish/resume/exists/invalidate）
+  index.ts             — barrel export
+```
+
+## 测试策略
+
+- Redis client: mock ioredis，测试配置解析、sentinel endpoint 解析、错误处理
+- StreamRegistry: mock resumable-stream context，测试 publish/resume/exists/invalidate 流程
+- 目标 ~35 个测试用例


### PR DESCRIPTION
## Summary

- StreamRegistry: create/resume/exists/isDone/invalidate/close for SSE streams
- Redis client factory: standalone + sentinel modes, graceful degradation
- Wraps `resumable-stream` library for cursor-based reconnection

## API

```typescript
registry.createStream(id, factory)     // Publish new stream
registry.resumeOrCreate(id, factory)   // Resume or create
registry.resume(id, skip?)             // Resume only
registry.exists(id)                    // Active or DONE?
registry.isDone(id)                    // Fully consumed?
registry.invalidate(id)               // Clean stale sentinel
registry.close()                      // Graceful shutdown
```

## Test Plan

- [x] 31 tests: redis-client (17) + stream-registry (14)
- [x] All mocked (no real Redis needed)
- [x] `pnpm build && pnpm check && pnpm lint && pnpm test` all pass

Closes #7