### PR TITLE
feat(web): Skills marketplace + MCP management pages

### DIFF
--- a/apps/web/app/(app)/mcps/page.tsx
+++ b/apps/web/app/(app)/mcps/page.tsx
@@ -1,14 +1,164 @@
-import { Rss } from 'lucide-react';
+'use client';
+
+import { Loader2, PlusIcon, RefreshCwIcon, RssIcon } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { McpCard, type McpItem } from '@/components/mcps/mcp-card';
+import { McpListItem } from '@/components/mcps/mcp-list-item';
+import { SearchInput } from '@/components/shared/search-input';
+import { type ViewMode, ViewModeToggle } from '@/components/shared/view-mode-toggle';
 
 export default function McpServersPage() {
+  const [servers, setServers] = useState<McpItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [transportFilter, setTransportFilter] = useState<string>('all');
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [projectId, setProjectId] = useState<string | null>(null);
+
+  const loadProjectAndServers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const projRes = await fetch('/api/projects/default');
+      const projJson = await projRes.json();
+      const pid = projJson.data?.id;
+      if (!pid) return;
+      setProjectId(pid);
+
+      const res = await fetch(`/api/projects/${pid}/mcp`);
+      const json = await res.json();
+      if (json.success && Array.isArray(json.data)) {
+        setServers(json.data);
+      }
+    } catch {
+      // Silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProjectAndServers();
+  }, [loadProjectAndServers]);
+
+  const handleDelete = useCallback(
+    async (mcp: McpItem) => {
+      if (!projectId) return;
+      try {
+        await fetch(`/api/projects/${projectId}/mcp`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ serverId: mcp.id }),
+        });
+        setServers((prev) => prev.filter((s) => s.id !== mcp.id));
+      } catch {
+        // Silent
+      }
+    },
+    [projectId],
+  );
+
+  const filtered = servers.filter((s) => {
+    if (transportFilter !== 'all' && s.transport !== transportFilter) return false;
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(q) ||
+      (s.description?.toLowerCase().includes(q) ?? false) ||
+      (s.command?.toLowerCase().includes(q) ?? false) ||
+      (s.url?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="text-center">
-        <Rss className="size-12 text-muted-foreground mx-auto mb-3" />
-        <h1 className="text-lg font-semibold tracking-tight">MCP Servers</h1>
-        <p className="text-[13px] text-muted-foreground mt-1">
-          External tool connections via Model Context Protocol. Coming soon.
-        </p>
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-[1400px] px-8 py-8">
+        {/* Header */}
+        <div className="mb-8 flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">MCP Servers</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              浏览和管理 MCP 服务器，用于扩展 AI 能力
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void loadProjectAndServers()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent transition-colors"
+            >
+              <RefreshCwIcon className="h-4 w-4" />
+              Sync
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4" />
+              Register MCP
+            </button>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="mb-6 flex flex-wrap items-center gap-3">
+          <SearchInput placeholder="搜索 MCP Servers..." value={search} onChange={setSearch} />
+          <select
+            value={transportFilter}
+            onChange={(e) => setTransportFilter(e.target.value)}
+            className="h-9 rounded-lg border-0 bg-muted px-3 text-sm shadow-none hover:bg-muted/80 focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none transition-all"
+          >
+            <option value="all">All Transports</option>
+            <option value="stdio">Stdio</option>
+            <option value="sse">SSE</option>
+            <option value="streamable-http">HTTP</option>
+          </select>
+          <div className="ml-auto">
+            <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
+          </div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex h-[320px] items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex h-[320px] flex-col items-center justify-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <RssIcon className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h3 className="text-sm font-medium">
+              {search || transportFilter !== 'all'
+                ? '没有找到匹配的 MCP Servers'
+                : '还没有注册 MCP Servers'}
+            </h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {search ? '尝试其他搜索词或筛选条件' : '点击 Register MCP 添加新的 MCP 服务器'}
+            </p>
+          </div>
+        ) : viewMode === 'grid' ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filtered.map((mcp) => (
+              <McpCard key={mcp.id} mcp={mcp} onDelete={handleDelete} />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {filtered.map((mcp) => (
+              <McpListItem key={mcp.id} mcp={mcp} onDelete={handleDelete} />
+            ))}
+          </div>
+        )}
+
+        {/* Footer stats */}
+        {!loading && filtered.length > 0 && (
+          <div className="mt-6 text-center text-xs text-muted-foreground">
+            共 {filtered.length} 个 MCP Servers
+            {(search || transportFilter !== 'all') &&
+              filtered.length !== servers.length &&
+              ` (筛选自 ${servers.length} 个)`}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/(app)/skills/page.tsx
+++ b/apps/web/app/(app)/skills/page.tsx
@@ -1,14 +1,152 @@
-import { Wrench } from 'lucide-react';
+'use client';
+
+import { Loader2, PlusIcon, PuzzleIcon, RefreshCwIcon } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { SearchInput } from '@/components/shared/search-input';
+import { type ViewMode, ViewModeToggle } from '@/components/shared/view-mode-toggle';
+import { SkillCard, type SkillItem } from '@/components/skills/skill-card';
+import { SkillListItem } from '@/components/skills/skill-list-item';
 
 export default function SkillsPage() {
+  const [skills, setSkills] = useState<SkillItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [projectId, setProjectId] = useState<string | null>(null);
+
+  const loadProjectAndSkills = useCallback(async () => {
+    setLoading(true);
+    try {
+      const projRes = await fetch('/api/projects/default');
+      const projJson = await projRes.json();
+      const pid = projJson.data?.id;
+      if (!pid) return;
+      setProjectId(pid);
+
+      const res = await fetch(`/api/projects/${pid}/skills`);
+      const json = await res.json();
+      if (json.success && Array.isArray(json.data)) {
+        setSkills(json.data);
+      }
+    } catch {
+      // Silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProjectAndSkills();
+  }, [loadProjectAndSkills]);
+
+  const handleToggle = useCallback(
+    async (skill: SkillItem) => {
+      if (!projectId) return;
+      try {
+        await fetch(`/api/projects/${projectId}/skills`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            skillRef: skill.source,
+            options: { enabled: !skill.enabled },
+          }),
+        });
+        setSkills((prev) =>
+          prev.map((s) => (s.name === skill.name ? { ...s, enabled: !s.enabled } : s)),
+        );
+      } catch {
+        // Silent
+      }
+    },
+    [projectId],
+  );
+
+  const filtered = skills.filter((s) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    return (
+      s.name.toLowerCase().includes(q) ||
+      s.source.toLowerCase().includes(q) ||
+      (s.description?.toLowerCase().includes(q) ?? false)
+    );
+  });
+
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="text-center">
-        <Wrench className="size-12 text-muted-foreground mx-auto mb-3" />
-        <h1 className="text-lg font-semibold tracking-tight">Skills</h1>
-        <p className="text-[13px] text-muted-foreground mt-1">
-          Reusable capability modules that extend what agents can do. Coming soon.
-        </p>
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-[1400px] px-8 py-8">
+        {/* Header */}
+        <div className="mb-8 flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Skills</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              浏览和管理 Skills，用于增强 Agent 能力
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void loadProjectAndSkills()}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium hover:bg-accent transition-colors"
+            >
+              <RefreshCwIcon className="h-4 w-4" />
+              Sync
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4" />
+              Add Skill
+            </button>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="mb-6 flex flex-wrap items-center gap-3">
+          <SearchInput placeholder="搜索 Skills..." value={search} onChange={setSearch} />
+          <div className="ml-auto">
+            <ViewModeToggle viewMode={viewMode} onViewModeChange={setViewMode} />
+          </div>
+        </div>
+
+        {/* Content */}
+        {loading ? (
+          <div className="flex h-[320px] items-center justify-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex h-[320px] flex-col items-center justify-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+              <PuzzleIcon className="h-6 w-6 text-muted-foreground" />
+            </div>
+            <h3 className="text-sm font-medium">
+              {search ? '没有找到匹配的 Skills' : '还没有安装 Skills'}
+            </h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {search ? '尝试其他搜索词' : '使用 reskill install 或点击 Add Skill 安装'}
+            </p>
+          </div>
+        ) : viewMode === 'grid' ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filtered.map((skill) => (
+              <SkillCard key={skill.name} skill={skill} onToggle={handleToggle} />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {filtered.map((skill) => (
+              <SkillListItem key={skill.name} skill={skill} onToggle={handleToggle} />
+            ))}
+          </div>
+        )}
+
+        {/* Footer stats */}
+        {!loading && filtered.length > 0 && (
+          <div className="mt-6 text-center text-xs text-muted-foreground">
+            共 {filtered.length} 个 Skills
+            {search && filtered.length !== skills.length && ` (筛选自 ${skills.length} 个)`}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/mcps/mcp-card.tsx
+++ b/apps/web/components/mcps/mcp-card.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import {
+  MonitorIcon,
+  RadioIcon,
+  ToggleLeftIcon,
+  ToggleRightIcon,
+  TrashIcon,
+  WifiIcon,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export interface McpItem {
+  id: string;
+  name: string;
+  transport: string;
+  command?: string | null;
+  url?: string | null;
+  enabled: boolean;
+  scope: string;
+  description?: string;
+  tags?: string[];
+  toolCount?: number;
+}
+
+interface McpCardProps {
+  mcp: McpItem;
+  onToggle?: (mcp: McpItem) => void;
+  onDelete?: (mcp: McpItem) => void;
+  onClick?: (mcp: McpItem) => void;
+}
+
+function getTransportIcon(transport: string) {
+  switch (transport) {
+    case 'stdio':
+      return MonitorIcon;
+    case 'sse':
+      return RadioIcon;
+    case 'streamable-http':
+      return WifiIcon;
+    default:
+      return MonitorIcon;
+  }
+}
+
+function getTransportLabel(transport: string) {
+  switch (transport) {
+    case 'stdio':
+      return 'Stdio';
+    case 'sse':
+      return 'SSE';
+    case 'streamable-http':
+      return 'HTTP';
+    default:
+      return transport;
+  }
+}
+
+export function McpCard({ mcp, onToggle, onDelete, onClick }: McpCardProps) {
+  const TransportIcon = getTransportIcon(mcp.transport);
+
+  return (
+    <div
+      className="group relative flex h-full min-w-0 cursor-pointer flex-col overflow-hidden rounded-xl bg-background p-5 shadow-[0px_0px_15px_rgba(0,0,0,0.09)] transition-all duration-200 hover:shadow-[0px_0px_20px_rgba(0,0,0,0.15)] hover:scale-[0.98] motion-reduce:transform-none dark:shadow-[0px_0px_15px_rgba(0,0,0,0.3)]"
+      onClick={() => onClick?.(mcp)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onClick?.(mcp);
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      {/* Corner decoration */}
+      <div
+        className="absolute right-0 top-0 h-12 w-12 bg-emerald-500"
+        style={{ clipPath: 'polygon(100% 0, 0 0, 100% 100%)' }}
+      />
+      <div className="absolute right-2 top-2 z-10">
+        <TransportIcon className="h-4 w-4 text-white/90" />
+      </div>
+
+      {/* Header */}
+      <div className="mb-3 pr-10">
+        <h3 className="truncate text-sm font-semibold text-foreground">{mcp.name}</h3>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+          {mcp.enabled && (
+            <Badge className="bg-green-100 text-green-700 hover:bg-green-100 px-1.5 py-0 text-[10px]">
+              Active
+            </Badge>
+          )}
+          <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+            {getTransportLabel(mcp.transport)}
+          </Badge>
+          <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+            {mcp.scope}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Description */}
+      <p className="mb-3 line-clamp-2 text-[13px] leading-relaxed text-foreground/60">
+        {mcp.description || (mcp.transport === 'stdio' ? mcp.command : mcp.url) || 'No description'}
+      </p>
+
+      {/* Tags */}
+      {mcp.tags && mcp.tags.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {mcp.tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-md bg-secondary px-2 py-0.5 text-xs font-medium"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="mt-auto flex items-center justify-between pt-2">
+        <div className="flex items-center gap-3">
+          {mcp.toolCount !== undefined && mcp.toolCount > 0 && (
+            <span className="text-xs text-muted-foreground">{mcp.toolCount} tools</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          {onToggle && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle(mcp);
+              }}
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            >
+              {mcp.enabled ? (
+                <ToggleRightIcon className="h-3.5 w-3.5 text-green-500" />
+              ) : (
+                <ToggleLeftIcon className="h-3.5 w-3.5" />
+              )}
+              {mcp.enabled ? 'Disable' : 'Enable'}
+            </button>
+          )}
+          {onDelete && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(mcp);
+              }}
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-destructive hover:bg-destructive/10 transition-colors"
+            >
+              <TrashIcon className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/mcps/mcp-list-item.tsx
+++ b/apps/web/components/mcps/mcp-list-item.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  ChevronRightIcon,
+  MonitorIcon,
+  RadioIcon,
+  ToggleLeftIcon,
+  ToggleRightIcon,
+  TrashIcon,
+  WifiIcon,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { McpItem } from './mcp-card';
+
+interface McpListItemProps {
+  mcp: McpItem;
+  onToggle?: (mcp: McpItem) => void;
+  onDelete?: (mcp: McpItem) => void;
+  onClick?: (mcp: McpItem) => void;
+}
+
+function getTransportIcon(transport: string) {
+  switch (transport) {
+    case 'stdio':
+      return MonitorIcon;
+    case 'sse':
+      return RadioIcon;
+    case 'streamable-http':
+      return WifiIcon;
+    default:
+      return MonitorIcon;
+  }
+}
+
+export function McpListItem({ mcp, onToggle, onDelete, onClick }: McpListItemProps) {
+  const TransportIcon = getTransportIcon(mcp.transport);
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-lg border border-border bg-background px-4 py-3 transition-colors hover:bg-accent/30 cursor-pointer"
+      onClick={() => onClick?.(mcp)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onClick?.(mcp);
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-50 dark:bg-emerald-950">
+        <TransportIcon className="h-4 w-4 text-emerald-500" />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{mcp.name}</span>
+          {mcp.enabled && (
+            <Badge className="bg-green-100 text-green-700 hover:bg-green-100 px-1.5 py-0 text-[10px]">
+              Active
+            </Badge>
+          )}
+          <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+            {mcp.transport}
+          </Badge>
+          <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+            {mcp.scope}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground truncate mt-0.5">
+          {mcp.description || (mcp.transport === 'stdio' ? mcp.command : mcp.url) || 'No description'}
+        </p>
+      </div>
+
+      {mcp.toolCount !== undefined && mcp.toolCount > 0 && (
+        <span className="hidden md:inline text-xs text-muted-foreground shrink-0">
+          {mcp.toolCount} tools
+        </span>
+      )}
+
+      <div className="flex items-center gap-1 shrink-0">
+        {onToggle && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(mcp);
+            }}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            {mcp.enabled ? (
+              <ToggleRightIcon className="h-4 w-4 text-green-500" />
+            ) : (
+              <ToggleLeftIcon className="h-4 w-4" />
+            )}
+          </button>
+        )}
+        {onDelete && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(mcp);
+            }}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+          >
+            <TrashIcon className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <ChevronRightIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+    </div>
+  );
+}

--- a/apps/web/components/shared/search-input.tsx
+++ b/apps/web/components/shared/search-input.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { SearchIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+interface SearchInputProps {
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+export function SearchInput({
+  placeholder = '搜索...',
+  value,
+  onChange,
+  className = '',
+}: SearchInputProps) {
+  const [composing, setComposing] = useState(false);
+  const [localValue, setLocalValue] = useState(value);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setLocalValue(e.target.value);
+      if (!composing) onChange(e.target.value);
+    },
+    [composing, onChange],
+  );
+
+  return (
+    <div className={`relative min-w-[200px] max-w-sm flex-1 ${className}`}>
+      <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <input
+        type="text"
+        placeholder={placeholder}
+        value={composing ? localValue : value}
+        onChange={handleChange}
+        onCompositionStart={() => setComposing(true)}
+        onCompositionEnd={(e) => {
+          setComposing(false);
+          onChange((e.target as HTMLInputElement).value);
+        }}
+        className="h-9 w-full rounded-lg pl-9 pr-3 border-0 bg-muted text-sm shadow-none hover:bg-muted/80 focus-visible:bg-background focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none transition-all duration-200"
+      />
+    </div>
+  );
+}

--- a/apps/web/components/shared/view-mode-toggle.tsx
+++ b/apps/web/components/shared/view-mode-toggle.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+export type ViewMode = 'grid' | 'list';
+
+interface ViewModeToggleProps {
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+}
+
+export function ViewModeToggle({ viewMode, onViewModeChange }: ViewModeToggleProps) {
+  return (
+    <div className="inline-flex items-center gap-0.5 rounded-lg border border-border bg-secondary p-0.5">
+      <button
+        type="button"
+        onClick={() => onViewModeChange('list')}
+        className={`flex h-7 w-7 items-center justify-center rounded-md transition-all ${
+          viewMode === 'list'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+        }`}
+        title="List view"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M4 6h16M4 10h16M4 14h16M4 18h16"
+          />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={() => onViewModeChange('grid')}
+        className={`flex h-7 w-7 items-center justify-center rounded-md transition-all ${
+          viewMode === 'grid'
+            ? 'bg-background text-foreground shadow-sm'
+            : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+        }`}
+        title="Grid view"
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+          />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/components/skills/skill-card.tsx
+++ b/apps/web/components/skills/skill-card.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { CheckIcon, CopyIcon, LockIcon, PuzzleIcon, ToggleLeftIcon, ToggleRightIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
+
+export interface SkillItem {
+  name: string;
+  source: string;
+  visibility: string;
+  enabled: boolean;
+  metadata?: string | null;
+  description?: string;
+  tags?: string[];
+  version?: string;
+}
+
+interface SkillCardProps {
+  skill: SkillItem;
+  onToggle?: (skill: SkillItem) => void;
+  onClick?: (skill: SkillItem) => void;
+}
+
+export function SkillCard({ skill, onToggle, onClick }: SkillCardProps) {
+  const [copied, setCopied] = useState(false);
+  const isPrivate = skill.visibility === 'private';
+  const installCmd = `reskill install ${skill.source}`;
+
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(installCmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    },
+    [installCmd],
+  );
+
+  return (
+    <div
+      className="group relative flex h-full cursor-pointer flex-col overflow-hidden rounded-xl bg-background p-5 shadow-[0px_0px_15px_rgba(0,0,0,0.09)] transition-all duration-200 hover:shadow-[0px_0px_20px_rgba(0,0,0,0.15)] hover:scale-[0.98] motion-reduce:transform-none dark:shadow-[0px_0px_15px_rgba(0,0,0,0.3)]"
+      onClick={() => onClick?.(skill)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick?.(skill);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      {/* Corner decoration */}
+      <div
+        className={`absolute right-0 top-0 h-12 w-12 ${isPrivate ? 'bg-amber-500' : 'bg-violet-500'}`}
+        style={{ clipPath: 'polygon(100% 0, 0 0, 100% 100%)' }}
+      />
+      <div className="absolute right-1.5 top-1.5 z-10">
+        {isPrivate ? (
+          <LockIcon className="h-4 w-4 text-white/90" />
+        ) : (
+          <PuzzleIcon className="h-4 w-4 text-white/90" />
+        )}
+      </div>
+
+      {/* Header */}
+      <div className="mb-3 pr-10">
+        <div className="mb-1 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-foreground truncate">{skill.name}</h3>
+          {skill.version && (
+            <span className="text-xs text-muted-foreground shrink-0 ml-2">
+              {skill.version.replace(/^v/, '')}
+            </span>
+          )}
+        </div>
+        <p className="line-clamp-2 text-xs leading-relaxed text-foreground/60">
+          {skill.description || skill.source}
+        </p>
+      </div>
+
+      {/* Tags */}
+      {skill.tags && skill.tags.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {skill.tags.slice(0, 3).map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-md bg-secondary px-2 py-0.5 text-xs font-medium"
+            >
+              {tag}
+            </span>
+          ))}
+          {skill.tags.length > 3 && (
+            <span className="inline-flex items-center rounded-md bg-secondary px-2 py-0.5 text-xs font-medium">
+              +{skill.tags.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Install command */}
+      <div className="mb-3 flex items-center gap-2 rounded-md border border-border bg-muted/50 p-2">
+        <code className="flex-1 truncate text-xs font-mono text-muted-foreground/80">
+          {installCmd}
+        </code>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="shrink-0 rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        >
+          {copied ? <CheckIcon className="h-3.5 w-3.5 text-green-500" /> : <CopyIcon className="h-3.5 w-3.5" />}
+        </button>
+      </div>
+
+      {/* Footer */}
+      <div className="mt-auto flex items-center justify-between text-xs text-muted-foreground/70">
+        <div className="flex items-center gap-1.5">
+          <span className="inline-flex items-center rounded-md bg-secondary px-1.5 py-0.5 text-[10px]">
+            {skill.visibility}
+          </span>
+          {skill.enabled ? (
+            <span className="text-green-600 text-[10px]">Enabled</span>
+          ) : (
+            <span className="text-muted-foreground text-[10px]">Disabled</span>
+          )}
+        </div>
+        {onToggle && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle(skill);
+            }}
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            {skill.enabled ? (
+              <ToggleRightIcon className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <ToggleLeftIcon className="h-3.5 w-3.5" />
+            )}
+            {skill.enabled ? 'Disable' : 'Enable'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/skills/skill-list-item.tsx
+++ b/apps/web/components/skills/skill-list-item.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { ChevronRightIcon, LockIcon, PuzzleIcon, ToggleLeftIcon, ToggleRightIcon } from 'lucide-react';
+import type { SkillItem } from './skill-card';
+
+interface SkillListItemProps {
+  skill: SkillItem;
+  onToggle?: (skill: SkillItem) => void;
+  onClick?: (skill: SkillItem) => void;
+}
+
+export function SkillListItem({ skill, onToggle, onClick }: SkillListItemProps) {
+  const isPrivate = skill.visibility === 'private';
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-lg border border-border bg-background px-4 py-3 transition-colors hover:bg-accent/30 cursor-pointer"
+      onClick={() => onClick?.(skill)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onClick?.(skill);
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-50 dark:bg-violet-950">
+        {isPrivate ? (
+          <LockIcon className="h-4 w-4 text-amber-500" />
+        ) : (
+          <PuzzleIcon className="h-4 w-4 text-violet-500" />
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium truncate">{skill.name}</span>
+          <span className="inline-flex items-center rounded-md bg-secondary px-1.5 py-0 text-[10px]">
+            {skill.visibility}
+          </span>
+          {skill.version && (
+            <span className="text-[10px] text-muted-foreground">{skill.version}</span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground truncate mt-0.5">
+          {skill.description || skill.source}
+        </p>
+      </div>
+
+      {skill.tags && skill.tags.length > 0 && (
+        <div className="hidden md:flex items-center gap-1.5 shrink-0">
+          {skill.tags.slice(0, 2).map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-md bg-secondary px-2 py-0.5 text-[10px]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {onToggle && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggle(skill);
+          }}
+          className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          {skill.enabled ? (
+            <ToggleRightIcon className="h-4 w-4 text-green-500" />
+          ) : (
+            <ToggleLeftIcon className="h-4 w-4" />
+          )}
+        </button>
+      )}
+
+      <ChevronRightIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Skills page** — grid/list view, search, skill cards with install command copy, enable/disable, visibility badges
- **MCP page** — grid/list view, search + transport filter, server cards with status badges, delete actions
- **Shared components** — SearchInput (IME-safe), ViewModeToggle

Style matches rush project card design.

## Test plan

- [x] Skills/MCPs pages return 200
- [x] TypeScript compile pass
- [ ] Browser manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)