### PR TITLE
fix(web): markdown rendering + reasoning collapse

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "streamdown/styles.css";
 @source "./**/*.{ts,tsx}";
 @source "../components/**/*.{ts,tsx}";
 @source "../lib/**/*.{ts,tsx}";

--- a/apps/web/components/ai-elements/part-renderer.tsx
+++ b/apps/web/components/ai-elements/part-renderer.tsx
@@ -3,7 +3,8 @@
 
 import type { ChatStatus, DynamicToolUIPart, UIMessage } from 'ai';
 import { memo } from 'react';
-import { Reasoning } from '@/components/ai-elements/reasoning';
+import { Reasoning, ReasoningTrigger, ReasoningContent } from '@/components/ai-elements/reasoning';
+import { MessageResponse } from '@/components/ai-elements/message';
 import type { ToolRegistry } from './tool-registry';
 import { defaultToolRegistry } from './tools';
 import { GenericTool } from './tools/generic-tool';
@@ -34,18 +35,23 @@ export const PartRenderer = memo(
   }: PartRendererProps) {
     const isStreaming = status === 'streaming';
 
-    // Text content — render as markdown (plain for now, streamdown later)
+    // Text content — render as markdown via Streamdown
     if (part.type === 'text') {
       return (
-        <div className="prose prose-sm dark:prose-invert max-w-none whitespace-pre-wrap break-words">
+        <MessageResponse isAnimating={isStreaming && isLastMessage}>
           {part.text}
-        </div>
+        </MessageResponse>
       );
     }
 
-    // Reasoning / chain-of-thought
+    // Reasoning / chain-of-thought — collapsible thinking block
     if (part.type === 'reasoning') {
-      return <Reasoning isStreaming={isStreaming}>{part.text}</Reasoning>;
+      return (
+        <Reasoning isStreaming={isStreaming && isLastMessage}>
+          <ReasoningTrigger />
+          <ReasoningContent>{part.text}</ReasoningContent>
+        </Reasoning>
+      );
     }
 
     // Step start/end markers — skip rendering


### PR DESCRIPTION
## Summary
- **Markdown 渲染修复**：chat 文本部分从纯文本 `{part.text}` 改为 `<MessageResponse>`（Streamdown），支持粗体、列表、代码块、表格、数学公式、mermaid 等完整 markdown 渲染
- **Reasoning 折叠修复**：补全 `<ReasoningTrigger>` + `<ReasoningContent>` 子组件，thinking 内容现在正确折叠为 "Thought for X seconds" 可展开区块，而不是直接暴露在页面上
- **Streamdown 样式引入**：在 globals.css 导入 `streamdown/styles.css` 支持流式动画效果

## Test plan
- [x] 打开已有对话，确认 reasoning 区块显示为可折叠的 "Thought for a few seconds"
- [x] 确认文本内容通过 Streamdown 渲染（DOM 中有 `<p>` 标签和 `data-streamdown="strong"` 属性）
- [x] 确认粗体文本正确渲染
- [ ] 发送包含代码块、列表、表格的消息，验证完整 markdown 渲染
- [ ] 验证流式输出时动画效果正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)