### PR TITLE
refactor(agent): remove model/provider, add skills/mcps multi-select

### DIFF
--- a/apps/web/app/(app)/chat/[id]/page.tsx
+++ b/apps/web/app/(app)/chat/[id]/page.tsx
@@ -35,39 +35,32 @@ export default function ChatPage() {
 
   const projectId = searchParams.get('projectId') ?? undefined;
   const conversationId = params.id;
-  const agentId = searchParams.get('agentId') ?? undefined;
   const agentName = searchParams.get('agent') || 'Builder';
   const initialPrompt = searchParams.get('prompt')?.trim() ?? '';
 
-  // Agent metadata (provider label = runtime + backend)
+  // Agent metadata (provider label = backend connection mode)
   const [providerLabel, setProviderLabel] = useState('Claude Code');
   useEffect(() => {
     let cancelled = false;
-    const runtimeLabels: Record<string, string> = { 'claude-code': 'Claude Code' };
     const backendLabels: Record<string, string> = {
       bedrock: 'Bedrock',
       anthropic: 'Anthropic API',
       custom: 'Custom Endpoint',
     };
 
-    Promise.all([
-      agentId
-        ? fetch(`/api/agents/${encodeURIComponent(agentId)}`).then((r) => (r.ok ? r.json() : null))
-        : null,
-      fetch('/api/health').then((r) => (r.ok ? r.json() : null)),
-    ])
-      .then(([agentJson, healthJson]) => {
+    fetch('/api/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((healthJson) => {
         if (cancelled) return;
-        const runtime = runtimeLabels[agentJson?.data?.providerType] ?? 'Claude Code';
         const backend = backendLabels[healthJson?.provider] ?? '';
-        setProviderLabel(backend ? `${runtime} · ${backend}` : runtime);
+        setProviderLabel(backend ? `Claude Code · ${backend}` : 'Claude Code');
       })
       .catch(() => {});
 
     return () => {
       cancelled = true;
     };
-  }, [agentId]);
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Transport & useChat

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -82,7 +82,6 @@ export default async function DashboardPage() {
                     {project.currentAgent ? (
                       <div className="mt-2 flex items-center gap-2">
                         <Badge variant="secondary">{project.currentAgent.name}</Badge>
-                        <Badge variant="outline">{project.currentAgent.providerType}</Badge>
                       </div>
                     ) : (
                       <p className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -16,7 +16,6 @@ interface AgentOption {
   id: string;
   name: string;
   description: string | null;
-  providerType: string;
   deliveryMode: 'chat' | 'workspace';
   projectId: string;
   projectName: string;
@@ -273,7 +272,7 @@ export default function HomePage() {
                 <div>
                   <div className="flex items-center gap-2">
                     <div className="text-[12px] font-medium text-foreground">{agent.name}</div>
-                    <Badge variant="outline">{agent.providerType}</Badge>
+                    <Badge variant="outline">{agent.deliveryMode}</Badge>
                   </div>
                   <div className="text-[11px] text-muted-foreground mt-1 line-clamp-3">
                     {getAgentWelcome(agent)}

--- a/apps/web/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/app/(app)/projects/[id]/page.tsx
@@ -82,7 +82,6 @@ export default async function ProjectPage({ params }: { params: Promise<{ id: st
                 <div className="mt-3 space-y-2">
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary">{currentAgent.name}</Badge>
-                    <Badge variant="outline">{currentAgent.providerType}</Badge>
                     <Badge
                       variant={currentAgent.deliveryMode === 'workspace' ? 'default' : 'outline'}
                     >

--- a/apps/web/app/api/agents/route.ts
+++ b/apps/web/app/api/agents/route.ts
@@ -74,8 +74,6 @@ export async function POST(request: Request) {
     name: parsed.data.name,
     description: parsed.data.description,
     icon: parsed.data.icon,
-    providerType: parsed.data.providerType,
-    model: parsed.data.model,
     systemPrompt: parsed.data.systemPrompt,
     allowedTools: parsed.data.allowedTools,
     skills: parsed.data.skills,

--- a/apps/web/components/agents/agent-form-fields.tsx
+++ b/apps/web/components/agents/agent-form-fields.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Input } from '@/components/ui/input';
+import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select';
 import {
   Select,
   SelectContent,
@@ -17,13 +18,14 @@ import {
   normalizeAgentMaxSteps,
 } from './agent-form';
 
-const PROVIDER_OPTIONS: AgentFormState['providerType'][] = ['claude-code', 'gemini', 'custom'];
 const DELIVERY_MODE_OPTIONS: AgentFormState['deliveryMode'][] = ['chat', 'workspace'];
 
 interface AgentFormFieldsProps {
   form: AgentFormState;
   idPrefix: string;
   promptRows?: number;
+  skillOptions?: MultiSelectOption[];
+  mcpOptions?: MultiSelectOption[];
   onChange: AgentFormChangeHandler;
 }
 
@@ -31,31 +33,21 @@ export function AgentFormFields({
   form,
   idPrefix,
   promptRows = 8,
+  skillOptions = [],
+  mcpOptions = [],
   onChange,
 }: AgentFormFieldsProps) {
   return (
     <div className="grid gap-4">
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="space-y-2">
-          <label htmlFor={`${idPrefix}-name`} className="text-sm text-muted-foreground">
-            Name
-          </label>
-          <Input
-            id={`${idPrefix}-name`}
-            value={form.name}
-            onChange={(event) => onChange('name', event.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <label htmlFor={`${idPrefix}-model`} className="text-sm text-muted-foreground">
-            Model
-          </label>
-          <Input
-            id={`${idPrefix}-model`}
-            value={form.model}
-            onChange={(event) => onChange('model', event.target.value)}
-          />
-        </div>
+      <div className="space-y-2">
+        <label htmlFor={`${idPrefix}-name`} className="text-sm text-muted-foreground">
+          Name
+        </label>
+        <Input
+          id={`${idPrefix}-name`}
+          value={form.name}
+          onChange={(event) => onChange('name', event.target.value)}
+        />
       </div>
 
       <div className="space-y-2">
@@ -70,33 +62,10 @@ export function AgentFormFields({
         />
       </div>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <div className="space-y-2">
-          <label htmlFor={`${idPrefix}-provider`} className="text-sm text-muted-foreground">
-            Provider
-          </label>
-          <Select
-            value={form.providerType}
-            onValueChange={(value) =>
-              onChange('providerType', value as AgentFormState['providerType'])
-            }
-          >
-            <SelectTrigger id={`${idPrefix}-provider`} className="w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PROVIDER_OPTIONS.map((option) => (
-                <SelectItem key={option} value={option}>
-                  {option}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
+      <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">
           <label htmlFor={`${idPrefix}-delivery`} className="text-sm text-muted-foreground">
-            Delivery
+            Delivery Mode
           </label>
           <Select
             value={form.deliveryMode}
@@ -147,6 +116,32 @@ export function AgentFormFields({
           value={form.systemPrompt}
           onChange={(event) => onChange('systemPrompt', event.target.value)}
         />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          {/* biome-ignore lint/a11y/noLabelWithoutControl: MultiSelect is a custom composite widget */}
+          <label className="text-sm text-muted-foreground">Skills</label>
+          <MultiSelect
+            options={skillOptions}
+            selected={form.skills}
+            onChange={(values) => onChange('skills', values)}
+            placeholder="Select skills..."
+            emptyText="No skills available."
+          />
+        </div>
+
+        <div className="space-y-2">
+          {/* biome-ignore lint/a11y/noLabelWithoutControl: MultiSelect is a custom composite widget */}
+          <label className="text-sm text-muted-foreground">MCP Servers</label>
+          <MultiSelect
+            options={mcpOptions}
+            selected={form.mcpServers}
+            onChange={(values) => onChange('mcpServers', values)}
+            placeholder="Select MCP servers..."
+            emptyText="No MCP servers available."
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/components/agents/agent-form.ts
+++ b/apps/web/components/agents/agent-form.ts
@@ -3,9 +3,9 @@ import type { Agent } from '@open-rush/contracts';
 export interface AgentFormState {
   name: string;
   description: string;
-  providerType: 'claude-code' | 'gemini' | 'custom';
-  model: string;
   systemPrompt: string;
+  skills: string[];
+  mcpServers: string[];
   maxSteps: number;
   deliveryMode: 'chat' | 'workspace';
 }
@@ -20,9 +20,9 @@ export const DEFAULT_AGENT_MAX_STEPS = 30;
 export const EMPTY_AGENT_FORM: AgentFormState = {
   name: '',
   description: '',
-  providerType: 'claude-code',
-  model: '',
   systemPrompt: '',
+  skills: [],
+  mcpServers: [],
   maxSteps: DEFAULT_AGENT_MAX_STEPS,
   deliveryMode: 'chat',
 };
@@ -31,9 +31,9 @@ export function toAgentFormState(agent: Agent): AgentFormState {
   return {
     name: agent.name,
     description: agent.description ?? '',
-    providerType: agent.providerType,
-    model: agent.model ?? '',
     systemPrompt: agent.systemPrompt ?? '',
+    skills: agent.skills ?? [],
+    mcpServers: agent.mcpServers ?? [],
     maxSteps: agent.maxSteps,
     deliveryMode: agent.deliveryMode,
   };
@@ -54,9 +54,9 @@ export function toAgentPayload(
   projectId: string;
   name: string;
   description: string | null;
-  providerType: AgentFormState['providerType'];
-  model: string | null;
   systemPrompt: string | null;
+  skills: string[];
+  mcpServers: string[];
   maxSteps: number;
   deliveryMode: AgentFormState['deliveryMode'];
 } {
@@ -64,9 +64,9 @@ export function toAgentPayload(
     projectId,
     name: form.name.trim(),
     description: form.description.trim() || null,
-    providerType: form.providerType,
-    model: form.model.trim() || null,
     systemPrompt: form.systemPrompt.trim() || null,
+    skills: form.skills.filter((s) => s.trim()),
+    mcpServers: form.mcpServers.filter((s) => s.trim()),
     maxSteps: normalizeAgentMaxSteps(form.maxSteps),
     deliveryMode: form.deliveryMode,
   };

--- a/apps/web/components/agents/agent-studio-client.tsx
+++ b/apps/web/components/agents/agent-studio-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { Agent } from '@open-rush/contracts';
-import { Bot, Cpu, Loader2, Pencil, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
+import { Bot, Loader2, Pencil, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
@@ -14,14 +14,7 @@ import {
 import { AgentFormFields } from '@/components/agents/agent-form-fields';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Dialog,
   DialogContent,
@@ -30,6 +23,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import type { MultiSelectOption } from '@/components/ui/multi-select';
 import {
   Select,
   SelectContent,
@@ -55,6 +49,8 @@ function AgentEditorDialog({
   form,
   mode,
   saving,
+  skillOptions,
+  mcpOptions,
   onChange,
   onSubmit,
 }: {
@@ -64,6 +60,8 @@ function AgentEditorDialog({
   form: AgentFormState;
   mode: 'create' | 'edit';
   saving: boolean;
+  skillOptions: MultiSelectOption[];
+  mcpOptions: MultiSelectOption[];
   onChange: AgentFormChangeHandler;
   onSubmit: () => void;
 }) {
@@ -77,7 +75,14 @@ function AgentEditorDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <AgentFormFields form={form} idPrefix="studio-agent" promptRows={10} onChange={onChange} />
+        <AgentFormFields
+          form={form}
+          idPrefix="studio-agent"
+          promptRows={10}
+          skillOptions={skillOptions}
+          mcpOptions={mcpOptions}
+          onChange={onChange}
+        />
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
@@ -106,6 +111,8 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
   const [form, setForm] = useState<AgentFormState>(EMPTY_AGENT_FORM);
+  const [skillOptions, setSkillOptions] = useState<MultiSelectOption[]>([]);
+  const [mcpOptions, setMcpOptions] = useState<MultiSelectOption[]>([]);
 
   const selectedProject = useMemo(
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
@@ -115,6 +122,8 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
   const load = useCallback(async () => {
     if (!selectedProjectId) {
       setAgents([]);
+      setSkillOptions([]);
+      setMcpOptions([]);
       setLoading(false);
       return;
     }
@@ -122,14 +131,29 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
     setLoading(true);
     setError(null);
     try {
-      const agentsRes = await fetch(`/api/agents?projectId=${selectedProjectId}`);
-      const agentsJson = await agentsRes.json();
+      const [agentsRes, skillsRes, mcpRes] = await Promise.all([
+        fetch(`/api/agents?projectId=${selectedProjectId}`),
+        fetch(`/api/projects/${selectedProjectId}/skills`).catch(() => null),
+        fetch(`/api/projects/${selectedProjectId}/mcp`).catch(() => null),
+      ]);
 
+      const agentsJson = await agentsRes.json();
       if (!agentsRes.ok) {
         throw new Error(agentsJson.error ?? 'Failed to load agents');
       }
-
       setAgents((agentsJson.data ?? []) as Agent[]);
+
+      if (skillsRes?.ok) {
+        const skillsJson = await skillsRes.json();
+        const skills = (skillsJson.data ?? []) as { name: string }[];
+        setSkillOptions(skills.map((s) => ({ value: s.name, label: s.name })));
+      }
+
+      if (mcpRes?.ok) {
+        const mcpJson = await mcpRes.json();
+        const servers = (mcpJson.data ?? []) as { name: string }[];
+        setMcpOptions(servers.map((s) => ({ value: s.name, label: s.name })));
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load agents');
     } finally {
@@ -288,10 +312,6 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
                         </div>
                         <div className="min-w-0">
                           <CardTitle className="truncate">{agent.name}</CardTitle>
-                          <CardDescription className="mt-0.5 flex items-center gap-1">
-                            <Cpu className="h-3.5 w-3.5" />
-                            {agent.providerType}
-                          </CardDescription>
                         </div>
                       </div>
                     </div>
@@ -303,8 +323,13 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
                   </p>
                   <div className="flex flex-wrap gap-2">
                     <Badge variant="secondary">{agent.deliveryMode}</Badge>
-                    {agent.model ? <Badge variant="outline">{agent.model}</Badge> : null}
                     <Badge variant="outline">{agent.maxSteps} steps</Badge>
+                    {agent.skills.length > 0 ? (
+                      <Badge variant="outline">{agent.skills.length} skills</Badge>
+                    ) : null}
+                    {agent.mcpServers.length > 0 ? (
+                      <Badge variant="outline">{agent.mcpServers.length} MCPs</Badge>
+                    ) : null}
                   </div>
                 </CardContent>
                 <CardFooter className="justify-between gap-2">
@@ -356,6 +381,8 @@ export function AgentStudioClient({ projects }: AgentStudioClientProps) {
         form={form}
         mode={editingAgentId ? 'edit' : 'create'}
         saving={saving}
+        skillOptions={skillOptions}
+        mcpOptions={mcpOptions}
         onChange={handleChange}
         onSubmit={() => void handleSave()}
       />

--- a/apps/web/components/agents/project-agent-manager.tsx
+++ b/apps/web/components/agents/project-agent-manager.tsx
@@ -20,6 +20,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import type { MultiSelectOption } from '@/components/ui/multi-select';
 
 interface ProjectAgentManagerProps {
   projectId: string;
@@ -37,6 +38,8 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [skillOptions, setSkillOptions] = useState<MultiSelectOption[]>([]);
+  const [mcpOptions, setMcpOptions] = useState<MultiSelectOption[]>([]);
 
   const selectedAgent = useMemo(
     () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
@@ -47,9 +50,11 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
     setLoading(true);
     setError(null);
     try {
-      const [agentsRes, currentRes] = await Promise.all([
+      const [agentsRes, currentRes, skillsRes, mcpRes] = await Promise.all([
         fetch(`/api/agents?projectId=${projectId}`),
         fetch(`/api/projects/${projectId}/agent`),
+        fetch(`/api/projects/${projectId}/skills`).catch(() => null),
+        fetch(`/api/projects/${projectId}/mcp`).catch(() => null),
       ]);
 
       const agentsJson = await agentsRes.json();
@@ -69,6 +74,18 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
       setAgents(nextAgents);
       setCurrentAgent(nextCurrentAgent);
       setCurrentBinding(nextBinding);
+
+      if (skillsRes?.ok) {
+        const skillsJson = await skillsRes.json();
+        const skills = (skillsJson.data ?? []) as { name: string }[];
+        setSkillOptions(skills.map((s) => ({ value: s.name, label: s.name })));
+      }
+
+      if (mcpRes?.ok) {
+        const mcpJson = await mcpRes.json();
+        const servers = (mcpJson.data ?? []) as { name: string }[];
+        setMcpOptions(servers.map((s) => ({ value: s.name, label: s.name })));
+      }
 
       setSelectedAgentId((prev) => {
         if (prev && nextAgents.some((agent) => agent.id === prev)) {
@@ -223,7 +240,6 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
                 <div className="flex items-center gap-2">
                   <Bot className="h-4 w-4 text-muted-foreground" />
                   <span className="font-medium">{currentAgent.name}</span>
-                  <Badge variant="secondary">{currentAgent.providerType}</Badge>
                   <Badge
                     variant={currentAgent.deliveryMode === 'workspace' ? 'default' : 'outline'}
                   >
@@ -286,7 +302,6 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
                           <div className="flex items-center gap-2">
                             <span className="font-medium">{agent.name}</span>
                             {isCurrent ? <Badge>Current</Badge> : null}
-                            <Badge variant="secondary">{agent.providerType}</Badge>
                           </div>
                           <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
                             {agent.description || 'No description provided.'}
@@ -337,7 +352,13 @@ export function ProjectAgentManager({ projectId }: ProjectAgentManagerProps) {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <AgentFormFields form={form} idPrefix="agent" onChange={handleChange} />
+            <AgentFormFields
+              form={form}
+              idPrefix="agent"
+              skillOptions={skillOptions}
+              mcpOptions={mcpOptions}
+              onChange={handleChange}
+            />
 
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
             {message ? <p className="text-sm text-emerald-600">{message}</p> : null}

--- a/apps/web/components/ui/multi-select.tsx
+++ b/apps/web/components/ui/multi-select.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { CheckIcon, ChevronsUpDown, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+}
+
+interface MultiSelectProps {
+  options: MultiSelectOption[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  placeholder?: string;
+  emptyText?: string;
+  className?: string;
+}
+
+export function MultiSelect({
+  options,
+  selected,
+  onChange,
+  placeholder = 'Select...',
+  emptyText = 'No options found.',
+  className,
+}: MultiSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = useCallback(
+    (value: string) => {
+      const next = selected.includes(value)
+        ? selected.filter((s) => s !== value)
+        : [...selected, value];
+      onChange(next);
+    },
+    [selected, onChange]
+  );
+
+  const selectedLabels = selected
+    .map((v) => options.find((o) => o.value === v))
+    .filter(Boolean) as MultiSelectOption[];
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={cn(
+          'flex min-h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs outline-none',
+          className
+        )}
+      >
+        <div className="flex flex-1 flex-wrap gap-1">
+          {selectedLabels.length > 0 ? (
+            selectedLabels.map((opt) => (
+              <Badge key={opt.value} variant="secondary" className="gap-1 pr-1">
+                {opt.label}
+                <button
+                  type="button"
+                  className="rounded-full outline-none hover:bg-muted-foreground/20"
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleToggle(opt.value);
+                  }}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            ))
+          ) : (
+            <span className="text-muted-foreground">{placeholder}</span>
+          )}
+        </div>
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--anchor-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search..." />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selected.includes(option.value);
+                return (
+                  <CommandItem
+                    key={option.value}
+                    value={option.value}
+                    keywords={[option.label]}
+                    onSelect={() => handleToggle(option.value)}
+                    data-checked={isSelected}
+                  >
+                    <div
+                      className={cn(
+                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                        isSelected ? 'bg-primary text-primary-foreground' : 'opacity-50'
+                      )}
+                    >
+                      {isSelected ? <CheckIcon className="h-3 w-3" /> : null}
+                    </div>
+                    {option.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/lib/agents/resolve-agent-id.ts
+++ b/apps/web/lib/agents/resolve-agent-id.ts
@@ -5,8 +5,6 @@ import type { DbClient } from '@open-rush/db';
 const DEFAULT_AGENT = {
   name: 'Web Builder',
   description: 'Build and iterate on web applications in the project workspace.',
-  providerType: 'claude-code' as const,
-  model: 'claude-sonnet-4-6',
   systemPrompt:
     'You are a web development assistant. Help users build web applications using modern technologies. You can create, edit, and manage files in the project workspace.',
   maxSteps: 30,
@@ -55,8 +53,6 @@ export async function resolveAgentIdForProject(options: {
     status: 'active',
     name: DEFAULT_AGENT.name,
     description: DEFAULT_AGENT.description,
-    providerType: DEFAULT_AGENT.providerType,
-    model: DEFAULT_AGENT.model,
     systemPrompt: DEFAULT_AGENT.systemPrompt,
     maxSteps: DEFAULT_AGENT.maxSteps,
     deliveryMode: DEFAULT_AGENT.deliveryMode,

--- a/packages/contracts/src/__tests__/schemas.test.ts
+++ b/packages/contracts/src/__tests__/schemas.test.ts
@@ -116,7 +116,6 @@ describe('Agent', () => {
   it('parses with defaults', () => {
     const a = Agent.parse(validAgent);
     expect(a.status).toBe('active');
-    expect(a.providerType).toBe('claude-code');
     expect(a.deliveryMode).toBe('chat');
     expect(a.customTitle).toBeNull();
     expect(a.config).toBeNull();
@@ -143,7 +142,7 @@ describe('CreateAgentRequest', () => {
       name: 'Research Agent',
     });
     expect(req.projectId).toBe(UUID);
-    expect(req.providerType).toBe('claude-code');
+    expect(req.deliveryMode).toBe('chat');
   });
 });
 

--- a/packages/contracts/src/agent.ts
+++ b/packages/contracts/src/agent.ts
@@ -1,12 +1,10 @@
 import { z } from 'zod';
-import { AgentDeliveryMode, AgentProviderType, AgentStatus } from './enums.js';
+import { AgentDeliveryMode, AgentStatus } from './enums.js';
 
 export const AgentConfig = z.object({
   name: z.string().min(1).max(120),
   description: z.string().max(2000).nullable().default(null),
   icon: z.string().max(50).nullable().default(null),
-  providerType: AgentProviderType.default('claude-code'),
-  model: z.string().max(255).nullable().default(null),
   systemPrompt: z.string().max(20000).nullable().default(null),
   allowedTools: z.array(z.string().min(1)).default([]),
   skills: z.array(z.string().min(1)).default([]),

--- a/packages/contracts/src/enums.ts
+++ b/packages/contracts/src/enums.ts
@@ -54,9 +54,6 @@ export function isValidRunTransition(from: RunStatus, to: RunStatus): boolean {
 export const AgentStatus = z.enum(['active', 'inactive']);
 export type AgentStatus = z.infer<typeof AgentStatus>;
 
-export const AgentProviderType = z.enum(['claude-code', 'gemini', 'custom']);
-export type AgentProviderType = z.infer<typeof AgentProviderType>;
-
 export const AgentDeliveryMode = z.enum(['chat', 'workspace']);
 export type AgentDeliveryMode = z.infer<typeof AgentDeliveryMode>;
 

--- a/packages/control-plane/src/__tests__/agent-config.test.ts
+++ b/packages/control-plane/src/__tests__/agent-config.test.ts
@@ -43,8 +43,6 @@ function makeAgent(overrides: Partial<AgentConfig> = {}): AgentConfig {
     name: 'Test Agent',
     scope: 'project',
     status: 'active',
-    providerType: 'claude-code',
-    model: 'claude-sonnet-4-6',
     systemPrompt: 'You are a test agent.',
     maxSteps: 30,
     deliveryMode: 'chat',
@@ -88,8 +86,8 @@ describe('AgentRegistry', () => {
     it('updates agent config', async () => {
       const config = makeAgent();
       await registry.createAgent(config);
-      const updated = await registry.updateAgent(config.id, { model: 'claude-opus-4-6' });
-      expect(updated.model).toBe('claude-opus-4-6');
+      const updated = await registry.updateAgent(config.id, { name: 'Renamed Agent' });
+      expect(updated.name).toBe('Renamed Agent');
     });
 
     it('rejects changing to builtin scope', async () => {
@@ -124,21 +122,19 @@ describe('AgentRegistry', () => {
     });
 
     it('project overrides builtin with same id', async () => {
-      await store.create(
-        makeAgent({ id: 'web-builder', scope: 'builtin', model: 'claude-sonnet-4-6' })
-      );
+      await store.create(makeAgent({ id: 'web-builder', scope: 'builtin', name: 'Web Builder' }));
       await store.create(
         makeAgent({
           id: 'web-builder',
           scope: 'project',
-          model: 'claude-opus-4-6',
+          name: 'Custom Builder',
           projectId,
         })
       );
 
       const agents = await registry.getAgentsForProject(projectId);
       const wb = agents.find((a) => a.id === 'web-builder');
-      expect(wb?.model).toBe('claude-opus-4-6');
+      expect(wb?.name).toBe('Custom Builder');
     });
   });
 

--- a/packages/control-plane/src/__tests__/project-agent-service.test.ts
+++ b/packages/control-plane/src/__tests__/project-agent-service.test.ts
@@ -108,8 +108,6 @@ describe('DrizzleAgentConfigStore', () => {
       name: 'Builder',
       scope: 'project',
       status: 'active',
-      providerType: 'claude-code',
-      model: 'claude-sonnet-4-6',
       systemPrompt: 'Build UI safely.',
       maxSteps: 20,
       deliveryMode: 'workspace',
@@ -124,10 +122,10 @@ describe('DrizzleAgentConfigStore', () => {
     expect(listed[0].name).toBe('Builder');
 
     const updated = await store.update(created.id, {
-      model: 'claude-opus-4-6',
+      name: 'Updated Builder',
       allowedTools: ['Read', 'Write'],
     });
-    expect(updated?.model).toBe('claude-opus-4-6');
+    expect(updated?.name).toBe('Updated Builder');
     expect(updated?.allowedTools).toEqual(['Read', 'Write']);
 
     const removed = await store.remove(created.id);

--- a/packages/control-plane/src/agent/agent-config.ts
+++ b/packages/control-plane/src/agent/agent-config.ts
@@ -8,8 +8,6 @@ export interface AgentConfig {
   status: 'active' | 'inactive';
   description?: string | null;
   icon?: string | null;
-  providerType: string;
-  model: string | null;
   systemPrompt: string | null;
   mcpServers?: string[];
   skills?: string[];
@@ -39,11 +37,11 @@ const BUILTIN_AGENTS: AgentConfig[] = [
     status: 'active',
     description: 'Build and iterate on web applications in the project workspace.',
     icon: 'code',
-    providerType: 'claude-code',
-    model: 'claude-sonnet-4-6',
     systemPrompt:
       'You are a web development assistant. Help users build web applications using modern technologies. You can create, edit, and manage files in the project workspace.',
     allowedTools: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'],
+    skills: [],
+    mcpServers: [],
     maxSteps: 30,
     deliveryMode: 'workspace',
     isBuiltin: true,

--- a/packages/control-plane/src/agent/drizzle-agent-config-store.ts
+++ b/packages/control-plane/src/agent/drizzle-agent-config-store.ts
@@ -14,8 +14,6 @@ function mapRow(row: AgentRow): AgentConfig {
     status: row.status as AgentConfig['status'],
     description: row.description,
     icon: row.icon,
-    providerType: row.providerType,
-    model: row.model,
     systemPrompt: row.systemPrompt,
     allowedTools: row.allowedTools ?? [],
     skills: row.skills ?? [],
@@ -65,8 +63,7 @@ export class DrizzleAgentConfigStore implements AgentConfigStore {
         name: config.name,
         description: config.description ?? null,
         icon: config.icon ?? null,
-        providerType: config.providerType,
-        model: config.model ?? null,
+        providerType: 'claude-code',
         systemPrompt: config.systemPrompt ?? null,
         allowedTools: config.allowedTools ?? [],
         skills: config.skills ?? [],
@@ -86,8 +83,6 @@ export class DrizzleAgentConfigStore implements AgentConfigStore {
     if (update.name !== undefined) updates.name = update.name;
     if (update.description !== undefined) updates.description = update.description;
     if (update.icon !== undefined) updates.icon = update.icon;
-    if (update.providerType !== undefined) updates.providerType = update.providerType;
-    if (update.model !== undefined) updates.model = update.model;
     if (update.systemPrompt !== undefined) updates.systemPrompt = update.systemPrompt;
     if (update.allowedTools !== undefined) updates.allowedTools = update.allowedTools;
     if (update.skills !== undefined) updates.skills = update.skills;

--- a/packages/control-plane/src/run/run-orchestrator.ts
+++ b/packages/control-plane/src/run/run-orchestrator.ts
@@ -82,7 +82,6 @@ export class RunOrchestrator {
         sessionId: runId,
         env: agentContext?.env,
         systemPrompt: agentContext?.systemPrompt,
-        modelId: agentContext?.agentConfig.model ?? undefined,
         allowedTools: agentContext?.agentConfig.allowedTools,
         maxTurns: agentContext?.agentConfig.maxSteps,
       });


### PR DESCRIPTION
## Summary
- Remove `AgentProviderType` enum, `providerType` and `model` fields — Lux only supports Claude Code
- Add multi-select dropdowns for Skills and MCP Servers in agent configuration forms
- Load options from project-level APIs (`/api/projects/{id}/skills`, `/api/projects/{id}/mcp`)
- New reusable `MultiSelect` UI component (Popover + Command combobox)

## Changed layers
- **contracts**: remove `AgentProviderType` enum, `providerType`/`model` from `AgentConfig`
- **control-plane**: update `AgentConfig` interface, `DrizzleAgentConfigStore`, builtin agents
- **web forms**: `agent-form.ts`, `agent-form-fields.tsx` — replace provider/model with skills/mcps select
- **web pages**: clean up provider/model badges from studio, dashboard, chat, project pages
- **API**: remove `providerType`/`model` from agent create payload

## Test plan
- [x] `pnpm build` — all packages pass (web needs `DATABASE_URL`)
- [x] `pnpm check` — TypeScript clean
- [x] `pnpm lint` — no new errors
- [x] `pnpm test` — 869 tests pass
- [ ] Manual: open `/studio`, create/edit agent — verify skills/mcps multi-select works
- [ ] Manual: verify agent cards no longer show provider/model badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)