### PR TITLE
fix(web): support Bedrock/API/custom endpoint in Chat API

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -8,8 +8,25 @@ AUTH_SECRET=generate-with-openssl-rand-base64-32
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
 
-# AI — Claude Code via GLM (智谱) compatible endpoint
-# See: https://docs.bigmodel.cn/cn/coding-plan/tool/claude
-ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic
-ANTHROPIC_API_KEY=your-glm-api-key
-CLAUDE_MODEL=glm-4.7
+# ─── AI Provider (choose one) ───────────────────────────────────────────
+
+# Option 1: AWS Bedrock
+# CLAUDE_CODE_USE_BEDROCK=1
+# AWS_REGION=us-west-2
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_SESSION_TOKEN=              # optional, for STS/SSO temporary credentials
+# ANTHROPIC_MODEL=                # Bedrock model ARN or inference profile ARN
+
+# Option 2: Anthropic API (direct)
+# ANTHROPIC_API_KEY=
+
+# Option 3: Custom endpoint (e.g. GLM)
+# ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic
+# ANTHROPIC_API_KEY=your-api-key
+# CLAUDE_MODEL=glm-4.7
+
+# ─── Network Proxy (optional) ──────────────────────────────────────────
+# HTTPS_PROXY=http://your-proxy:port
+# HTTP_PROXY=http://your-proxy:port
+# NO_PROXY=localhost,127.0.0.1

--- a/apps/web/app/(app)/chat/[id]/page.tsx
+++ b/apps/web/app/(app)/chat/[id]/page.tsx
@@ -35,8 +35,35 @@ export default function ChatPage() {
 
   const projectId = searchParams.get('projectId') ?? undefined;
   const conversationId = params.id;
+  const agentId = searchParams.get('agentId') ?? undefined;
   const agentName = searchParams.get('agent') || 'Builder';
   const initialPrompt = searchParams.get('prompt')?.trim() ?? '';
+
+  // Agent metadata (provider label = runtime + backend)
+  const [providerLabel, setProviderLabel] = useState('Claude Code');
+  useEffect(() => {
+    let cancelled = false;
+    const runtimeLabels: Record<string, string> = { 'claude-code': 'Claude Code' };
+    const backendLabels: Record<string, string> = {
+      bedrock: 'Bedrock',
+      anthropic: 'Anthropic API',
+      custom: 'Custom Endpoint',
+    };
+
+    Promise.all([
+      agentId
+        ? fetch(`/api/agents/${encodeURIComponent(agentId)}`).then((r) => (r.ok ? r.json() : null))
+        : null,
+      fetch('/api/health').then((r) => (r.ok ? r.json() : null)),
+    ]).then(([agentJson, healthJson]) => {
+      if (cancelled) return;
+      const runtime = runtimeLabels[agentJson?.data?.providerType] ?? 'Claude Code';
+      const backend = backendLabels[healthJson?.provider] ?? '';
+      setProviderLabel(backend ? `${runtime} · ${backend}` : runtime);
+    }).catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [agentId]);
 
   // ---------------------------------------------------------------------------
   // Transport & useChat
@@ -155,7 +182,7 @@ export default function ChatPage() {
           </div>
           <div>
             <div className="text-[14px] font-semibold leading-none">{agentName}</div>
-            <div className="text-[11px] text-muted-foreground mt-0.5">GLM · open-rush</div>
+            <div className="text-[11px] text-muted-foreground mt-0.5">{providerLabel}</div>
           </div>
           {isLoading && (
             <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-50 dark:bg-blue-950 text-[11px] font-medium text-blue-600 dark:text-blue-400 ml-2">
@@ -292,7 +319,7 @@ export default function ChatPage() {
                   send
                 </span>
                 <span className="text-[10px] font-mono text-muted-foreground">
-                  GLM · Claude Code
+                  {providerLabel}
                 </span>
               </div>
             </div>

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,8 +1,7 @@
 /**
  * Chat API — POST /api/chat
  *
- * Streams AI responses via Claude Code (GLM compatible endpoint).
- * Reference: rush-app apps/agent/app/api/ai-stream-v2/route.ts
+ * Streams AI responses via Claude Code SDK (supports Anthropic API / AWS Bedrock / custom endpoint).
  */
 
 import { convertToModelMessages, streamText, type UIMessage } from 'ai';
@@ -10,8 +9,46 @@ import { claudeCode } from 'ai-sdk-provider-claude-code';
 import { registerAbortController, unregisterAbortController } from '@/lib/ai/stream-abort-registry';
 import { requireAuth } from '@/lib/api-utils';
 
-// Allow streaming responses up to 300 seconds
 export const maxDuration = 300;
+
+// ---------------------------------------------------------------------------
+// Claude Code model — env vars forwarded to the CLI subprocess
+// ---------------------------------------------------------------------------
+
+const ENV_PASSTHROUGH_KEYS = [
+  // Bedrock
+  'CLAUDE_CODE_USE_BEDROCK',
+  'AWS_REGION',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'ANTHROPIC_MODEL',
+  // Direct API / custom endpoint
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  // Network proxy
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+] as const;
+
+function buildClaudeEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of ENV_PASSTHROUGH_KEYS) {
+    if (process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
+const modelId = process.env.CLAUDE_MODEL || process.env.ANTHROPIC_MODEL || 'sonnet';
+
+const model = claudeCode(modelId, {
+  permissionMode: 'bypassPermissions',
+  maxTurns: 30,
+  env: buildClaudeEnv(),
+});
 
 // ---------------------------------------------------------------------------
 // Error helpers
@@ -20,7 +57,7 @@ export const maxDuration = 300;
 function errorResponse(error: string, status: number, details?: unknown): Response {
   return Response.json(
     { error, timestamp: new Date().toISOString(), ...(details ? { details } : {}) },
-    { status }
+    { status },
   );
 }
 
@@ -30,26 +67,6 @@ function classifyStreamError(error: unknown): 'aborted' | '429' | 'unknown' {
     if (error.message.includes('429') || error.message.includes('rate limit')) return '429';
   }
   return 'unknown';
-}
-
-// ---------------------------------------------------------------------------
-// Claude Code model factory
-// ---------------------------------------------------------------------------
-
-function createModel(modelId: string) {
-  const env: Record<string, string> = {};
-  if (process.env.ANTHROPIC_BASE_URL) {
-    env.ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL;
-  }
-  if (process.env.ANTHROPIC_API_KEY) {
-    env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
-  }
-
-  return claudeCode(modelId, {
-    permissionMode: 'bypassPermissions',
-    maxTurns: 30,
-    ...(Object.keys(env).length > 0 ? { env } : {}),
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -90,9 +107,8 @@ export async function POST(req: Request) {
     const modelMessages = await convertToModelMessages(messages as UIMessage[]);
 
     // 5. Stream
-    const modelId = process.env.CLAUDE_MODEL || 'sonnet';
     const result = streamText({
-      model: createModel(modelId),
+      model,
       messages: modelMessages,
       abortSignal: abortController.signal,
     });

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,7 +1,19 @@
+function isTruthy(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function getProviderBackend(): string {
+  if (isTruthy(process.env.CLAUDE_CODE_USE_BEDROCK)) return 'bedrock';
+  if (process.env.ANTHROPIC_BASE_URL) return 'custom';
+  if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
+  return 'unknown';
+}
+
 export async function GET() {
   return Response.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
     service: 'rush-web',
+    provider: getProviderBackend(),
   });
 }


### PR DESCRIPTION
## Summary

- Chat API 原只支持 GLM 代理模式，重构为支持 AWS Bedrock / Anthropic API / 自定义端点三种模式
- 通过声明式 `ENV_PASSTHROUGH_KEYS` 白名单向 Claude Code CLI 子进程透传环境变量（Bedrock 凭据、网络代理等）
- 修复 `modelId` 取值：Bedrock 场景必须传完整 ARN 作为 `--model` 参数，否则 CLI 会调用无权限的默认 inference-profile
- Health API 暴露 `provider` 字段（bedrock/anthropic/custom），Chat UI 动态展示实际 provider 信息
- 更新 `.env.example` 文档化三种 provider 配置 + 可选网络代理

## Test plan

- [x] Bedrock 模式：配置 ARN + AWS 凭据 + HTTPS_PROXY，发送消息正常返回（~11s）
- [x] UI 顶部和底部正确显示 "Claude Code · Bedrock"
- [x] `pnpm check` 类型检查通过
- [x] `pnpm build` 构建通过
- [x] Sparring review (gpt-5.3-codex) CONCERNS 全部修复

🤖 Generated with [Claude Code](https://claude.com/claude-code)