### PR TITLE
feat: finalization — checkpoint + S3 storage (#74)

### DIFF
--- a/packages/control-plane/src/__tests__/finalization.test.ts
+++ b/packages/control-plane/src/__tests__/finalization.test.ts
@@ -1,0 +1,274 @@
+import type { SandboxInfo, SandboxProvider } from '@rush/sandbox';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { InMemoryEventStore } from '../event-store.js';
+import type { Checkpoint, CheckpointDb, CheckpointStorage } from '../run/checkpoint-service.js';
+import { CheckpointService } from '../run/checkpoint-service.js';
+import { RunOrchestrator } from '../run/run-orchestrator.js';
+import type { CreateRunInput, Run, RunDb } from '../run/run-service.js';
+import { RunService } from '../run/run-service.js';
+import type { RunStatus } from '../run/run-state-machine.js';
+import { S3CheckpointStorage } from '../run/s3-checkpoint-storage.js';
+
+// --- Mocks ---
+
+class MockRunDb implements RunDb {
+  private runs = new Map<string, Run>();
+  async create(input: CreateRunInput): Promise<Run> {
+    const run: Run = {
+      id: `run-${Date.now()}`,
+      agentId: input.agentId,
+      parentRunId: null,
+      status: 'queued',
+      prompt: input.prompt,
+      provider: 'anthropic',
+      connectionMode: 'sse',
+      modelId: null,
+      triggerSource: 'api',
+      activeStreamId: null,
+      retryCount: 0,
+      maxRetries: 3,
+      errorMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      startedAt: null,
+      completedAt: null,
+    };
+    this.runs.set(run.id, run);
+    return { ...run };
+  }
+  async findById(id: string): Promise<Run | null> {
+    const r = this.runs.get(id);
+    return r ? { ...r } : null;
+  }
+  async updateStatus(id: string, status: RunStatus, extra?: Partial<Run>): Promise<Run | null> {
+    const r = this.runs.get(id);
+    if (!r) return null;
+    r.status = status;
+    r.updatedAt = new Date();
+    if (extra) Object.assign(r, extra);
+    return { ...r };
+  }
+  async listByAgent(): Promise<Run[]> {
+    return [];
+  }
+  async findStuckRuns(): Promise<Run[]> {
+    return [];
+  }
+  seed(run: Run): void {
+    this.runs.set(run.id, { ...run });
+  }
+}
+
+class MockSandboxProvider implements SandboxProvider {
+  async create(): Promise<SandboxInfo> {
+    return {
+      id: 'sbx-1',
+      status: 'running',
+      endpoint: 'http://localhost:8787',
+      previewUrl: null,
+      createdAt: new Date(),
+    };
+  }
+  async destroy(): Promise<void> {}
+  async getInfo(): Promise<SandboxInfo | null> {
+    return null;
+  }
+  async healthCheck(): Promise<boolean> {
+    return true;
+  }
+  async getEndpointUrl(_id: string, port: number): Promise<string | null> {
+    return `http://localhost:${port}`;
+  }
+  async exec(): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }
+}
+
+class MockCheckpointDb implements CheckpointDb {
+  private checkpoints = new Map<string, Checkpoint>();
+  async create(runId: string): Promise<Checkpoint> {
+    const cp: Checkpoint = {
+      id: `cp-${Date.now()}`,
+      runId,
+      status: 'in_progress',
+      messagesSnapshotRef: null,
+      workspaceDeltaRef: null,
+      lastEventSeq: null,
+      degradedRecovery: false,
+      createdAt: new Date(),
+    };
+    this.checkpoints.set(cp.id, cp);
+    return { ...cp };
+  }
+  async update(id: string, updates: Partial<Checkpoint>): Promise<Checkpoint | null> {
+    const cp = this.checkpoints.get(id);
+    if (!cp) return null;
+    Object.assign(cp, updates);
+    return { ...cp };
+  }
+  async findLatest(runId: string): Promise<Checkpoint | null> {
+    for (const cp of this.checkpoints.values()) {
+      if (cp.runId === runId) return { ...cp };
+    }
+    return null;
+  }
+}
+
+class MockS3Storage {
+  uploads = new Map<string, Buffer>();
+  async upload(key: string, body: Buffer): Promise<void> {
+    this.uploads.set(key, body);
+  }
+  async download(key: string): Promise<Buffer> {
+    const data = this.uploads.get(key);
+    if (!data) throw new Error('Not found');
+    return data;
+  }
+}
+
+function makeQueuedRun(id: string): Run {
+  return {
+    id,
+    agentId: 'agent-1',
+    parentRunId: null,
+    status: 'queued',
+    prompt: 'test',
+    provider: 'anthropic',
+    connectionMode: 'sse',
+    modelId: null,
+    triggerSource: 'api',
+    activeStreamId: null,
+    retryCount: 0,
+    maxRetries: 3,
+    errorMessage: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    startedAt: null,
+    completedAt: null,
+  };
+}
+
+function mockSSEResponse(events: Array<Record<string, unknown>>): Response {
+  const body = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('');
+  return new Response(body, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+}
+
+const originalFetch = globalThis.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// --- Tests ---
+
+describe('Finalization with CheckpointService', () => {
+  it('creates checkpoint during finalization', async () => {
+    const runDb = new MockRunDb();
+    const eventStore = new InMemoryEventStore();
+    const s3 = new MockS3Storage();
+    const checkpointDb = new MockCheckpointDb();
+    const checkpointService = new CheckpointService(checkpointDb, new S3CheckpointStorage(s3));
+
+    const orchestrator = new RunOrchestrator({
+      runService: new RunService(runDb),
+      sandboxProvider: new MockSandboxProvider(),
+      eventStore,
+      checkpointService,
+    });
+
+    const run = makeQueuedRun('run-fin-1');
+    runDb.seed(run);
+    fetchMock.mockResolvedValueOnce(
+      mockSSEResponse([
+        { type: 'text-delta', content: 'Hello' },
+        { type: 'finish', reason: 'end_turn' },
+      ])
+    );
+
+    await orchestrator.execute('run-fin-1', 'test', 'agent-1');
+
+    const finalRun = await runDb.findById('run-fin-1');
+    expect(finalRun?.status).toBe('completed');
+
+    // Checkpoint should have been created
+    const cp = await checkpointDb.findLatest('run-fin-1');
+    expect(cp).not.toBeNull();
+    expect(cp?.status).toBe('completed');
+    expect(cp?.messagesSnapshotRef).toBeTruthy();
+    expect(cp?.lastEventSeq).toBe(1); // 2 events, last seq = 1
+
+    // S3 should have the snapshot
+    expect(s3.uploads.size).toBe(1);
+    const [, data] = [...s3.uploads.entries()][0];
+    const parsed = JSON.parse(data.toString());
+    expect(parsed).toHaveLength(2);
+  });
+
+  it('completes even if checkpoint fails', async () => {
+    const runDb = new MockRunDb();
+    const eventStore = new InMemoryEventStore();
+    const failingStorage: CheckpointStorage = {
+      uploadSnapshot: () => Promise.reject(new Error('S3 down')),
+      downloadSnapshot: () => Promise.reject(new Error('S3 down')),
+    };
+    const checkpointService = new CheckpointService(new MockCheckpointDb(), failingStorage);
+
+    const orchestrator = new RunOrchestrator({
+      runService: new RunService(runDb),
+      sandboxProvider: new MockSandboxProvider(),
+      eventStore,
+      checkpointService,
+    });
+
+    const run = makeQueuedRun('run-fin-fail');
+    runDb.seed(run);
+    fetchMock.mockResolvedValueOnce(mockSSEResponse([{ type: 'finish', reason: 'end_turn' }]));
+
+    await orchestrator.execute('run-fin-fail', 'test', 'agent-1');
+
+    const finalRun = await runDb.findById('run-fin-fail');
+    expect(finalRun?.status).toBe('completed');
+  });
+
+  it('works without checkpointService (backward compat)', async () => {
+    const runDb = new MockRunDb();
+    const eventStore = new InMemoryEventStore();
+
+    const orchestrator = new RunOrchestrator({
+      runService: new RunService(runDb),
+      sandboxProvider: new MockSandboxProvider(),
+      eventStore,
+      // No checkpointService
+    });
+
+    const run = makeQueuedRun('run-no-cp');
+    runDb.seed(run);
+    fetchMock.mockResolvedValueOnce(mockSSEResponse([{ type: 'finish', reason: 'end_turn' }]));
+
+    await orchestrator.execute('run-no-cp', 'test', 'agent-1');
+
+    const finalRun = await runDb.findById('run-no-cp');
+    expect(finalRun?.status).toBe('completed');
+  });
+});
+
+describe('S3CheckpointStorage', () => {
+  it('uploads and downloads snapshot', async () => {
+    const s3 = new MockS3Storage();
+    const storage = new S3CheckpointStorage(s3);
+
+    const data = Buffer.from('{"events":[]}');
+    const ref = await storage.uploadSnapshot('run-1', data);
+    expect(ref).toContain('checkpoints/run-1/');
+
+    const downloaded = await storage.downloadSnapshot(ref);
+    expect(downloaded.toString()).toBe('{"events":[]}');
+  });
+});

--- a/packages/control-plane/src/run/drizzle-checkpoint-db.ts
+++ b/packages/control-plane/src/run/drizzle-checkpoint-db.ts
@@ -1,0 +1,59 @@
+import { type DbClient, runCheckpoints } from '@rush/db';
+import { desc, eq } from 'drizzle-orm';
+
+import type { Checkpoint, CheckpointDb } from './checkpoint-service.js';
+
+type CheckpointRow = typeof runCheckpoints.$inferSelect;
+
+function mapRow(row: CheckpointRow): Checkpoint {
+  return {
+    id: row.id,
+    runId: row.runId!,
+    status: row.status as Checkpoint['status'],
+    messagesSnapshotRef: row.messagesSnapshotRef,
+    workspaceDeltaRef: row.workspaceDeltaRef,
+    lastEventSeq: row.lastEventSeq,
+    degradedRecovery: row.degradedRecovery ?? false,
+    createdAt: row.createdAt,
+  };
+}
+
+export class DrizzleCheckpointDb implements CheckpointDb {
+  constructor(private db: DbClient) {}
+
+  async create(runId: string): Promise<Checkpoint> {
+    const [row] = await this.db
+      .insert(runCheckpoints)
+      .values({ runId, status: 'in_progress' })
+      .returning();
+    return mapRow(row);
+  }
+
+  async update(id: string, updates: Partial<Checkpoint>): Promise<Checkpoint | null> {
+    const values: Record<string, unknown> = {};
+    if (updates.status !== undefined) values.status = updates.status;
+    if (updates.messagesSnapshotRef !== undefined)
+      values.messagesSnapshotRef = updates.messagesSnapshotRef;
+    if (updates.workspaceDeltaRef !== undefined)
+      values.workspaceDeltaRef = updates.workspaceDeltaRef;
+    if (updates.lastEventSeq !== undefined) values.lastEventSeq = updates.lastEventSeq;
+    if (updates.degradedRecovery !== undefined) values.degradedRecovery = updates.degradedRecovery;
+
+    const [row] = await this.db
+      .update(runCheckpoints)
+      .set(values)
+      .where(eq(runCheckpoints.id, id))
+      .returning();
+    return row ? mapRow(row) : null;
+  }
+
+  async findLatest(runId: string): Promise<Checkpoint | null> {
+    const [row] = await this.db
+      .select()
+      .from(runCheckpoints)
+      .where(eq(runCheckpoints.runId, runId))
+      .orderBy(desc(runCheckpoints.createdAt))
+      .limit(1);
+    return row ? mapRow(row) : null;
+  }
+}

--- a/packages/control-plane/src/run/index.ts
+++ b/packages/control-plane/src/run/index.ts
@@ -6,6 +6,7 @@ export {
   CheckpointService,
   type CheckpointStorage,
 } from './checkpoint-service.js';
+export { DrizzleCheckpointDb } from './drizzle-checkpoint-db.js';
 export { DrizzleRunDb } from './drizzle-run-db.js';
 export { RunOrchestrator, type RunOrchestratorDeps } from './run-orchestrator.js';
 export { type CreateRunInput, type Run, type RunDb, RunService } from './run-service.js';
@@ -16,6 +17,7 @@ export {
   isTerminal,
   type RunStatus,
 } from './run-state-machine.js';
+export { S3CheckpointStorage, type S3StorageAdapter } from './s3-checkpoint-storage.js';
 export {
   createErrorHandler,
   createIncrementalSave,

--- a/packages/control-plane/src/run/run-orchestrator.ts
+++ b/packages/control-plane/src/run/run-orchestrator.ts
@@ -2,6 +2,7 @@ import type { CreateSandboxOptions, SandboxProvider } from '@rush/sandbox';
 
 import type { EventStore } from '../event-store.js';
 import { AgentBridge } from './agent-bridge.js';
+import type { CheckpointService } from './checkpoint-service.js';
 import type { RunService } from './run-service.js';
 import {
   createErrorHandler,
@@ -14,6 +15,7 @@ export interface RunOrchestratorDeps {
   runService: RunService;
   sandboxProvider: SandboxProvider;
   eventStore: EventStore;
+  checkpointService?: CheckpointService;
 }
 
 export class RunOrchestrator {
@@ -50,45 +52,63 @@ export class RunOrchestrator {
       // 4. Consume SSE stream
       await this.consumeStream(runId, response);
 
-      // 5. Simplified finalization (MVP)
-      await this.deps.runService.transition(runId, 'finalizing_prepare');
-      await this.deps.runService.transition(runId, 'finalizing_uploading');
-      await this.deps.runService.transition(runId, 'finalizing_verifying');
-      await this.deps.runService.transition(runId, 'finalizing_metadata_commit');
-      await this.deps.runService.transition(runId, 'finalized');
-      await this.deps.runService.transition(runId, 'completed');
+      // 5. Finalization
+      await this.finalize(runId);
     } catch (error) {
-      // Attempt to transition to failed
       try {
         await this.deps.runService.transition(runId, 'failed', {
           errorMessage: error instanceof Error ? error.message : String(error),
         });
       } catch {
-        // Best-effort: if transition to failed itself fails, we still want cleanup
+        // Best-effort
       }
     } finally {
-      // Best-effort sandbox cleanup
       if (sandboxId) {
         this.deps.sandboxProvider.destroy(sandboxId).catch(() => {});
       }
     }
   }
 
+  private async finalize(runId: string): Promise<void> {
+    await this.deps.runService.transition(runId, 'finalizing_prepare');
+
+    // Create checkpoint (snapshot events for recovery)
+    if (this.deps.checkpointService) {
+      try {
+        const events = await this.deps.eventStore.getEvents(runId);
+        const lastSeq = await this.deps.eventStore.getLastSeq(runId);
+        const snapshot = Buffer.from(JSON.stringify(events));
+        await this.deps.checkpointService.createCheckpoint(runId, snapshot, lastSeq);
+      } catch (err) {
+        console.error('[finalize] Checkpoint creation failed (non-fatal):', err);
+      }
+    }
+
+    await this.deps.runService.transition(runId, 'finalizing_uploading');
+    // TODO: Upload workspace artifacts to S3
+
+    await this.deps.runService.transition(runId, 'finalizing_verifying');
+    // TODO: Verify artifact checksums
+
+    await this.deps.runService.transition(runId, 'finalizing_metadata_commit');
+    // TODO: Create PR if applicable
+
+    await this.deps.runService.transition(runId, 'finalized');
+    await this.deps.runService.transition(runId, 'completed');
+  }
+
   private async consumeStream(runId: string, response: Response): Promise<void> {
     const pipeline = new StreamPipeline();
 
     pipeline.use(
-      createIncrementalSave(
-        async (event) => {
-          await this.deps.eventStore.append({
-            runId,
-            eventType: event.type,
-            payload: event.data,
-            seq: event.seq,
-          });
-        },
-        1 // flush every event for reliability — batch optimization comes later
-      )
+      createIncrementalSave(async (event) => {
+        await this.deps.eventStore.append({
+          runId,
+          eventType: event.type,
+          payload: event.data,
+          seq: event.seq,
+        });
+      }, 1)
     );
 
     pipeline.use(

--- a/packages/control-plane/src/run/s3-checkpoint-storage.ts
+++ b/packages/control-plane/src/run/s3-checkpoint-storage.ts
@@ -1,0 +1,27 @@
+import type { CheckpointStorage } from './checkpoint-service.js';
+
+/**
+ * S3-backed checkpoint storage adapter.
+ * Wraps any object that has upload/download methods (e.g. @rush/integrations StorageService).
+ */
+export interface S3StorageAdapter {
+  upload(key: string, body: Buffer | Uint8Array, options?: { contentType?: string }): Promise<void>;
+  download(key: string): Promise<Buffer>;
+}
+
+export class S3CheckpointStorage implements CheckpointStorage {
+  constructor(
+    private storage: S3StorageAdapter,
+    private prefix = 'checkpoints'
+  ) {}
+
+  async uploadSnapshot(runId: string, data: Buffer): Promise<string> {
+    const key = `${this.prefix}/${runId}/${Date.now()}-messages.json`;
+    await this.storage.upload(key, data, { contentType: 'application/json' });
+    return key;
+  }
+
+  async downloadSnapshot(ref: string): Promise<Buffer> {
+    return this.storage.download(ref);
+  }
+}

--- a/specs/finalization.md
+++ b/specs/finalization.md
@@ -1,0 +1,40 @@
+# Finalization Specification
+
+Run 完成后的产物收集和持久化。
+
+## 流程
+
+```
+running → finalizing_prepare
+  ↓ checkpoint 创建（events snapshot → S3）
+finalizing_uploading
+  ↓ workspace artifacts 上传（TODO）
+finalizing_verifying
+  ↓ checksum 验证（TODO）
+finalizing_metadata_commit
+  ↓ PR 创建 / metadata 写入（TODO）
+finalized → completed
+```
+
+## Checkpoint 创建
+
+RunOrchestrator.finalize() 在 finalizing_prepare 阶段：
+1. 从 EventStore 读取所有事件
+2. 序列化为 JSON Buffer
+3. 通过 CheckpointService.createCheckpoint() 上传到 S3
+4. 记录 lastEventSeq 到 run_checkpoints 表
+
+Checkpoint 失败不阻塞 finalization（non-fatal，日志告警）。
+
+## 存储层
+
+- **DrizzleCheckpointDb**: run_checkpoints 表的 Drizzle 实现
+- **S3CheckpointStorage**: 适配 @rush/integrations StorageService → CheckpointStorage 接口
+  - Key 格式: `checkpoints/{runId}/{timestamp}-messages.json`
+
+## 后续增强（TODO）
+
+- Workspace snapshot 上传到 S3
+- Git diff 导出 + PR 创建
+- Artifact checksum 验证
+- Finalization 失败重试（finalizing_retryable_failed 路径）


### PR DESCRIPTION
## Summary

- **DrizzleCheckpointDb** — run_checkpoints 表 Drizzle 实现
- **S3CheckpointStorage** — 适配 CheckpointStorage → S3
- **RunOrchestrator.finalize()** — 真实 checkpoint 创建（events snapshot → S3 + DB）
- Checkpoint 失败不阻塞 finalization (non-fatal)
- **4 个新测试** + Spec

TODO: workspace artifact upload, PR creation, checksum verification

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)