### PR TITLE
test: comprehensive unit + integration test coverage

### DIFF
--- a/apps/agent-worker/src/__tests__/server.test.ts
+++ b/apps/agent-worker/src/__tests__/server.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('ai', () => ({
+  streamText: vi.fn(),
+}));
+vi.mock('ai-sdk-provider-claude-code', () => ({
+  claudeCode: vi.fn(() => 'mock-model'),
+}));
+vi.mock('@hono/node-server', () => ({
+  serve: vi.fn(),
+}));
+
+import { streamText } from 'ai';
+import { claudeCode } from 'ai-sdk-provider-claude-code';
+import app from '../server.js';
+
+// Helper to parse JSON response body
+async function json(res: Response): Promise<Record<string, unknown>> {
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+describe('agent-worker server', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------
+  // GET /health
+  // ---------------------------------------------------------------
+  describe('GET /health', () => {
+    it('returns 200 with status ok, service name, activeRuns count, and timestamp', async () => {
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+
+      const body = await json(res);
+      expect(body.status).toBe('ok');
+      expect(body.service).toBe('agent-worker');
+      expect(typeof body.activeRuns).toBe('number');
+      expect(body.timestamp).toBeDefined();
+      // timestamp should be a valid ISO string
+      expect(Number.isNaN(Date.parse(body.timestamp as string))).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // GET /status
+  // ---------------------------------------------------------------
+  describe('GET /status', () => {
+    it('returns 200 with ready true and activeRuns count', async () => {
+      const res = await app.request('/status');
+      expect(res.status).toBe(200);
+
+      const body = await json(res);
+      expect(body.ready).toBe(true);
+      expect(typeof body.activeRuns).toBe('number');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // POST /prompt
+  // ---------------------------------------------------------------
+  describe('POST /prompt', () => {
+    function postPrompt(payload: Record<string, unknown>) {
+      return app.request('/prompt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+
+    function mockStreamTextSuccess() {
+      const mockResult = {
+        toTextStreamResponse: vi.fn(() => new Response('streamed text')),
+        response: Promise.resolve({}),
+      };
+      (streamText as Mock).mockReturnValue(mockResult);
+      return mockResult;
+    }
+
+    it('returns 400 when neither prompt nor messages is provided', async () => {
+      const res = await postPrompt({});
+      expect(res.status).toBe(400);
+
+      const body = await json(res);
+      expect(body.error).toBe('prompt is required');
+    });
+
+    it('returns 400 when messages array has no user messages', async () => {
+      const res = await postPrompt({
+        messages: [
+          { role: 'assistant', content: 'hello' },
+          { role: 'system', content: 'you are helpful' },
+        ],
+      });
+      expect(res.status).toBe(400);
+
+      const body = await json(res);
+      expect(body.error).toBe('prompt is required');
+    });
+
+    it('returns 400 when messages is an empty array', async () => {
+      const res = await postPrompt({ messages: [] });
+      expect(res.status).toBe(400);
+
+      const body = await json(res);
+      expect(body.error).toBe('prompt is required');
+    });
+
+    it('calls streamText with the correct prompt when prompt string is provided', async () => {
+      const mockResult = mockStreamTextSuccess();
+
+      const res = await postPrompt({ prompt: 'write hello world' });
+      expect(res.status).toBe(200);
+
+      expect(streamText).toHaveBeenCalledOnce();
+      const callArgs = (streamText as Mock).mock.calls[0][0];
+      expect(callArgs.prompt).toBe('write hello world');
+      expect(callArgs.model).toBe('mock-model');
+      expect(callArgs.abortSignal).toBeInstanceOf(AbortSignal);
+      expect(mockResult.toTextStreamResponse).toHaveBeenCalledOnce();
+    });
+
+    it('extracts the last user message from messages array', async () => {
+      mockStreamTextSuccess();
+
+      const res = await postPrompt({
+        messages: [
+          { role: 'user', content: 'first question' },
+          { role: 'assistant', content: 'answer' },
+          { role: 'user', content: 'follow up' },
+        ],
+      });
+      expect(res.status).toBe(200);
+
+      const callArgs = (streamText as Mock).mock.calls[0][0];
+      expect(callArgs.prompt).toBe('follow up');
+    });
+
+    it('prompt takes precedence over messages when both are provided', async () => {
+      mockStreamTextSuccess();
+
+      const res = await postPrompt({
+        prompt: 'direct prompt',
+        messages: [{ role: 'user', content: 'from messages' }],
+      });
+      expect(res.status).toBe(200);
+
+      const callArgs = (streamText as Mock).mock.calls[0][0];
+      expect(callArgs.prompt).toBe('direct prompt');
+    });
+
+    it('passes systemPrompt as system option to streamText', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({
+        prompt: 'hello',
+        systemPrompt: 'you are a coding assistant',
+      });
+
+      const callArgs = (streamText as Mock).mock.calls[0][0];
+      expect(callArgs.system).toBe('you are a coding assistant');
+    });
+
+    it('does not include system option when systemPrompt is not provided', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello' });
+
+      const callArgs = (streamText as Mock).mock.calls[0][0];
+      expect(callArgs.system).toBeUndefined();
+    });
+
+    it('passes custom modelId to claudeCode provider', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello', modelId: 'opus' });
+
+      expect(claudeCode).toHaveBeenCalledWith(
+        'opus',
+        expect.objectContaining({ permissionMode: 'bypassPermissions' })
+      );
+    });
+
+    it('defaults modelId to sonnet when ANTHROPIC_MODEL env is not set', async () => {
+      mockStreamTextSuccess();
+      const original = process.env.ANTHROPIC_MODEL;
+      delete process.env.ANTHROPIC_MODEL;
+
+      await postPrompt({ prompt: 'hello' });
+
+      expect(claudeCode).toHaveBeenCalledWith(
+        'sonnet',
+        expect.objectContaining({ permissionMode: 'bypassPermissions' })
+      );
+
+      // Restore
+      if (original !== undefined) process.env.ANTHROPIC_MODEL = original;
+    });
+
+    it('passes maxTurns to claudeCode provider (defaults to 30)', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello' });
+      expect(claudeCode).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ maxTurns: 30 })
+      );
+    });
+
+    it('passes custom maxTurns to claudeCode provider', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello', maxTurns: 10 });
+      expect(claudeCode).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ maxTurns: 10 })
+      );
+    });
+
+    it('passes allowedTools to claudeCode when provided', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello', allowedTools: ['Bash', 'Read'] });
+      expect(claudeCode).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ allowedTools: ['Bash', 'Read'] })
+      );
+    });
+
+    it('passes custom sessionId to claudeCode provider', async () => {
+      mockStreamTextSuccess();
+
+      await postPrompt({ prompt: 'hello', sessionId: 'my-session-123' });
+      expect(claudeCode).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ sessionId: 'my-session-123' })
+      );
+    });
+
+    it('returns 500 with error message when streamText throws', async () => {
+      (streamText as Mock).mockImplementation(() => {
+        throw new Error('model unavailable');
+      });
+
+      const res = await postPrompt({ prompt: 'hello' });
+      expect(res.status).toBe(500);
+
+      const body = await json(res);
+      expect(body.error).toBe('model unavailable');
+    });
+
+    it('returns 500 with stringified error when streamText throws a non-Error', async () => {
+      (streamText as Mock).mockImplementation(() => {
+        throw 'something went wrong';
+      });
+
+      const res = await postPrompt({ prompt: 'hello' });
+      expect(res.status).toBe(500);
+
+      const body = await json(res);
+      expect(body.error).toBe('something went wrong');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // POST /abort
+  // ---------------------------------------------------------------
+  describe('POST /abort', () => {
+    function postAbort(payload: Record<string, unknown>) {
+      return app.request('/abort', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+
+    function postPrompt(payload: Record<string, unknown>) {
+      return app.request('/prompt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
+
+    it('returns 400 when sessionId is missing', async () => {
+      const res = await postAbort({});
+      expect(res.status).toBe(400);
+
+      const body = await json(res);
+      expect(body.error).toBe('sessionId is required');
+    });
+
+    it('returns 404 when sessionId is not found in active sessions', async () => {
+      const res = await postAbort({ sessionId: 'nonexistent-session' });
+      expect(res.status).toBe(404);
+
+      const body = await json(res);
+      expect(body.aborted).toBe(false);
+      expect(body.reason).toBe('session not found');
+    });
+
+    it('aborts an active session created by /prompt (round-trip)', async () => {
+      // Mock streamText to return a result whose response never resolves,
+      // keeping the session in activeSessions
+      const mockResult = {
+        toTextStreamResponse: vi.fn(() => new Response('stream')),
+        response: new Promise(() => {}), // never resolves
+      };
+      (streamText as Mock).mockReturnValue(mockResult);
+
+      const sessionId = 'session-to-abort';
+
+      // Create the session via /prompt
+      const promptRes = await postPrompt({ prompt: 'hello', sessionId });
+      expect(promptRes.status).toBe(200);
+
+      // Verify the session is now tracked (activeRuns should be >= 1)
+      const statusRes = await app.request('/health');
+      const statusBody = await json(statusRes);
+      expect(statusBody.activeRuns).toBeGreaterThanOrEqual(1);
+
+      // Abort the session
+      const abortRes = await postAbort({ sessionId });
+      expect(abortRes.status).toBe(200);
+
+      const abortBody = await json(abortRes);
+      expect(abortBody.aborted).toBe(true);
+
+      // After abort, the session should be removed — trying to abort again yields 404
+      const abortAgainRes = await postAbort({ sessionId });
+      expect(abortAgainRes.status).toBe(404);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // 404 for unknown routes
+  // ---------------------------------------------------------------
+  describe('unknown routes', () => {
+    it('returns 404 for unregistered paths', async () => {
+      const res = await app.request('/nonexistent');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/web/app/api/health/__tests__/route.test.ts
+++ b/apps/web/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We need to control env vars before importing the route handler
+const originalEnv = { ...process.env };
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    // Clean env for each test
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  async function importAndCall() {
+    // Re-import to pick up fresh env
+    const mod = await import('../route.js');
+    const response = await mod.GET();
+    return response.json();
+  }
+
+  it('returns ok status with timestamp and service name', async () => {
+    const body = await importAndCall();
+    expect(body.status).toBe('ok');
+    expect(body.service).toBe('lux-web');
+    expect(body.timestamp).toBeDefined();
+    // Verify timestamp is a valid ISO string
+    expect(() => new Date(body.timestamp)).not.toThrow();
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+  });
+
+  it('detects bedrock provider when CLAUDE_CODE_USE_BEDROCK=1', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    const body = await importAndCall();
+    expect(body.provider).toBe('bedrock');
+  });
+
+  it('detects bedrock provider when CLAUDE_CODE_USE_BEDROCK=true', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = 'true';
+    const body = await importAndCall();
+    expect(body.provider).toBe('bedrock');
+  });
+
+  it('detects bedrock provider when CLAUDE_CODE_USE_BEDROCK=yes', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = 'yes';
+    const body = await importAndCall();
+    expect(body.provider).toBe('bedrock');
+  });
+
+  it('does not treat CLAUDE_CODE_USE_BEDROCK=0 as truthy', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '0';
+    const body = await importAndCall();
+    expect(body.provider).not.toBe('bedrock');
+  });
+
+  it('detects custom provider when ANTHROPIC_BASE_URL is set', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://custom.api.com';
+    const body = await importAndCall();
+    expect(body.provider).toBe('custom');
+  });
+
+  it('detects anthropic provider when ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+    const body = await importAndCall();
+    expect(body.provider).toBe('anthropic');
+  });
+
+  it('returns unknown provider when no env vars configured', async () => {
+    const body = await importAndCall();
+    expect(body.provider).toBe('unknown');
+  });
+
+  it('bedrock takes precedence over custom and anthropic', async () => {
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.ANTHROPIC_BASE_URL = 'https://custom.api.com';
+    process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+    const body = await importAndCall();
+    expect(body.provider).toBe('bedrock');
+  });
+
+  it('custom takes precedence over anthropic', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://custom.api.com';
+    process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+    const body = await importAndCall();
+    expect(body.provider).toBe('custom');
+  });
+});

--- a/apps/web/lib/__tests__/api-utils.test.ts
+++ b/apps/web/lib/__tests__/api-utils.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuth = vi.fn();
+vi.mock('@/auth', () => ({
+  auth: () => mockAuth(),
+}));
+
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+const mockLimit = vi.fn();
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({
+    select: mockSelect,
+  }),
+  projects: { id: 'projects.id', createdBy: 'projects.createdBy', deletedAt: 'projects.deletedAt' },
+}));
+
+// Chain: db.select(...).from(...).where(...).limit(1) → [row]
+function mockDbQuery(result: unknown[]) {
+  mockLimit.mockResolvedValue(result);
+  mockWhere.mockReturnValue({ limit: mockLimit });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+}
+
+const mockGetMembership = vi.fn();
+vi.mock('@open-rush/control-plane', () => {
+  class MockDrizzleMembershipDb {}
+  class MockDbMembershipStore {
+    getMembership = mockGetMembership;
+  }
+  return {
+    DrizzleMembershipDb: MockDrizzleMembershipDb,
+    DbMembershipStore: MockDbMembershipStore,
+  };
+});
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col: unknown, val: unknown) => val),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  apiError,
+  apiSuccess,
+  getProjectRole,
+  requireAuth,
+  verifyProjectAccess,
+} from '../api-utils';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// apiError / apiSuccess (pure functions)
+// ---------------------------------------------------------------------------
+
+describe('apiError', () => {
+  it('returns JSON response with correct status', async () => {
+    const res = apiError(404, 'NOT_FOUND', 'Resource not found');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'Resource not found', code: 'NOT_FOUND' });
+  });
+
+  it('works with 400 status', async () => {
+    const res = apiError(400, 'VALIDATION_ERROR', 'Invalid input');
+    expect(res.status).toBe(400);
+  });
+
+  it('works with 500 status', async () => {
+    const res = apiError(500, 'INTERNAL_ERROR', 'Server error');
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('apiSuccess', () => {
+  it('returns JSON response with default 200 status', async () => {
+    const res = apiSuccess({ id: 'test-123' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, data: { id: 'test-123' } });
+  });
+
+  it('accepts custom status code', async () => {
+    const res = apiSuccess({ created: true }, 201);
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, data: { created: true } });
+  });
+
+  it('handles null data', async () => {
+    const res = apiSuccess(null);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, data: null });
+  });
+
+  it('handles array data', async () => {
+    const res = apiSuccess([1, 2, 3]);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, data: [1, 2, 3] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireAuth
+// ---------------------------------------------------------------------------
+
+describe('requireAuth', () => {
+  it('returns userId when session is valid', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } });
+    const userId = await requireAuth();
+    expect(userId).toBe('user-1');
+  });
+
+  it('throws 401 Response when no session', async () => {
+    mockAuth.mockResolvedValue(null);
+    try {
+      await requireAuth();
+      expect.fail('Should have thrown');
+    } catch (err) {
+      const res = err as Response;
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.code).toBe('UNAUTHORIZED');
+    }
+  });
+
+  it('throws 401 Response when session has no user', async () => {
+    mockAuth.mockResolvedValue({ user: null });
+    try {
+      await requireAuth();
+      expect.fail('Should have thrown');
+    } catch (err) {
+      const res = err as Response;
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it('throws 401 Response when user has no id', async () => {
+    mockAuth.mockResolvedValue({ user: { name: 'Test' } });
+    try {
+      await requireAuth();
+      expect.fail('Should have thrown');
+    } catch (err) {
+      const res = err as Response;
+      expect(res.status).toBe(401);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyProjectAccess
+// ---------------------------------------------------------------------------
+
+describe('verifyProjectAccess', () => {
+  it('returns false when project not found', async () => {
+    mockDbQuery([]);
+    const result = await verifyProjectAccess('proj-1', 'user-1');
+    expect(result).toBe(false);
+  });
+
+  it('returns false when project is soft-deleted', async () => {
+    mockDbQuery([{ createdBy: 'user-1', deletedAt: new Date() }]);
+    const result = await verifyProjectAccess('proj-1', 'user-1');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when user has membership', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue({ role: 'member' });
+    const result = await verifyProjectAccess('proj-1', 'user-1');
+    expect(result).toBe(true);
+  });
+
+  it('returns true when user is project creator (fallback)', async () => {
+    mockDbQuery([{ createdBy: 'user-1', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue(null);
+    const result = await verifyProjectAccess('proj-1', 'user-1');
+    expect(result).toBe(true);
+  });
+
+  it('returns false when not member and not creator', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue(null);
+    const result = await verifyProjectAccess('proj-1', 'user-1');
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getProjectRole
+// ---------------------------------------------------------------------------
+
+describe('getProjectRole', () => {
+  it('returns null when project not found', async () => {
+    mockDbQuery([]);
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBeNull();
+  });
+
+  it('returns null when project is soft-deleted', async () => {
+    mockDbQuery([{ createdBy: 'user-1', deletedAt: new Date() }]);
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBeNull();
+  });
+
+  it('returns membership role when member', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue({ role: 'admin' });
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBe('admin');
+  });
+
+  it('returns owner role for creator fallback', async () => {
+    mockDbQuery([{ createdBy: 'user-1', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue(null);
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBe('owner');
+  });
+
+  it('returns null when not member and not creator', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue(null);
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBeNull();
+  });
+
+  it('returns member role', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue({ role: 'member' });
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBe('member');
+  });
+
+  it('returns owner role from membership', async () => {
+    mockDbQuery([{ createdBy: 'other-user', deletedAt: null }]);
+    mockGetMembership.mockResolvedValue({ role: 'owner' });
+    const role = await getProjectRole('proj-1', 'user-1');
+    expect(role).toBe('owner');
+  });
+});

--- a/apps/web/lib/agents/__tests__/resolve-agent-id.test.ts
+++ b/apps/web/lib/agents/__tests__/resolve-agent-id.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock @open-rush/control-plane
+// ---------------------------------------------------------------------------
+const mockGetById = vi.fn();
+const mockGetProjectAgents = vi.fn();
+const mockCreate = vi.fn();
+const mockGetCurrentAgent = vi.fn();
+const mockSetCurrentAgent = vi.fn();
+
+vi.mock('@open-rush/control-plane', () => {
+  class MockDrizzleAgentConfigStore {
+    getById = mockGetById;
+    getProjectAgents = mockGetProjectAgents;
+    create = mockCreate;
+  }
+  class MockProjectAgentService {
+    getCurrentAgent = mockGetCurrentAgent;
+    setCurrentAgent = mockSetCurrentAgent;
+  }
+  return {
+    DrizzleAgentConfigStore: MockDrizzleAgentConfigStore,
+    ProjectAgentService: MockProjectAgentService,
+  };
+});
+
+// Mock randomUUID so we can predict the generated id.
+vi.mock('node:crypto', () => ({
+  randomUUID: () => 'generated-uuid-1234',
+}));
+
+import { resolveAgentIdForProject } from '../resolve-agent-id';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const db = {} as never; // Fake DbClient — the real one is never used thanks to mocks.
+const PROJECT_ID = 'proj-1';
+const USER_ID = 'user-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// With requestedAgentId
+// ---------------------------------------------------------------------------
+describe('with requestedAgentId', () => {
+  it('validates the agent, sets it as current, and returns the id', async () => {
+    const agentId = 'agent-42';
+    mockGetById.mockResolvedValue({
+      id: agentId,
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+
+    const result = await resolveAgentIdForProject({
+      db,
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+      requestedAgentId: agentId,
+    });
+
+    expect(result).toBe(agentId);
+    expect(mockGetById).toHaveBeenCalledWith(agentId);
+    expect(mockSetCurrentAgent).toHaveBeenCalledWith(PROJECT_ID, agentId);
+  });
+
+  it('throws when the agent is not found', async () => {
+    mockGetById.mockResolvedValue(null);
+
+    await expect(
+      resolveAgentIdForProject({
+        db,
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        requestedAgentId: 'missing-agent',
+      })
+    ).rejects.toThrow('Agent does not belong to this project');
+  });
+
+  it('throws when the agent belongs to a different project', async () => {
+    mockGetById.mockResolvedValue({
+      id: 'agent-42',
+      projectId: 'other-project',
+      status: 'active',
+    });
+
+    await expect(
+      resolveAgentIdForProject({
+        db,
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        requestedAgentId: 'agent-42',
+      })
+    ).rejects.toThrow('Agent does not belong to this project');
+  });
+
+  it('throws when the agent is inactive', async () => {
+    mockGetById.mockResolvedValue({
+      id: 'agent-42',
+      projectId: PROJECT_ID,
+      status: 'archived',
+    });
+
+    await expect(
+      resolveAgentIdForProject({
+        db,
+        projectId: PROJECT_ID,
+        userId: USER_ID,
+        requestedAgentId: 'agent-42',
+      })
+    ).rejects.toThrow('Agent does not belong to this project');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Without requestedAgentId — current agent exists
+// ---------------------------------------------------------------------------
+describe('without requestedAgentId, current agent exists', () => {
+  it('returns the current agent id without creating anything', async () => {
+    mockGetCurrentAgent.mockResolvedValue({ agentId: 'current-agent-99' });
+
+    const result = await resolveAgentIdForProject({
+      db,
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+    });
+
+    expect(result).toBe('current-agent-99');
+    expect(mockGetById).not.toHaveBeenCalled();
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockSetCurrentAgent).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Without requestedAgentId — no current, but project agents exist
+// ---------------------------------------------------------------------------
+describe('without requestedAgentId, no current but project agents exist', () => {
+  it('uses the first project agent as fallback and sets it as current', async () => {
+    mockGetCurrentAgent.mockResolvedValue(null);
+    mockGetProjectAgents.mockResolvedValue([
+      { id: 'fallback-agent-1' },
+      { id: 'fallback-agent-2' },
+    ]);
+
+    const result = await resolveAgentIdForProject({
+      db,
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+    });
+
+    expect(result).toBe('fallback-agent-1');
+    expect(mockSetCurrentAgent).toHaveBeenCalledWith(PROJECT_ID, 'fallback-agent-1');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Without requestedAgentId — no agents at all
+// ---------------------------------------------------------------------------
+describe('without requestedAgentId, no agents at all', () => {
+  it('creates a default agent, sets it as current, and returns the new id', async () => {
+    mockGetCurrentAgent.mockResolvedValue(null);
+    mockGetProjectAgents.mockResolvedValue([]);
+    mockCreate.mockResolvedValue({ id: 'generated-uuid-1234' });
+
+    const result = await resolveAgentIdForProject({
+      db,
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+    });
+
+    expect(result).toBe('generated-uuid-1234');
+
+    // Verify the create call includes the expected default agent fields.
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'generated-uuid-1234',
+        projectId: PROJECT_ID,
+        scope: 'project',
+        status: 'active',
+        name: 'Web Builder',
+        maxSteps: 30,
+        deliveryMode: 'workspace',
+        createdBy: USER_ID,
+      })
+    );
+
+    expect(mockSetCurrentAgent).toHaveBeenCalledWith(PROJECT_ID, 'generated-uuid-1234');
+  });
+});

--- a/apps/web/lib/ai/__tests__/stream-abort-registry.test.ts
+++ b/apps/web/lib/ai/__tests__/stream-abort-registry.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  abortStream,
+  registerAbortController,
+  unregisterAbortController,
+} from '../stream-abort-registry';
+
+// The registry is a module-level singleton Map. We clean up known keys before
+// each test to avoid cross-test interference.
+const TEST_PROJECT_A = 'project-a';
+const TEST_PROJECT_B = 'project-b';
+
+beforeEach(() => {
+  // Ensure a clean slate by aborting any leftover entries from previous tests.
+  abortStream(TEST_PROJECT_A);
+  abortStream(TEST_PROJECT_B);
+});
+
+// ---------------------------------------------------------------------------
+// registerAbortController
+// ---------------------------------------------------------------------------
+describe('registerAbortController', () => {
+  it('stores a controller that can later be aborted', () => {
+    const controller = new AbortController();
+    registerAbortController(TEST_PROJECT_A, controller);
+
+    // If the controller is registered, abortStream should find it and return true.
+    expect(abortStream(TEST_PROJECT_A)).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unregisterAbortController
+// ---------------------------------------------------------------------------
+describe('unregisterAbortController', () => {
+  it('removes the controller when the same instance is passed', () => {
+    const controller = new AbortController();
+    registerAbortController(TEST_PROJECT_A, controller);
+    unregisterAbortController(TEST_PROJECT_A, controller);
+
+    // After unregistering, abortStream should not find it.
+    expect(abortStream(TEST_PROJECT_A)).toBe(false);
+    // The controller itself should NOT have been aborted by unregister.
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('does NOT remove the controller when a different instance is passed', () => {
+    const original = new AbortController();
+    const imposter = new AbortController();
+    registerAbortController(TEST_PROJECT_A, original);
+
+    unregisterAbortController(TEST_PROJECT_A, imposter);
+
+    // The original should still be in the registry.
+    expect(abortStream(TEST_PROJECT_A)).toBe(true);
+    expect(original.signal.aborted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// abortStream
+// ---------------------------------------------------------------------------
+describe('abortStream', () => {
+  it('calls abort(), removes the controller, and returns true', () => {
+    const controller = new AbortController();
+    registerAbortController(TEST_PROJECT_A, controller);
+
+    expect(abortStream(TEST_PROJECT_A)).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+
+    // A second call should return false because the entry was removed.
+    expect(abortStream(TEST_PROJECT_A)).toBe(false);
+  });
+
+  it('returns false when no controller is registered for the projectId', () => {
+    expect(abortStream('non-existent-project')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple projectIds
+// ---------------------------------------------------------------------------
+describe('multiple projectIds', () => {
+  it('tracks controllers independently per projectId', () => {
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+
+    registerAbortController(TEST_PROJECT_A, controllerA);
+    registerAbortController(TEST_PROJECT_B, controllerB);
+
+    // Abort only A.
+    expect(abortStream(TEST_PROJECT_A)).toBe(true);
+    expect(controllerA.signal.aborted).toBe(true);
+
+    // B should still be registered and not aborted.
+    expect(controllerB.signal.aborted).toBe(false);
+    expect(abortStream(TEST_PROJECT_B)).toBe(true);
+    expect(controllerB.signal.aborted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-registration after abort
+// ---------------------------------------------------------------------------
+describe('register → abort → register again', () => {
+  it('allows a fresh controller after the previous one was aborted', () => {
+    const first = new AbortController();
+    registerAbortController(TEST_PROJECT_A, first);
+    abortStream(TEST_PROJECT_A);
+
+    const second = new AbortController();
+    registerAbortController(TEST_PROJECT_A, second);
+
+    expect(second.signal.aborted).toBe(false);
+    expect(abortStream(TEST_PROJECT_A)).toBe(true);
+    expect(second.signal.aborted).toBe(true);
+  });
+});

--- a/apps/web/lib/skills/__tests__/skill-md-utils.test.ts
+++ b/apps/web/lib/skills/__tests__/skill-md-utils.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractDescriptionFromFrontmatter,
+  parseFrontmatter,
+  parseGitHubUrl,
+  parseGitLabUrl,
+  sourceUrlToSkillMdRawUrl,
+  stripFrontmatter,
+} from '../skill-md-utils';
+
+// ---------------------------------------------------------------------------
+// parseGitHubUrl
+// ---------------------------------------------------------------------------
+describe('parseGitHubUrl', () => {
+  it('parses a basic GitHub URL with defaults', () => {
+    const result = parseGitHubUrl('https://github.com/owner/repo');
+    expect(result).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: '',
+    });
+  });
+
+  it('parses a URL with an explicit branch', () => {
+    const result = parseGitHubUrl('https://github.com/owner/repo/tree/develop');
+    expect(result).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'develop',
+      path: '',
+    });
+  });
+
+  it('parses a URL with branch and nested path', () => {
+    const result = parseGitHubUrl('https://github.com/owner/repo/tree/main/path/to/dir');
+    expect(result).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: 'path/to/dir',
+    });
+  });
+
+  it('strips .git suffix from the repo name', () => {
+    const result = parseGitHubUrl('https://github.com/owner/repo.git');
+    expect(result).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: '',
+    });
+  });
+
+  it('returns null for an invalid URL', () => {
+    expect(parseGitHubUrl('not-a-url')).toBeNull();
+  });
+
+  it('returns null for a non-GitHub URL', () => {
+    expect(parseGitHubUrl('https://gitlab.com/owner/repo')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseGitLabUrl
+// ---------------------------------------------------------------------------
+describe('parseGitLabUrl', () => {
+  it('parses a basic GitLab URL with defaults', () => {
+    const result = parseGitLabUrl('https://gitlab.com/owner/repo');
+    expect(result).toEqual({
+      host: 'https://gitlab.com',
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: '',
+    });
+  });
+
+  it('parses a URL with an explicit branch', () => {
+    const result = parseGitLabUrl('https://gitlab.com/owner/repo/-/tree/develop');
+    expect(result).toEqual({
+      host: 'https://gitlab.com',
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'develop',
+      path: '',
+    });
+  });
+
+  it('parses a URL with branch and nested path', () => {
+    const result = parseGitLabUrl('https://gitlab.com/owner/repo/-/tree/main/path/to/dir');
+    expect(result).toEqual({
+      host: 'https://gitlab.com',
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: 'path/to/dir',
+    });
+  });
+
+  it('parses a self-hosted GitLab URL', () => {
+    const result = parseGitLabUrl('https://git.company.com/owner/repo');
+    expect(result).toEqual({
+      host: 'https://git.company.com',
+      owner: 'owner',
+      repo: 'repo',
+      branch: 'main',
+      path: '',
+    });
+  });
+
+  it('returns null for an invalid URL', () => {
+    expect(parseGitLabUrl('not-a-url')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sourceUrlToSkillMdRawUrl
+// ---------------------------------------------------------------------------
+describe('sourceUrlToSkillMdRawUrl', () => {
+  it('converts a GitHub URL to a raw SKILL.md URL', () => {
+    expect(sourceUrlToSkillMdRawUrl('https://github.com/owner/repo')).toBe(
+      'https://raw.githubusercontent.com/owner/repo/main/SKILL.md'
+    );
+  });
+
+  it('includes nested path in the raw GitHub URL', () => {
+    expect(sourceUrlToSkillMdRawUrl('https://github.com/owner/repo/tree/main/skills/web')).toBe(
+      'https://raw.githubusercontent.com/owner/repo/main/skills/web/SKILL.md'
+    );
+  });
+
+  it('converts a GitLab URL to a raw SKILL.md URL', () => {
+    expect(sourceUrlToSkillMdRawUrl('https://gitlab.com/owner/repo')).toBe(
+      'https://gitlab.com/owner/repo/-/raw/main/SKILL.md'
+    );
+  });
+
+  it('passes through a direct .md URL unchanged', () => {
+    const url = 'https://example.com/some/path/readme.md';
+    expect(sourceUrlToSkillMdRawUrl(url)).toBe(url);
+  });
+
+  it('passes through a direct /SKILL.md URL unchanged', () => {
+    const url = 'https://example.com/skills/SKILL.md';
+    expect(sourceUrlToSkillMdRawUrl(url)).toBe(url);
+  });
+
+  it('uses sourceType override for an unknown domain', () => {
+    expect(sourceUrlToSkillMdRawUrl('https://github.com/owner/repo', 'github')).toBe(
+      'https://raw.githubusercontent.com/owner/repo/main/SKILL.md'
+    );
+  });
+
+  it('returns null for an unknown format', () => {
+    expect(sourceUrlToSkillMdRawUrl('https://example.com/some/path')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractDescriptionFromFrontmatter
+// ---------------------------------------------------------------------------
+describe('extractDescriptionFromFrontmatter', () => {
+  it('extracts description from valid frontmatter', () => {
+    const content = '---\ntitle: Hello\ndescription: A cool skill\n---\n# Body';
+    expect(extractDescriptionFromFrontmatter(content)).toBe('A cool skill');
+  });
+
+  it('returns null when frontmatter has no description field', () => {
+    const content = '---\ntitle: Hello\nauthor: Alice\n---\n# Body';
+    expect(extractDescriptionFromFrontmatter(content)).toBeNull();
+  });
+
+  it('returns null when there is no frontmatter', () => {
+    expect(extractDescriptionFromFrontmatter('# Just markdown')).toBeNull();
+  });
+
+  it('trims leading and trailing spaces from description', () => {
+    const content = '---\ndescription:   spaced out   \n---\n';
+    expect(extractDescriptionFromFrontmatter(content)).toBe('spaced out');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFrontmatter
+// ---------------------------------------------------------------------------
+describe('parseFrontmatter', () => {
+  it('parses multiple key-value pairs', () => {
+    const content = '---\ntitle: Hello\nauthor: Alice\nversion: 1.0\n---\n# Body';
+    expect(parseFrontmatter(content)).toEqual({
+      title: 'Hello',
+      author: 'Alice',
+      version: '1.0',
+    });
+  });
+
+  it('returns an empty object for empty frontmatter', () => {
+    const content = '---\n\n---\n# Body';
+    expect(parseFrontmatter(content)).toEqual({});
+  });
+
+  it('returns an empty object when there is no frontmatter', () => {
+    expect(parseFrontmatter('# Just markdown')).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripFrontmatter
+// ---------------------------------------------------------------------------
+describe('stripFrontmatter', () => {
+  it('removes frontmatter and keeps content', () => {
+    const content = '---\ntitle: Hello\n---\n# Body\nParagraph';
+    expect(stripFrontmatter(content)).toBe('# Body\nParagraph');
+  });
+
+  it('returns content unchanged when there is no frontmatter', () => {
+    const content = '# Just markdown\nParagraph';
+    expect(stripFrontmatter(content)).toBe(content);
+  });
+
+  it('strips trailing newlines after frontmatter', () => {
+    const content = '---\ntitle: Hello\n---\n\n\n# Body';
+    expect(stripFrontmatter(content)).toBe('# Body');
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
   test: {
     passWithNoTests: true,
   },

--- a/packages/contracts/src/__tests__/enums-state-machine.test.ts
+++ b/packages/contracts/src/__tests__/enums-state-machine.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isValidRunTransition,
+  RunStatus,
+  TERMINAL_RUN_STATUSES,
+  VALID_RUN_TRANSITIONS,
+} from '../enums.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ALL_STATUSES: readonly RunStatus[] = RunStatus.options;
+
+/** Walk the happy path and assert every consecutive pair is a valid transition. */
+function assertPathIsValid(path: readonly RunStatus[]) {
+  for (let i = 0; i < path.length - 1; i++) {
+    const from = path[i];
+    const to = path[i + 1];
+    expect(
+      isValidRunTransition(from, to),
+      `Expected transition ${from} -> ${to} to be valid (step ${i + 1})`
+    ).toBe(true);
+  }
+}
+
+/** BFS from `start`, returning the set of all reachable statuses. */
+function reachableFrom(start: RunStatus): Set<RunStatus> {
+  const visited = new Set<RunStatus>();
+  const queue: RunStatus[] = [start];
+  visited.add(start);
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) break;
+    for (const next of VALID_RUN_TRANSITIONS[current]) {
+      if (!visited.has(next)) {
+        visited.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return visited;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Happy path walkthrough
+// ---------------------------------------------------------------------------
+
+describe('Happy path walkthrough', () => {
+  const HAPPY_PATH: readonly RunStatus[] = [
+    'queued',
+    'provisioning',
+    'preparing',
+    'running',
+    'finalizing_prepare',
+    'finalizing_uploading',
+    'finalizing_verifying',
+    'finalizing_metadata_commit',
+    'finalized',
+    'completed',
+  ];
+
+  it('every consecutive step in the happy path is a valid transition', () => {
+    assertPathIsValid(HAPPY_PATH);
+  });
+
+  it('happy path starts at queued and ends at completed', () => {
+    expect(HAPPY_PATH[0]).toBe('queued');
+    expect(HAPPY_PATH[HAPPY_PATH.length - 1]).toBe('completed');
+  });
+
+  it('happy path has exactly 10 states', () => {
+    expect(HAPPY_PATH).toHaveLength(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Failure from every non-terminal state that can fail
+// ---------------------------------------------------------------------------
+
+describe('Failure transitions', () => {
+  // States that CAN transition to failed
+  const STATES_THAT_CAN_FAIL: readonly RunStatus[] = [
+    'queued',
+    'provisioning',
+    'preparing',
+    'running',
+    'finalizing_prepare',
+    'finalizing_uploading',
+    'finalizing_verifying',
+    'finalizing_metadata_commit',
+    'worker_unreachable',
+    'finalizing_manual_intervention',
+  ];
+
+  // States that CANNOT transition to failed
+  const STATES_THAT_CANNOT_FAIL: readonly RunStatus[] = [
+    'completed',
+    'finalized',
+    'failed',
+    'finalizing_retryable_failed',
+    'finalizing_timeout',
+  ];
+
+  for (const status of STATES_THAT_CAN_FAIL) {
+    it(`${status} -> failed is valid`, () => {
+      expect(isValidRunTransition(status, 'failed')).toBe(true);
+    });
+  }
+
+  for (const status of STATES_THAT_CANNOT_FAIL) {
+    it(`${status} -> failed is NOT valid`, () => {
+      expect(isValidRunTransition(status, 'failed')).toBe(false);
+    });
+  }
+
+  it('every status is accounted for in can-fail or cannot-fail lists', () => {
+    const accounted = new Set([...STATES_THAT_CAN_FAIL, ...STATES_THAT_CANNOT_FAIL]);
+    for (const status of ALL_STATUSES) {
+      expect(
+        accounted.has(status),
+        `Status "${status}" not classified in failure transition lists`
+      ).toBe(true);
+    }
+    expect(accounted.size).toBe(ALL_STATUSES.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Retry cycle: failed -> queued -> ... -> completed
+// ---------------------------------------------------------------------------
+
+describe('Retry cycle', () => {
+  it('failed -> queued is valid (retry entry point)', () => {
+    expect(isValidRunTransition('failed', 'queued')).toBe(true);
+  });
+
+  it('full retry path: failed -> queued -> ... -> completed', () => {
+    const retryPath: readonly RunStatus[] = [
+      'failed',
+      'queued',
+      'provisioning',
+      'preparing',
+      'running',
+      'finalizing_prepare',
+      'finalizing_uploading',
+      'finalizing_verifying',
+      'finalizing_metadata_commit',
+      'finalized',
+      'completed',
+    ];
+    assertPathIsValid(retryPath);
+  });
+
+  it('failed cannot skip to provisioning directly', () => {
+    expect(isValidRunTransition('failed', 'provisioning')).toBe(false);
+  });
+
+  it('failed cannot go to completed directly', () => {
+    expect(isValidRunTransition('failed', 'completed')).toBe(false);
+  });
+
+  it('failed can only go to queued', () => {
+    expect(VALID_RUN_TRANSITIONS.failed).toEqual(['queued']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Worker unreachable paths
+// ---------------------------------------------------------------------------
+
+describe('Worker unreachable paths', () => {
+  it('running -> worker_unreachable is valid', () => {
+    expect(isValidRunTransition('running', 'worker_unreachable')).toBe(true);
+  });
+
+  it('worker_unreachable -> running (recovery)', () => {
+    expect(isValidRunTransition('worker_unreachable', 'running')).toBe(true);
+  });
+
+  it('worker_unreachable -> failed (give up)', () => {
+    expect(isValidRunTransition('worker_unreachable', 'failed')).toBe(true);
+  });
+
+  it('worker_unreachable has exactly 2 outgoing transitions', () => {
+    expect(VALID_RUN_TRANSITIONS.worker_unreachable).toHaveLength(2);
+  });
+
+  it('full recovery path: running -> worker_unreachable -> running -> finalization -> completed', () => {
+    const recoveryPath: readonly RunStatus[] = [
+      'running',
+      'worker_unreachable',
+      'running',
+      'finalizing_prepare',
+      'finalizing_uploading',
+      'finalizing_verifying',
+      'finalizing_metadata_commit',
+      'finalized',
+      'completed',
+    ];
+    assertPathIsValid(recoveryPath);
+  });
+
+  it('give-up path: running -> worker_unreachable -> failed -> queued (retry)', () => {
+    const giveUpPath: readonly RunStatus[] = ['running', 'worker_unreachable', 'failed', 'queued'];
+    assertPathIsValid(giveUpPath);
+  });
+
+  it('only running can reach worker_unreachable', () => {
+    for (const status of ALL_STATUSES) {
+      if (status === 'running') continue;
+      expect(
+        isValidRunTransition(status, 'worker_unreachable'),
+        `${status} -> worker_unreachable should be invalid`
+      ).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Finalization retry paths
+// ---------------------------------------------------------------------------
+
+describe('Finalization retry paths', () => {
+  const FINALIZING_STATES_WITH_RETRY: readonly RunStatus[] = [
+    'finalizing_prepare',
+    'finalizing_uploading',
+    'finalizing_verifying',
+    'finalizing_metadata_commit',
+  ];
+
+  for (const state of FINALIZING_STATES_WITH_RETRY) {
+    it(`${state} -> finalizing_retryable_failed is valid`, () => {
+      expect(isValidRunTransition(state, 'finalizing_retryable_failed')).toBe(true);
+    });
+  }
+
+  it('finalizing_retryable_failed -> finalizing_uploading (retry)', () => {
+    expect(isValidRunTransition('finalizing_retryable_failed', 'finalizing_uploading')).toBe(true);
+  });
+
+  it('finalizing_retryable_failed -> finalizing_timeout (escalate)', () => {
+    expect(isValidRunTransition('finalizing_retryable_failed', 'finalizing_timeout')).toBe(true);
+  });
+
+  it('finalizing_retryable_failed has exactly 2 outgoing transitions', () => {
+    expect(VALID_RUN_TRANSITIONS.finalizing_retryable_failed).toHaveLength(2);
+  });
+
+  it('retry loop: finalizing_uploading -> retryable_failed -> finalizing_uploading', () => {
+    const retryLoop: readonly RunStatus[] = [
+      'finalizing_uploading',
+      'finalizing_retryable_failed',
+      'finalizing_uploading',
+      'finalizing_verifying',
+      'finalizing_metadata_commit',
+      'finalized',
+      'completed',
+    ];
+    assertPathIsValid(retryLoop);
+  });
+
+  it('escalation path: retryable_failed -> timeout -> manual_intervention -> failed', () => {
+    const escalationPath: readonly RunStatus[] = [
+      'finalizing_retryable_failed',
+      'finalizing_timeout',
+      'finalizing_manual_intervention',
+      'failed',
+    ];
+    assertPathIsValid(escalationPath);
+  });
+
+  it('full escalation from running: running -> finalization failure -> escalation -> failed', () => {
+    const fullEscalation: readonly RunStatus[] = [
+      'running',
+      'finalizing_prepare',
+      'finalizing_uploading',
+      'finalizing_retryable_failed',
+      'finalizing_timeout',
+      'finalizing_manual_intervention',
+      'failed',
+    ];
+    assertPathIsValid(fullEscalation);
+  });
+
+  it('finalizing_timeout can only go to finalizing_manual_intervention', () => {
+    expect(VALID_RUN_TRANSITIONS.finalizing_timeout).toEqual(['finalizing_manual_intervention']);
+  });
+
+  it('finalizing_manual_intervention can only go to failed', () => {
+    expect(VALID_RUN_TRANSITIONS.finalizing_manual_intervention).toEqual(['failed']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. No backward transitions
+// ---------------------------------------------------------------------------
+
+describe('No backward transitions', () => {
+  const BACKWARD_PAIRS: readonly [RunStatus, RunStatus][] = [
+    ['running', 'queued'],
+    ['running', 'provisioning'],
+    ['running', 'preparing'],
+    ['finalized', 'running'],
+    ['finalized', 'finalizing_prepare'],
+    ['finalized', 'finalizing_uploading'],
+    ['finalized', 'finalizing_verifying'],
+    ['finalized', 'finalizing_metadata_commit'],
+    ['completed', 'queued'],
+    ['completed', 'running'],
+    ['completed', 'finalized'],
+    ['completed', 'failed'],
+    ['preparing', 'provisioning'],
+    ['preparing', 'queued'],
+    ['provisioning', 'queued'],
+    ['finalizing_verifying', 'finalizing_uploading'],
+    ['finalizing_metadata_commit', 'finalizing_verifying'],
+    ['finalizing_metadata_commit', 'finalizing_uploading'],
+  ];
+
+  for (const [from, to] of BACKWARD_PAIRS) {
+    it(`${from} -> ${to} is not allowed (backward)`, () => {
+      expect(isValidRunTransition(from, to)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. No skip-ahead transitions
+// ---------------------------------------------------------------------------
+
+describe('No skip-ahead transitions', () => {
+  const SKIP_AHEAD_PAIRS: readonly [RunStatus, RunStatus][] = [
+    ['queued', 'running'],
+    ['queued', 'preparing'],
+    ['queued', 'completed'],
+    ['queued', 'finalized'],
+    ['queued', 'finalizing_prepare'],
+    ['provisioning', 'running'],
+    ['provisioning', 'completed'],
+    ['provisioning', 'finalized'],
+    ['preparing', 'finalizing_prepare'],
+    ['preparing', 'completed'],
+    ['running', 'finalized'],
+    ['running', 'completed'],
+    ['running', 'finalizing_uploading'],
+    ['running', 'finalizing_verifying'],
+    ['running', 'finalizing_metadata_commit'],
+    ['finalizing_prepare', 'finalized'],
+    ['finalizing_prepare', 'completed'],
+    ['finalizing_prepare', 'finalizing_verifying'],
+    ['finalizing_prepare', 'finalizing_metadata_commit'],
+    ['finalizing_uploading', 'finalized'],
+    ['finalizing_uploading', 'completed'],
+    ['finalizing_uploading', 'finalizing_metadata_commit'],
+    ['finalizing_verifying', 'finalized'],
+    ['finalizing_verifying', 'completed'],
+  ];
+
+  for (const [from, to] of SKIP_AHEAD_PAIRS) {
+    it(`${from} -> ${to} is not allowed (skip-ahead)`, () => {
+      expect(isValidRunTransition(from, to)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 8. Graph completeness
+// ---------------------------------------------------------------------------
+
+describe('Graph completeness', () => {
+  it('every RunStatus option has an entry in VALID_RUN_TRANSITIONS', () => {
+    const transitionKeys = new Set(Object.keys(VALID_RUN_TRANSITIONS));
+    for (const status of ALL_STATUSES) {
+      expect(
+        transitionKeys.has(status),
+        `Status "${status}" missing from VALID_RUN_TRANSITIONS`
+      ).toBe(true);
+    }
+  });
+
+  it('VALID_RUN_TRANSITIONS has no extra keys beyond RunStatus options', () => {
+    const statusSet = new Set<string>(ALL_STATUSES);
+    for (const key of Object.keys(VALID_RUN_TRANSITIONS)) {
+      expect(
+        statusSet.has(key),
+        `Key "${key}" in VALID_RUN_TRANSITIONS is not a valid RunStatus`
+      ).toBe(true);
+    }
+  });
+
+  it('all transition targets are valid RunStatus values', () => {
+    const statusSet = new Set<string>(ALL_STATUSES);
+    for (const [from, targets] of Object.entries(VALID_RUN_TRANSITIONS)) {
+      for (const to of targets) {
+        expect(
+          statusSet.has(to),
+          `Transition target "${to}" from "${from}" is not a valid RunStatus`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('no duplicate targets in any transition list', () => {
+    for (const [from, targets] of Object.entries(VALID_RUN_TRANSITIONS)) {
+      const unique = new Set(targets);
+      expect(unique.size, `Status "${from}" has duplicate transition targets`).toBe(targets.length);
+    }
+  });
+
+  it('no self-transitions exist', () => {
+    for (const status of ALL_STATUSES) {
+      expect(
+        isValidRunTransition(status, status),
+        `Self-transition ${status} -> ${status} should not exist`
+      ).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Graph reachability (BFS from queued)
+// ---------------------------------------------------------------------------
+
+describe('Graph reachability', () => {
+  it('every status is reachable from queued', () => {
+    const reachable = reachableFrom('queued');
+    for (const status of ALL_STATUSES) {
+      expect(reachable.has(status), `Status "${status}" is not reachable from "queued"`).toBe(true);
+    }
+  });
+
+  it('completed is reachable from every non-terminal status via some path', () => {
+    // Every status except completed itself should be able to eventually reach completed
+    for (const status of ALL_STATUSES) {
+      if (status === 'completed') continue;
+      const reachable = reachableFrom(status);
+      expect(reachable.has('completed'), `"completed" is not reachable from "${status}"`).toBe(
+        true
+      );
+    }
+  });
+
+  it('failed is reachable from queued', () => {
+    const reachable = reachableFrom('queued');
+    expect(reachable.has('failed')).toBe(true);
+  });
+
+  it('queued is reachable from failed (retry cycle creates a loop)', () => {
+    const reachable = reachableFrom('failed');
+    expect(reachable.has('queued')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Terminal states
+// ---------------------------------------------------------------------------
+
+describe('Terminal states', () => {
+  it('completed is the only status with zero outgoing transitions', () => {
+    const terminalStatuses = ALL_STATUSES.filter((s) => VALID_RUN_TRANSITIONS[s].length === 0);
+    expect(terminalStatuses).toEqual(['completed']);
+  });
+
+  it('TERMINAL_RUN_STATUSES matches the computed terminal states', () => {
+    const computed = ALL_STATUSES.filter((s) => VALID_RUN_TRANSITIONS[s].length === 0);
+    expect([...TERMINAL_RUN_STATUSES]).toEqual(computed);
+  });
+
+  it('every non-terminal status has at least one outgoing transition', () => {
+    for (const status of ALL_STATUSES) {
+      if (TERMINAL_RUN_STATUSES.includes(status)) continue;
+      expect(
+        VALID_RUN_TRANSITIONS[status].length,
+        `Non-terminal status "${status}" should have outgoing transitions`
+      ).toBeGreaterThan(0);
+    }
+  });
+
+  it('completed cannot transition to any status', () => {
+    for (const target of ALL_STATUSES) {
+      expect(isValidRunTransition('completed', target)).toBe(false);
+    }
+  });
+});

--- a/packages/control-plane/src/__tests__/run-lifecycle-flow.test.ts
+++ b/packages/control-plane/src/__tests__/run-lifecycle-flow.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Run Lifecycle Integration Tests
+ *
+ * Tests the complete run lifecycle through real service chains:
+ * RunService + RunStateMachine — only the DB layer is in-memory.
+ *
+ * Covers:
+ * 1. Happy path: queued → ... → completed
+ * 2. Failure + retry cycle
+ * 3. Worker unreachable recovery
+ * 4. Finalization retry/timeout escalation
+ * 5. Max retry guard
+ * 6. recoverStuckRuns cron behavior
+ * 7. Timestamp management (startedAt, completedAt)
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { CreateRunInput, Run, RunDb } from '../run/run-service.js';
+import { RunService } from '../run/run-service.js';
+import type { RunStatus } from '../run/run-state-machine.js';
+
+// ---------------------------------------------------------------------------
+// In-Memory RunDb
+// ---------------------------------------------------------------------------
+
+class InMemoryRunDb implements RunDb {
+  private runs = new Map<string, Run>();
+  private nextId = 1;
+
+  async create(input: CreateRunInput): Promise<Run> {
+    const run: Run = {
+      id: `run-${this.nextId++}`,
+      agentId: input.agentId,
+      parentRunId: input.parentRunId ?? null,
+      status: 'queued',
+      prompt: input.prompt,
+      provider: input.provider ?? 'claude-code',
+      connectionMode: input.connectionMode ?? 'anthropic',
+      modelId: input.modelId ?? null,
+      triggerSource: input.triggerSource ?? 'user',
+      activeStreamId: null,
+      retryCount: 0,
+      maxRetries: 3,
+      errorMessage: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      startedAt: null,
+      completedAt: null,
+    };
+    this.runs.set(run.id, run);
+    return { ...run };
+  }
+
+  async findById(id: string): Promise<Run | null> {
+    const run = this.runs.get(id);
+    return run ? { ...run } : null;
+  }
+
+  async updateStatus(id: string, status: RunStatus, extra?: Partial<Run>): Promise<Run | null> {
+    const run = this.runs.get(id);
+    if (!run) return null;
+    run.status = status;
+    run.updatedAt = new Date();
+    if (extra) Object.assign(run, extra);
+    return { ...run };
+  }
+
+  async listByAgent(agentId: string, limit = 50): Promise<Run[]> {
+    return [...this.runs.values()]
+      .filter((r) => r.agentId === agentId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .slice(0, limit);
+  }
+
+  async findStuckRuns(olderThanMs: number): Promise<Run[]> {
+    const threshold = Date.now() - olderThanMs;
+    return [...this.runs.values()].filter(
+      (r) => r.status !== 'completed' && r.status !== 'failed' && r.updatedAt.getTime() < threshold
+    );
+  }
+
+  /** Direct seed for testing */
+  seed(run: Run): void {
+    this.runs.set(run.id, { ...run });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Run Lifecycle Flow', () => {
+  let db: InMemoryRunDb;
+  let service: RunService;
+
+  beforeEach(() => {
+    db = new InMemoryRunDb();
+    service = new RunService(db);
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Happy path: queued → completed
+  // -----------------------------------------------------------------------
+
+  describe('happy path: queued → completed', () => {
+    it('walks through all 10 states in order', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'Build a web app' });
+
+      const transitions: RunStatus[] = [
+        'provisioning',
+        'preparing',
+        'running',
+        'finalizing_prepare',
+        'finalizing_uploading',
+        'finalizing_verifying',
+        'finalizing_metadata_commit',
+        'finalized',
+        'completed',
+      ];
+
+      const statusHistory: RunStatus[] = [run.status as RunStatus];
+
+      for (const to of transitions) {
+        const updated = await service.transition(run.id, to);
+        statusHistory.push(updated.status as RunStatus);
+      }
+
+      expect(statusHistory).toEqual([
+        'queued',
+        'provisioning',
+        'preparing',
+        'running',
+        'finalizing_prepare',
+        'finalizing_uploading',
+        'finalizing_verifying',
+        'finalizing_metadata_commit',
+        'finalized',
+        'completed',
+      ]);
+    });
+
+    it('sets startedAt when entering running state', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      expect(run.startedAt).toBeNull();
+
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      const running = await service.transition(run.id, 'running');
+
+      expect(running.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('sets completedAt when reaching completed', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      const steps: RunStatus[] = [
+        'provisioning',
+        'preparing',
+        'running',
+        'finalizing_prepare',
+        'finalizing_uploading',
+        'finalizing_verifying',
+        'finalizing_metadata_commit',
+        'finalized',
+        'completed',
+      ];
+
+      let result: Run = run;
+      for (const s of steps) {
+        result = await service.transition(run.id, s);
+      }
+
+      expect(result.completedAt).toBeInstanceOf(Date);
+    });
+
+    it('sets completedAt when transitioning to failed', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await service.transition(run.id, 'provisioning');
+
+      const failed = await service.transition(run.id, 'failed', {
+        errorMessage: 'Something went wrong',
+      });
+
+      expect(failed.completedAt).toBeInstanceOf(Date);
+      expect(failed.errorMessage).toBe('Something went wrong');
+    });
+
+    it('does not overwrite startedAt on re-entry to running via retry', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      const firstRunning = await service.transition(run.id, 'running');
+      const firstStartedAt = firstRunning.startedAt;
+
+      // Fail and retry
+      await service.transition(run.id, 'failed');
+      const retried = await service.retry(run.id);
+      expect(retried.status).toBe('queued');
+
+      // Walk back to running
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      const secondRunning = await service.transition(run.id, 'running');
+
+      // startedAt should NOT be overwritten because the run already has one
+      expect(secondRunning.startedAt).toEqual(firstStartedAt);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Failure + retry cycle
+  // -----------------------------------------------------------------------
+
+  describe('failure + retry cycle', () => {
+    it('retries a failed run back to queued with incremented retryCount', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      expect(run.retryCount).toBe(0);
+
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'failed', { errorMessage: 'timeout' });
+
+      const retried = await service.retry(run.id);
+      expect(retried.status).toBe('queued');
+      expect(retried.retryCount).toBe(1);
+      expect(retried.errorMessage).toBeNull();
+    });
+
+    it('supports multiple retry cycles', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      for (let i = 0; i < 3; i++) {
+        // Each retry cycle: queued → provisioning → failed → retry
+        await service.transition(run.id, 'provisioning');
+        await service.transition(run.id, 'failed');
+        const retried = await service.retry(run.id);
+        expect(retried.retryCount).toBe(i + 1);
+      }
+    });
+
+    it('throws when retrying a non-failed run', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      await expect(service.retry(run.id)).rejects.toThrow('Can only retry failed runs');
+    });
+
+    it('throws when max retries exceeded', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      // Use all 3 retries
+      for (let i = 0; i < 3; i++) {
+        await service.transition(run.id, 'provisioning');
+        await service.transition(run.id, 'failed');
+        await service.retry(run.id);
+      }
+
+      // 4th retry should fail
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'failed');
+      await expect(service.retry(run.id)).rejects.toThrow('Max retries exceeded');
+    });
+
+    it('complete retry cycle: fail → retry → succeed', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'retry test' });
+
+      // First attempt fails
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      await service.transition(run.id, 'running');
+      await service.transition(run.id, 'failed', { errorMessage: 'network error' });
+
+      // Retry
+      await service.retry(run.id);
+
+      // Second attempt succeeds
+      const fullPath: RunStatus[] = [
+        'provisioning',
+        'preparing',
+        'running',
+        'finalizing_prepare',
+        'finalizing_uploading',
+        'finalizing_verifying',
+        'finalizing_metadata_commit',
+        'finalized',
+        'completed',
+      ];
+
+      for (const s of fullPath) {
+        await service.transition(run.id, s);
+      }
+
+      const final = await service.getById(run.id);
+      expect(final?.status).toBe('completed');
+      expect(final?.retryCount).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Worker unreachable recovery
+  // -----------------------------------------------------------------------
+
+  describe('worker unreachable', () => {
+    it('recovers from worker_unreachable back to running', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      await service.transition(run.id, 'running');
+      await service.transition(run.id, 'worker_unreachable');
+
+      // Recover
+      const recovered = await service.transition(run.id, 'running');
+      expect(recovered.status).toBe('running');
+    });
+
+    it('fails from worker_unreachable when recovery not possible', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      await service.transition(run.id, 'running');
+      await service.transition(run.id, 'worker_unreachable');
+
+      const failed = await service.transition(run.id, 'failed', {
+        errorMessage: 'Worker unreachable timeout',
+      });
+      expect(failed.status).toBe('failed');
+      expect(failed.errorMessage).toBe('Worker unreachable timeout');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Finalization retry/timeout escalation
+  // -----------------------------------------------------------------------
+
+  describe('finalization retry + timeout escalation', () => {
+    async function advanceToFinalizing(runId: string): Promise<void> {
+      await service.transition(runId, 'provisioning');
+      await service.transition(runId, 'preparing');
+      await service.transition(runId, 'running');
+      await service.transition(runId, 'finalizing_prepare');
+      await service.transition(runId, 'finalizing_uploading');
+    }
+
+    it('retries from finalizing_retryable_failed back to uploading', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await advanceToFinalizing(run.id);
+
+      // Fail during upload
+      await service.transition(run.id, 'finalizing_retryable_failed');
+
+      // Retry
+      const retried = await service.transition(run.id, 'finalizing_uploading');
+      expect(retried.status).toBe('finalizing_uploading');
+    });
+
+    it('escalates to timeout after retryable failure', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await advanceToFinalizing(run.id);
+
+      await service.transition(run.id, 'finalizing_retryable_failed');
+      const timeout = await service.transition(run.id, 'finalizing_timeout');
+      expect(timeout.status).toBe('finalizing_timeout');
+    });
+
+    it('full escalation: retryable_failed → timeout → manual_intervention → failed', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await advanceToFinalizing(run.id);
+
+      await service.transition(run.id, 'finalizing_retryable_failed');
+      await service.transition(run.id, 'finalizing_timeout');
+      await service.transition(run.id, 'finalizing_manual_intervention');
+      const failed = await service.transition(run.id, 'failed');
+
+      expect(failed.status).toBe('failed');
+    });
+
+    it('rejects skipping finalization steps', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await advanceToFinalizing(run.id);
+
+      // Can't jump from uploading to finalized
+      await expect(service.transition(run.id, 'finalized')).rejects.toThrow('Invalid transition');
+
+      // Can't jump from uploading to completed
+      await expect(service.transition(run.id, 'completed')).rejects.toThrow('Invalid transition');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Invalid transitions
+  // -----------------------------------------------------------------------
+
+  describe('invalid transitions', () => {
+    it('rejects backward transition from running to queued', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      await service.transition(run.id, 'provisioning');
+      await service.transition(run.id, 'preparing');
+      await service.transition(run.id, 'running');
+
+      await expect(service.transition(run.id, 'queued')).rejects.toThrow('Invalid transition');
+    });
+
+    it('rejects transition from completed (terminal)', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      const steps: RunStatus[] = [
+        'provisioning',
+        'preparing',
+        'running',
+        'finalizing_prepare',
+        'finalizing_uploading',
+        'finalizing_verifying',
+        'finalizing_metadata_commit',
+        'finalized',
+        'completed',
+      ];
+      for (const s of steps) await service.transition(run.id, s);
+
+      await expect(service.transition(run.id, 'queued')).rejects.toThrow('Invalid transition');
+      await expect(service.transition(run.id, 'failed')).rejects.toThrow('Invalid transition');
+    });
+
+    it('rejects transition for non-existent run', async () => {
+      await expect(service.transition('nonexistent', 'provisioning')).rejects.toThrow(
+        'Run not found'
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. recoverStuckRuns
+  // -----------------------------------------------------------------------
+
+  describe('recoverStuckRuns', () => {
+    function makeOldRun(id: string, status: RunStatus, minutesAgo: number): Run {
+      const d = new Date(Date.now() - minutesAgo * 60_000);
+      return {
+        id,
+        agentId: 'agent-1',
+        parentRunId: null,
+        status,
+        prompt: 'test',
+        provider: 'claude-code',
+        connectionMode: 'anthropic',
+        modelId: null,
+        triggerSource: 'user',
+        activeStreamId: null,
+        retryCount: 0,
+        maxRetries: 3,
+        errorMessage: null,
+        createdAt: d,
+        updatedAt: d,
+        startedAt: null,
+        completedAt: null,
+      };
+    }
+
+    it('recovers worker_unreachable runs older than threshold', async () => {
+      db.seed(makeOldRun('stuck-1', 'worker_unreachable', 5));
+
+      const recovered = await service.recoverStuckRuns(120_000);
+
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0].id).toBe('stuck-1');
+      expect(recovered[0].status).toBe('failed');
+      expect(recovered[0].errorMessage).toBe('Worker unreachable timeout');
+    });
+
+    it('ignores worker_unreachable runs newer than threshold', async () => {
+      // Create a "stuck" run that was updated 1 minute ago (below 2-min threshold)
+      db.seed(makeOldRun('recent-1', 'worker_unreachable', 1));
+
+      const recovered = await service.recoverStuckRuns(120_000);
+      expect(recovered).toHaveLength(0);
+    });
+
+    it('ignores completed/failed runs', async () => {
+      db.seed(makeOldRun('completed-1', 'completed', 10));
+      db.seed(makeOldRun('failed-1', 'failed', 10));
+
+      const recovered = await service.recoverStuckRuns(120_000);
+      expect(recovered).toHaveLength(0);
+    });
+
+    it('only transitions worker_unreachable (not running or provisioning)', async () => {
+      // "running" runs that are old are found by findStuckRuns but
+      // recoverStuckRuns only acts on worker_unreachable
+      db.seed(makeOldRun('running-old', 'running', 10));
+      db.seed(makeOldRun('stuck-wu', 'worker_unreachable', 10));
+
+      const recovered = await service.recoverStuckRuns(120_000);
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0].id).toBe('stuck-wu');
+
+      // The running one should not have been touched
+      const runningRun = await db.findById('running-old');
+      expect(runningRun?.status).toBe('running');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Service CRUD
+  // -----------------------------------------------------------------------
+
+  describe('service CRUD', () => {
+    it('creates run with defaults', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'Hello' });
+
+      expect(run.status).toBe('queued');
+      expect(run.prompt).toBe('Hello');
+      expect(run.agentId).toBe('agent-1');
+      expect(run.retryCount).toBe(0);
+      expect(run.maxRetries).toBe(3);
+      expect(run.startedAt).toBeNull();
+      expect(run.completedAt).toBeNull();
+    });
+
+    it('getById returns null for missing run', async () => {
+      const run = await service.getById('nonexistent');
+      expect(run).toBeNull();
+    });
+
+    it('listByAgent returns runs for agent', async () => {
+      await service.createRun({ agentId: 'agent-1', prompt: 'Run 1' });
+      await service.createRun({ agentId: 'agent-1', prompt: 'Run 2' });
+      await service.createRun({ agentId: 'agent-2', prompt: 'Run 3' });
+
+      const agent1Runs = await service.listByAgent('agent-1');
+      expect(agent1Runs).toHaveLength(2);
+      expect(agent1Runs.every((r) => r.agentId === 'agent-1')).toBe(true);
+    });
+
+    it('setActiveStreamId updates stream reference', async () => {
+      const run = await service.createRun({ agentId: 'agent-1', prompt: 'test' });
+      expect(run.activeStreamId).toBeNull();
+
+      await service.setActiveStreamId(run.id, 'stream-abc');
+
+      const updated = await service.getById(run.id);
+      expect(updated?.activeStreamId).toBe('stream-abc');
+    });
+
+    it('setActiveStreamId throws for non-existent run', async () => {
+      await expect(service.setActiveStreamId('missing', 'stream-1')).rejects.toThrow(
+        'Run not found'
+      );
+    });
+  });
+});

--- a/packages/mcp/src/__tests__/client.test.ts
+++ b/packages/mcp/src/__tests__/client.test.ts
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMcpClient, getMcpTools, HttpMcpClient, StdioMcpClient } from '../client.js';
+import type { McpServerConfig } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<McpServerConfig> = {}): McpServerConfig {
+  return {
+    id: 'test-server',
+    name: 'Test Server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+    scope: 'global',
+    ...overrides,
+  };
+}
+
+function jsonRpcOk(result: unknown, headers?: Record<string, string>) {
+  const responseHeaders = new Headers({ 'Content-Type': 'application/json' });
+  if (headers) {
+    for (const [k, v] of Object.entries(headers)) {
+      responseHeaders.set(k, v);
+    }
+  }
+  return new Response(JSON.stringify({ jsonrpc: '2.0', result, id: 1 }), {
+    status: 200,
+    statusText: 'OK',
+    headers: responseHeaders,
+  });
+}
+
+function jsonRpcError(code: number, message: string) {
+  return new Response(JSON.stringify({ jsonrpc: '2.0', error: { code, message }, id: 1 }), {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function httpError(status: number, statusText: string) {
+  return new Response(null, { status, statusText });
+}
+
+// ---------------------------------------------------------------------------
+// HttpMcpClient
+// ---------------------------------------------------------------------------
+
+describe('HttpMcpClient', () => {
+  const mockFetch = vi.fn<(input: string | URL, init?: RequestInit) => Promise<Response>>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('connect()', () => {
+    it('throws if no URL configured', async () => {
+      const client = new HttpMcpClient(makeConfig({ transport: 'sse', url: undefined }));
+      await expect(client.connect()).rejects.toThrow('HTTP/SSE config requires url');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('sends initialize request on connect', async () => {
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({ protocolVersion: '2024-11-05' }));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://localhost:3000/mcp');
+      expect(init?.method).toBe('POST');
+
+      const body = JSON.parse(init?.body as string);
+      expect(body.method).toBe('initialize');
+      expect(body.jsonrpc).toBe('2.0');
+      expect(body.params.protocolVersion).toBe('2024-11-05');
+      expect(body.params.clientInfo.name).toBe('lux-mcp-client');
+    });
+  });
+
+  describe('listTools()', () => {
+    it('sends tools/list and parses response into McpTool[]', async () => {
+      // connect first
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({ protocolVersion: '2024-11-05' }));
+
+      const toolsResult = {
+        tools: [
+          { name: 'read_file', description: 'Reads a file', inputSchema: { type: 'object' } },
+          { name: 'write_file' }, // missing optional fields
+        ],
+      };
+      mockFetch.mockResolvedValueOnce(jsonRpcOk(toolsResult));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+      const tools = await client.listTools();
+
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toEqual({
+        name: 'read_file',
+        description: 'Reads a file',
+        inputSchema: { type: 'object' },
+      });
+      // Missing description/inputSchema default to '' and {}
+      expect(tools[1]).toEqual({
+        name: 'write_file',
+        description: '',
+        inputSchema: {},
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+      expect(body.method).toBe('tools/list');
+    });
+  });
+
+  describe('callTool()', () => {
+    it('sends tools/call with name and arguments', async () => {
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({})); // initialize
+      mockFetch.mockResolvedValueOnce(
+        jsonRpcOk({
+          content: [{ type: 'text', text: 'file contents here' }],
+        })
+      );
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+      const result = await client.callTool('read_file', { path: '/tmp/test.txt' });
+
+      expect(result.content).toEqual([{ type: 'text', text: 'file contents here' }]);
+
+      const body = JSON.parse(mockFetch.mock.calls[1][1]?.body as string);
+      expect(body.method).toBe('tools/call');
+      expect(body.params).toEqual({
+        name: 'read_file',
+        arguments: { path: '/tmp/test.txt' },
+      });
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('clears sessionId so subsequent calls do not include it', async () => {
+      // connect with session
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({}, { 'Mcp-Session-Id': 'session-abc' }));
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+
+      await client.disconnect();
+
+      // Reconnect -- session should not carry over
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({}));
+      await client.connect();
+
+      const reconnectHeaders = mockFetch.mock.calls[1][1]?.headers as Record<string, string>;
+      expect(reconnectHeaders['Mcp-Session-Id']).toBeUndefined();
+    });
+  });
+
+  describe('session management', () => {
+    it('captures Mcp-Session-Id from response and sends it on subsequent requests', async () => {
+      // initialize returns session id
+      mockFetch.mockResolvedValueOnce(
+        jsonRpcOk({ protocolVersion: '2024-11-05' }, { 'Mcp-Session-Id': 'sess-123' })
+      );
+      // tools/list
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({ tools: [] }));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+      await client.listTools();
+
+      // Second request should include the session id
+      const secondCallHeaders = mockFetch.mock.calls[1][1]?.headers as Record<string, string>;
+      expect(secondCallHeaders['Mcp-Session-Id']).toBe('sess-123');
+    });
+
+    it('does not send Mcp-Session-Id when server does not provide one', async () => {
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({}));
+      mockFetch.mockResolvedValueOnce(jsonRpcOk({ tools: [] }));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await client.connect();
+      await client.listTools();
+
+      const secondCallHeaders = mockFetch.mock.calls[1][1]?.headers as Record<string, string>;
+      expect(secondCallHeaders['Mcp-Session-Id']).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on HTTP error status', async () => {
+      mockFetch.mockResolvedValueOnce(httpError(502, 'Bad Gateway'));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await expect(client.connect()).rejects.toThrow('MCP HTTP error: 502 Bad Gateway');
+    });
+
+    it('throws on JSON-RPC error in response body', async () => {
+      mockFetch.mockResolvedValueOnce(jsonRpcError(-32600, 'Invalid Request'));
+
+      const client = new HttpMcpClient(
+        makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      await expect(client.connect()).rejects.toThrow('MCP error -32600: Invalid Request');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMcpClient (factory)
+// ---------------------------------------------------------------------------
+
+describe('createMcpClient', () => {
+  it('returns StdioMcpClient for transport="stdio"', () => {
+    const client = createMcpClient(makeConfig({ transport: 'stdio' }));
+    expect(client).toBeInstanceOf(StdioMcpClient);
+  });
+
+  it('returns HttpMcpClient for transport="sse"', () => {
+    const client = createMcpClient(
+      makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+    );
+    expect(client).toBeInstanceOf(HttpMcpClient);
+  });
+
+  it('returns HttpMcpClient for transport="streamable-http"', () => {
+    const client = createMcpClient(
+      makeConfig({ transport: 'streamable-http', url: 'http://localhost:3000/mcp' })
+    );
+    expect(client).toBeInstanceOf(HttpMcpClient);
+  });
+
+  it('throws for unsupported transport', () => {
+    expect(() => createMcpClient(makeConfig({ transport: 'grpc' as 'stdio' }))).toThrow(
+      'Unsupported transport: grpc'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getMcpTools (helper)
+// ---------------------------------------------------------------------------
+
+describe('getMcpTools', () => {
+  const mockFetch = vi.fn<(input: string | URL, init?: RequestInit) => Promise<Response>>();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('connects, lists tools, disconnects, and returns tools', async () => {
+    // initialize
+    mockFetch.mockResolvedValueOnce(jsonRpcOk({}));
+    // tools/list
+    mockFetch.mockResolvedValueOnce(
+      jsonRpcOk({
+        tools: [{ name: 'bash', description: 'Run shell commands', inputSchema: {} }],
+      })
+    );
+
+    const tools = await getMcpTools(
+      makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' })
+    );
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe('bash');
+  });
+
+  it('disconnects even when listTools throws', async () => {
+    // initialize succeeds
+    mockFetch.mockResolvedValueOnce(jsonRpcOk({}));
+    // tools/list fails with HTTP error
+    mockFetch.mockResolvedValueOnce(httpError(500, 'Internal Server Error'));
+
+    await expect(
+      getMcpTools(makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' }))
+    ).rejects.toThrow('MCP HTTP error: 500');
+
+    // The function should still have completed (disconnect is in finally block).
+    // We verify by ensuring it didn't throw an unhandled error outside the rejection.
+  });
+
+  it('disconnects even when connect throws', async () => {
+    // connect fails
+    mockFetch.mockResolvedValueOnce(httpError(503, 'Service Unavailable'));
+
+    await expect(
+      getMcpTools(makeConfig({ transport: 'sse', url: 'http://localhost:3000/mcp' }))
+    ).rejects.toThrow('MCP HTTP error: 503');
+  });
+});

--- a/packages/mcp/src/__tests__/probe.test.ts
+++ b/packages/mcp/src/__tests__/probe.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_PROBE_CONFIG, McpProbe } from '../probe.js';
+import type { McpRegistry } from '../registry.js';
+import type { McpServerConfig } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<McpServerConfig> = {}): McpServerConfig {
+  return {
+    id: 'test-server',
+    name: 'Test Server',
+    transport: 'stdio',
+    command: 'node',
+    args: ['server.js'],
+    enabled: true,
+    scope: 'global',
+    ...overrides,
+  };
+}
+
+function mockRegistry(): McpRegistry {
+  return { updateStatus: vi.fn() } as unknown as McpRegistry;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('McpProbe', () => {
+  const mockFetch = vi.fn<(input: string | URL, init?: RequestInit) => Promise<Response>>();
+  let registry: McpRegistry;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    registry = mockRegistry();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('DEFAULT_PROBE_CONFIG', () => {
+    it('has expected defaults', () => {
+      expect(DEFAULT_PROBE_CONFIG.intervalMs).toBe(30_000);
+      expect(DEFAULT_PROBE_CONFIG.timeoutMs).toBe(5_000);
+    });
+  });
+
+  describe('checkHealth', () => {
+    describe('stdio transport', () => {
+      it('always returns healthy=true without making a network call', async () => {
+        const probe = new McpProbe(registry);
+        const server = makeConfig({ id: 'stdio-server', transport: 'stdio' });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.serverId).toBe('stdio-server');
+        expect(result.healthy).toBe(true);
+        expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+        expect(result.error).toBeUndefined();
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('HTTP transport with URL', () => {
+      it('returns healthy=true when response.ok is true', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+        const probe = new McpProbe(registry);
+        const server = makeConfig({
+          id: 'http-ok',
+          transport: 'sse',
+          url: 'http://localhost:4000/mcp',
+        });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.serverId).toBe('http-ok');
+        expect(result.healthy).toBe(true);
+        expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+        expect(result.error).toBeUndefined();
+
+        expect(mockFetch).toHaveBeenCalledOnce();
+        const [url, init] = mockFetch.mock.calls[0];
+        expect(url).toBe('http://localhost:4000/mcp');
+        expect(init?.method).toBe('HEAD');
+      });
+
+      it('returns healthy=false when response.ok is false', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+        const probe = new McpProbe(registry);
+        const server = makeConfig({
+          id: 'http-down',
+          transport: 'streamable-http',
+          url: 'http://localhost:4000/mcp',
+        });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.serverId).toBe('http-down');
+        expect(result.healthy).toBe(false);
+        expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    describe('HTTP transport without URL', () => {
+      it('returns healthy=false with error message', async () => {
+        const probe = new McpProbe(registry);
+        const server = makeConfig({
+          id: 'no-url',
+          transport: 'sse',
+          url: undefined,
+        });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.serverId).toBe('no-url');
+        expect(result.healthy).toBe(false);
+        expect(result.error).toBe('No URL configured for health check');
+        expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('fetch throws (network error / timeout)', () => {
+      it('returns healthy=false and calls registry.updateStatus', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('Network timeout'));
+
+        const probe = new McpProbe(registry);
+        const server = makeConfig({
+          id: 'timeout-server',
+          transport: 'sse',
+          url: 'http://unreachable:9999/mcp',
+        });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.serverId).toBe('timeout-server');
+        expect(result.healthy).toBe(false);
+        expect(result.error).toBe('Network timeout');
+        expect(result.responseTimeMs).toBeGreaterThanOrEqual(0);
+
+        expect(registry.updateStatus).toHaveBeenCalledWith(
+          'timeout-server',
+          'unreachable',
+          'Network timeout'
+        );
+      });
+
+      it('handles non-Error thrown values with "Unknown error"', async () => {
+        mockFetch.mockRejectedValueOnce('string-error');
+
+        const probe = new McpProbe(registry);
+        const server = makeConfig({
+          id: 'weird-error',
+          transport: 'sse',
+          url: 'http://localhost:4000/mcp',
+        });
+
+        const result = await probe.checkHealth(server);
+
+        expect(result.healthy).toBe(false);
+        expect(result.error).toBe('Unknown error');
+        expect(registry.updateStatus).toHaveBeenCalledWith(
+          'weird-error',
+          'unreachable',
+          'Unknown error'
+        );
+      });
+    });
+
+    describe('custom probe config', () => {
+      it('uses custom timeoutMs for AbortSignal', async () => {
+        mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+        const probe = new McpProbe(registry, { intervalMs: 10_000, timeoutMs: 2_000 });
+        const server = makeConfig({
+          id: 'custom-timeout',
+          transport: 'sse',
+          url: 'http://localhost:4000/mcp',
+        });
+
+        await probe.checkHealth(server);
+
+        // Verify the signal was passed (AbortSignal.timeout is called with our value)
+        expect(mockFetch).toHaveBeenCalledOnce();
+        const init = mockFetch.mock.calls[0][1];
+        expect(init?.signal).toBeDefined();
+      });
+    });
+  });
+
+  describe('checkAll', () => {
+    it('probes multiple servers in parallel and returns all results', async () => {
+      mockFetch
+        .mockResolvedValueOnce(new Response(null, { status: 200 }))
+        .mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+      const probe = new McpProbe(registry);
+      const servers = [
+        makeConfig({ id: 'stdio-1', transport: 'stdio' }),
+        makeConfig({ id: 'http-ok', transport: 'sse', url: 'http://localhost:3000/mcp' }),
+        makeConfig({ id: 'http-down', transport: 'sse', url: 'http://localhost:4000/mcp' }),
+      ];
+
+      const results = await probe.checkAll(servers);
+
+      expect(results).toHaveLength(3);
+
+      const byId = new Map(results.map((r) => [r.serverId, r]));
+      expect(byId.get('stdio-1')?.healthy).toBe(true);
+      expect(byId.get('http-ok')?.healthy).toBe(true);
+      expect(byId.get('http-down')?.healthy).toBe(false);
+    });
+
+    it('returns empty array for empty server list', async () => {
+      const probe = new McpProbe(registry);
+      const results = await probe.checkAll([]);
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('responseTimeMs', () => {
+    it('is a non-negative number for all code paths', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+      mockFetch.mockRejectedValueOnce(new Error('fail'));
+
+      const probe = new McpProbe(registry);
+
+      // stdio path
+      const r1 = await probe.checkHealth(makeConfig({ id: 's1', transport: 'stdio' }));
+      expect(r1.responseTimeMs).toBeGreaterThanOrEqual(0);
+
+      // http success path
+      const r2 = await probe.checkHealth(
+        makeConfig({ id: 's2', transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      expect(r2.responseTimeMs).toBeGreaterThanOrEqual(0);
+
+      // http error path
+      const r3 = await probe.checkHealth(
+        makeConfig({ id: 's3', transport: 'sse', url: 'http://localhost:3000/mcp' })
+      );
+      expect(r3.responseTimeMs).toBeGreaterThanOrEqual(0);
+
+      // no-url path
+      const r4 = await probe.checkHealth(
+        makeConfig({ id: 's4', transport: 'sse', url: undefined })
+      );
+      expect(r4.responseTimeMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/packages/sandbox/src/__tests__/batch-sandbox.test.ts
+++ b/packages/sandbox/src/__tests__/batch-sandbox.test.ts
@@ -1,0 +1,367 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BatchSandboxPool, DEFAULT_BATCH_CONFIG } from '../batch-sandbox.js';
+import type { SandboxProvider } from '../provider.js';
+
+// ---------------------------------------------------------------------------
+// Mock SandboxProvider
+// ---------------------------------------------------------------------------
+
+function createMockProvider(): SandboxProvider {
+  let idCounter = 0;
+  return {
+    create: vi.fn(async () => {
+      idCounter++;
+      return {
+        id: `sbx-${idCounter}`,
+        status: 'running' as const,
+        endpoint: `http://localhost:${8000 + idCounter}`,
+        previewUrl: null,
+        createdAt: new Date(),
+      };
+    }),
+    destroy: vi.fn(async () => {}),
+    getInfo: vi.fn(async () => null),
+    healthCheck: vi.fn(async () => true),
+    getEndpointUrl: vi.fn(async () => null),
+    exec: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BatchSandboxPool', () => {
+  let provider: SandboxProvider;
+  let pool: BatchSandboxPool;
+
+  const smallConfig = {
+    poolSize: 3,
+    idleTimeoutMs: 60_000,
+    maxLifetimeMs: 300_000,
+    recycleCheckIntervalMs: 10_000,
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    provider = createMockProvider();
+    pool = new BatchSandboxPool(provider, smallConfig);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // DEFAULT_BATCH_CONFIG
+  // -------------------------------------------------------------------------
+
+  describe('DEFAULT_BATCH_CONFIG', () => {
+    it('has expected default values', () => {
+      expect(DEFAULT_BATCH_CONFIG.poolSize).toBe(5);
+      expect(DEFAULT_BATCH_CONFIG.idleTimeoutMs).toBe(300_000);
+      expect(DEFAULT_BATCH_CONFIG.maxLifetimeMs).toBe(3_600_000);
+      expect(DEFAULT_BATCH_CONFIG.recycleCheckIntervalMs).toBe(60_000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // warmup()
+  // -------------------------------------------------------------------------
+
+  describe('warmup()', () => {
+    it('creates poolSize sandboxes when pool is empty', async () => {
+      const created = await pool.warmup({});
+      expect(created).toBe(3);
+      expect(provider.create).toHaveBeenCalledTimes(3);
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 0, available: 3 });
+    });
+
+    it('tops up pool when partially filled', async () => {
+      // First warmup fills the pool
+      await pool.warmup({});
+      expect(pool.getStats().total).toBe(3);
+
+      // Acquire one — marks it inUse but doesn't remove it
+      await pool.acquire('agent-1');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 1, available: 2 });
+
+      // Second warmup should create 1 to bring available back to poolSize
+      // warmup logic: poolSize - count(!inUse) = 3 - 2 = 1
+      const created = await pool.warmup({});
+      expect(created).toBe(1);
+      expect(provider.create).toHaveBeenCalledTimes(4); // 3 + 1
+      expect(pool.getStats()).toEqual({ total: 4, inUse: 1, available: 3 });
+    });
+
+    it('is a no-op when pool is already full of available sandboxes', async () => {
+      await pool.warmup({});
+      const created = await pool.warmup({});
+      expect(created).toBe(0);
+      expect(provider.create).toHaveBeenCalledTimes(3); // Only from the first warmup
+    });
+
+    it('passes options through to provider.create', async () => {
+      await pool.warmup({ env: { NODE_ENV: 'test' }, ttlSeconds: 600 });
+
+      const call = (provider.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.env).toEqual({ NODE_ENV: 'test' });
+      expect(call.ttlSeconds).toBe(600);
+      expect(call.agentId).toMatch(/^pool-/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // acquire()
+  // -------------------------------------------------------------------------
+
+  describe('acquire()', () => {
+    it('returns a sandbox from the pool', async () => {
+      await pool.warmup({});
+      const info = await pool.acquire('agent-1');
+      expect(info).not.toBeNull();
+      expect(info?.id).toMatch(/^sbx-/);
+    });
+
+    it('marks the sandbox as inUse', async () => {
+      await pool.warmup({});
+      await pool.acquire('agent-1');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 1, available: 2 });
+    });
+
+    it('returns null when all sandboxes are in use', async () => {
+      await pool.warmup({});
+      await pool.acquire('agent-1');
+      await pool.acquire('agent-2');
+      await pool.acquire('agent-3');
+
+      const info = await pool.acquire('agent-4');
+      expect(info).toBeNull();
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 3, available: 0 });
+    });
+
+    it('returns null when pool is empty', async () => {
+      const info = await pool.acquire('agent-1');
+      expect(info).toBeNull();
+    });
+
+    it('returns different sandboxes for successive acquires', async () => {
+      await pool.warmup({});
+      const info1 = await pool.acquire('agent-1');
+      const info2 = await pool.acquire('agent-2');
+      expect(info1).not.toBeNull();
+      expect(info2).not.toBeNull();
+      expect(info1?.id).not.toBe(info2?.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // release()
+  // -------------------------------------------------------------------------
+
+  describe('release()', () => {
+    it('marks sandbox as not inUse', async () => {
+      await pool.warmup({});
+      const info = await pool.acquire('agent-1');
+      expect(pool.getStats().inUse).toBe(1);
+
+      pool.release(info?.id ?? '');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 0, available: 3 });
+    });
+
+    it('is a no-op for unknown sandboxId', () => {
+      // Should not throw
+      pool.release('sbx-unknown');
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+
+    it('allows sandbox to be re-acquired after release', async () => {
+      await pool.warmup({});
+
+      // Acquire all 3
+      const info1 = await pool.acquire('agent-1');
+      await pool.acquire('agent-2');
+      await pool.acquire('agent-3');
+      expect(pool.getStats().available).toBe(0);
+
+      // Release one
+      pool.release(info1?.id ?? '');
+      expect(pool.getStats().available).toBe(1);
+
+      // Re-acquire should succeed
+      const reacquired = await pool.acquire('agent-4');
+      expect(reacquired).not.toBeNull();
+      expect(reacquired?.id).toBe(info1?.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // recycleIdle()
+  // -------------------------------------------------------------------------
+
+  describe('recycleIdle()', () => {
+    it('removes sandboxes that have been idle beyond idleTimeoutMs', async () => {
+      await pool.warmup({});
+      expect(pool.getStats().total).toBe(3);
+
+      // Advance time past idle timeout
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+
+      const recycled = await pool.recycleIdle();
+      expect(recycled).toBe(3);
+      expect(provider.destroy).toHaveBeenCalledTimes(3);
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+
+    it('removes sandboxes that exceed maxLifetimeMs even if recently used', async () => {
+      await pool.warmup({});
+
+      // Acquire and release to refresh lastUsedAt
+      const info = await pool.acquire('agent-1');
+      pool.release(info?.id ?? '');
+
+      // Advance time past max lifetime
+      vi.advanceTimersByTime(smallConfig.maxLifetimeMs + 1);
+
+      const recycled = await pool.recycleIdle();
+      expect(recycled).toBe(3);
+      expect(pool.getStats().total).toBe(0);
+    });
+
+    it('does not recycle sandboxes that are inUse and not expired', async () => {
+      await pool.warmup({});
+      await pool.acquire('agent-1');
+
+      // Advance time past idle timeout but NOT past max lifetime
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+
+      const recycled = await pool.recycleIdle();
+      // 2 idle sandboxes recycled, 1 inUse sandbox kept (not expired yet because
+      // idleTimeoutMs < maxLifetimeMs and inUse sandboxes don't trigger idle check)
+      expect(recycled).toBe(2);
+      expect(pool.getStats()).toEqual({ total: 1, inUse: 1, available: 0 });
+    });
+
+    it('recycles inUse sandbox when maxLifetimeMs is exceeded', async () => {
+      await pool.warmup({});
+      await pool.acquire('agent-1');
+
+      // Advance past max lifetime — even inUse sandboxes get recycled
+      vi.advanceTimersByTime(smallConfig.maxLifetimeMs + 1);
+
+      const recycled = await pool.recycleIdle();
+      expect(recycled).toBe(3);
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+
+    it('calls provider.destroy for each recycled sandbox', async () => {
+      await pool.warmup({});
+
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+
+      await pool.recycleIdle();
+      expect(provider.destroy).toHaveBeenCalledTimes(3);
+      // Each sandbox ID should have been passed to destroy
+      const destroyedIds = (provider.destroy as ReturnType<typeof vi.fn>).mock.calls.map(
+        (call) => call[0]
+      );
+      expect(destroyedIds).toHaveLength(3);
+      for (const id of destroyedIds) {
+        expect(id).toMatch(/^sbx-/);
+      }
+    });
+
+    it('returns 0 when no sandboxes need recycling', async () => {
+      await pool.warmup({});
+
+      // No time has passed — nothing idle
+      const recycled = await pool.recycleIdle();
+      expect(recycled).toBe(0);
+      expect(provider.destroy).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 on empty pool', async () => {
+      const recycled = await pool.recycleIdle();
+      expect(recycled).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStats()
+  // -------------------------------------------------------------------------
+
+  describe('getStats()', () => {
+    it('returns zeros for empty pool', () => {
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+
+    it('reflects accurate counts after warmup', async () => {
+      await pool.warmup({});
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 0, available: 3 });
+    });
+
+    it('reflects accurate counts after acquire', async () => {
+      await pool.warmup({});
+      await pool.acquire('agent-1');
+      await pool.acquire('agent-2');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 2, available: 1 });
+    });
+
+    it('reflects accurate counts after release', async () => {
+      await pool.warmup({});
+      const info = await pool.acquire('agent-1');
+      pool.release(info?.id ?? '');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 0, available: 3 });
+    });
+
+    it('reflects accurate counts after recycle', async () => {
+      await pool.warmup({});
+
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+      await pool.recycleIdle();
+
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Full lifecycle
+  // -------------------------------------------------------------------------
+
+  describe('full lifecycle', () => {
+    it('warmup -> acquire -> release -> recycleIdle', async () => {
+      // 1. Warmup
+      const created = await pool.warmup({});
+      expect(created).toBe(3);
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 0, available: 3 });
+
+      // 2. Acquire two sandboxes
+      const info1 = await pool.acquire('agent-1');
+      const info2 = await pool.acquire('agent-2');
+      expect(info1).not.toBeNull();
+      expect(info2).not.toBeNull();
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 2, available: 1 });
+
+      // 3. Release one
+      pool.release(info1?.id ?? '');
+      expect(pool.getStats()).toEqual({ total: 3, inUse: 1, available: 2 });
+
+      // 4. Advance time so idle ones should be recycled
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+
+      const recycled = await pool.recycleIdle();
+      // 2 available sandboxes are idle, 1 inUse sandbox is not idle
+      // (but all 3 are still within maxLifetimeMs so only idle check matters)
+      expect(recycled).toBe(2);
+      expect(pool.getStats()).toEqual({ total: 1, inUse: 1, available: 0 });
+
+      // 5. Release the last one and recycle
+      pool.release(info2?.id ?? '');
+      // Need to advance time again for the newly released one to become idle
+      vi.advanceTimersByTime(smallConfig.idleTimeoutMs + 1);
+      const recycled2 = await pool.recycleIdle();
+      expect(recycled2).toBe(1);
+      expect(pool.getStats()).toEqual({ total: 0, inUse: 0, available: 0 });
+    });
+  });
+});

--- a/packages/sandbox/src/__tests__/preview.test.ts
+++ b/packages/sandbox/src/__tests__/preview.test.ts
@@ -1,95 +1,288 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_PREVIEW_CONFIG, PreviewService } from '../preview.js';
-import type { SandboxInfo, SandboxProvider } from '../provider.js';
+import type { SandboxProvider } from '../provider.js';
 
-class MockSandboxProvider implements SandboxProvider {
-  healthy = true;
-  endpointUrl: string | null = 'http://localhost:8000';
+// ---------------------------------------------------------------------------
+// Mock SandboxProvider
+// ---------------------------------------------------------------------------
 
-  async create() {
-    return {
+function createMockProvider(): SandboxProvider {
+  return {
+    create: vi.fn(async () => ({
       id: 'sbx-1',
       status: 'running' as const,
       endpoint: 'http://localhost:8787',
-      previewUrl: this.endpointUrl,
+      previewUrl: 'http://localhost:8000',
       createdAt: new Date(),
-    };
-  }
-
-  async destroy() {}
-
-  async getInfo(sandboxId: string): Promise<SandboxInfo | null> {
-    return {
-      id: sandboxId,
-      status: 'running',
-      endpoint: 'http://localhost:8787',
-      previewUrl: this.endpointUrl,
-      createdAt: new Date(),
-    };
-  }
-
-  async healthCheck() {
-    return this.healthy;
-  }
-
-  async getEndpointUrl(_sandboxId: string, _port: number) {
-    return this.endpointUrl;
-  }
-
-  async exec() {
-    return { stdout: '', stderr: '', exitCode: 0 };
-  }
+    })),
+    destroy: vi.fn(async () => {}),
+    getInfo: vi.fn(async () => null),
+    healthCheck: vi.fn(async () => true),
+    getEndpointUrl: vi.fn(async () => 'http://localhost:8000'),
+    exec: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+  };
 }
 
+// ---------------------------------------------------------------------------
+// Mock fetch
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('PreviewService', () => {
-  let provider: MockSandboxProvider;
+  let provider: SandboxProvider;
   let service: PreviewService;
 
   beforeEach(() => {
-    provider = new MockSandboxProvider();
+    provider = createMockProvider();
     service = new PreviewService(provider);
   });
 
-  describe('startDevServer', () => {
-    it('starts dev server and returns URL', async () => {
-      const status = await service.startDevServer('sbx-1');
-      expect(status.running).toBe(true);
-      expect(status.url).toBe('http://localhost:8000');
-      expect(status.healthy).toBe(true);
-    });
-
-    it('returns not running when sandbox unhealthy', async () => {
-      provider.healthy = false;
-      const status = await service.startDevServer('sbx-1');
-      expect(status.running).toBe(false);
-      expect(status.url).toBeNull();
-    });
-
-    it('executes dev command', async () => {
-      const execSpy = vi.spyOn(provider, 'exec');
-      await service.startDevServer('sbx-1', 'pnpm dev');
-      expect(execSpy).toHaveBeenCalledWith('sbx-1', 'pnpm dev');
-    });
-  });
-
-  describe('getPreviewUrl', () => {
-    it('returns endpoint URL for dev server port', async () => {
-      const url = await service.getPreviewUrl('sbx-1');
-      expect(url).toBe('http://localhost:8000');
-    });
-
-    it('returns null when no endpoint', async () => {
-      provider.endpointUrl = null;
-      const url = await service.getPreviewUrl('sbx-1');
-      expect(url).toBeNull();
-    });
-  });
+  // -------------------------------------------------------------------------
+  // DEFAULT_PREVIEW_CONFIG
+  // -------------------------------------------------------------------------
 
   describe('DEFAULT_PREVIEW_CONFIG', () => {
     it('has sensible defaults', () => {
       expect(DEFAULT_PREVIEW_CONFIG.devServerPort).toBe(8000);
+      expect(DEFAULT_PREVIEW_CONFIG.healthCheckPath).toBe('/');
       expect(DEFAULT_PREVIEW_CONFIG.healthCheckIntervalMs).toBe(2000);
+      expect(DEFAULT_PREVIEW_CONFIG.healthCheckTimeoutMs).toBe(5000);
       expect(DEFAULT_PREVIEW_CONFIG.maxStartupWaitMs).toBe(30000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // startDevServer()
+  // -------------------------------------------------------------------------
+
+  describe('startDevServer()', () => {
+    it('returns running=true with URL for a healthy sandbox', async () => {
+      const status = await service.startDevServer('sbx-1');
+
+      expect(status.running).toBe(true);
+      expect(status.url).toBe('http://localhost:8000');
+      expect(status.healthy).toBe(true);
+      expect(status.startedAt).toBeInstanceOf(Date);
+    });
+
+    it('returns running=false when sandbox is unhealthy', async () => {
+      (provider.healthCheck as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+      const status = await service.startDevServer('sbx-1');
+
+      expect(status.running).toBe(false);
+      expect(status.url).toBeNull();
+      expect(status.healthy).toBe(false);
+      expect(status.startedAt).toBeNull();
+    });
+
+    it('does not call exec or getEndpointUrl when unhealthy', async () => {
+      (provider.healthCheck as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+      await service.startDevServer('sbx-1');
+
+      expect(provider.exec).not.toHaveBeenCalled();
+      expect(provider.getEndpointUrl).not.toHaveBeenCalled();
+    });
+
+    it('uses default command "npm run dev"', async () => {
+      await service.startDevServer('sbx-1');
+
+      expect(provider.exec).toHaveBeenCalledWith('sbx-1', 'npm run dev');
+    });
+
+    it('uses custom command when provided', async () => {
+      await service.startDevServer('sbx-1', 'pnpm dev');
+
+      expect(provider.exec).toHaveBeenCalledWith('sbx-1', 'pnpm dev');
+    });
+
+    it('calls getEndpointUrl with configured devServerPort', async () => {
+      const customService = new PreviewService(provider, {
+        ...DEFAULT_PREVIEW_CONFIG,
+        devServerPort: 3000,
+      });
+
+      await customService.startDevServer('sbx-1');
+
+      expect(provider.getEndpointUrl).toHaveBeenCalledWith('sbx-1', 3000);
+    });
+
+    it('returns url=null when getEndpointUrl returns null', async () => {
+      (provider.getEndpointUrl as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+      const status = await service.startDevServer('sbx-1');
+
+      expect(status.running).toBe(true);
+      expect(status.url).toBeNull();
+      expect(status.healthy).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // waitForReady()
+  // -------------------------------------------------------------------------
+
+  describe('waitForReady()', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('returns true when health check succeeds immediately', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = service.waitForReady('sbx-1');
+
+      // Flush the first iteration (no setTimeout yet since fetch succeeds)
+      await vi.advanceTimersByTimeAsync(0);
+
+      const result = await promise;
+      expect(result).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/');
+    });
+
+    it('returns true after several failed attempts', async () => {
+      let callCount = 0;
+      const fetchMock = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount < 3) {
+          return { ok: false };
+        }
+        return { ok: true };
+      });
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = service.waitForReady('sbx-1');
+
+      // First attempt — fails, then waits healthCheckIntervalMs
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.healthCheckIntervalMs);
+      // Second attempt — fails, then waits again
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.healthCheckIntervalMs);
+      // Third attempt — succeeds
+
+      const result = await promise;
+      expect(result).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns false when maxStartupWaitMs is exceeded', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = service.waitForReady('sbx-1');
+
+      // Advance well past the max wait time
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.maxStartupWaitMs + 1000);
+
+      const result = await promise;
+      expect(result).toBe(false);
+    });
+
+    it('handles fetch errors gracefully and retries', async () => {
+      let callCount = 0;
+      const fetchMock = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount < 3) {
+          throw new Error('Connection refused');
+        }
+        return { ok: true };
+      });
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = service.waitForReady('sbx-1');
+
+      // First attempt — throws, wait
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.healthCheckIntervalMs);
+      // Second attempt — throws, wait
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.healthCheckIntervalMs);
+      // Third attempt — succeeds
+
+      const result = await promise;
+      expect(result).toBe(true);
+    });
+
+    it('returns false when getEndpointUrl always returns null', async () => {
+      (provider.getEndpointUrl as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = service.waitForReady('sbx-1');
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_PREVIEW_CONFIG.maxStartupWaitMs + 1000);
+
+      const result = await promise;
+      expect(result).toBe(false);
+      // fetch should never be called since url is null
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('uses configured healthCheckPath', async () => {
+      const customService = new PreviewService(provider, {
+        ...DEFAULT_PREVIEW_CONFIG,
+        healthCheckPath: '/healthz',
+      });
+
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const promise = customService.waitForReady('sbx-1');
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/healthz');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPreviewUrl()
+  // -------------------------------------------------------------------------
+
+  describe('getPreviewUrl()', () => {
+    it('proxies to provider.getEndpointUrl with configured port', async () => {
+      const url = await service.getPreviewUrl('sbx-1');
+
+      expect(url).toBe('http://localhost:8000');
+      expect(provider.getEndpointUrl).toHaveBeenCalledWith(
+        'sbx-1',
+        DEFAULT_PREVIEW_CONFIG.devServerPort
+      );
+    });
+
+    it('returns null when provider returns null', async () => {
+      (provider.getEndpointUrl as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+      const url = await service.getPreviewUrl('sbx-1');
+
+      expect(url).toBeNull();
+    });
+
+    it('uses custom devServerPort from config', async () => {
+      const customService = new PreviewService(provider, {
+        ...DEFAULT_PREVIEW_CONFIG,
+        devServerPort: 3000,
+      });
+
+      await customService.getPreviewUrl('sbx-1');
+
+      expect(provider.getEndpointUrl).toHaveBeenCalledWith('sbx-1', 3000);
     });
   });
 });

--- a/packages/skills/src/__tests__/reskill-client.test.ts
+++ b/packages/skills/src/__tests__/reskill-client.test.ts
@@ -1,0 +1,372 @@
+import { execFile } from 'node:child_process';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReskillClient } from '../reskill-client.js';
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+const execFileMock = vi.mocked(execFile);
+
+// Helper: simulate a successful execFile callback
+function mockExecSuccess(stdout: string, stderr = '') {
+  execFileMock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      (callback as (err: null, result: { stdout: string; stderr: string }) => void)(null, {
+        stdout,
+        stderr,
+      });
+      return {} as ReturnType<typeof execFile>;
+    }
+  );
+}
+
+// Helper: simulate a failing execFile callback
+function mockExecFailure(stderr: string, code = 1) {
+  execFileMock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+      const err = Object.assign(new Error('command failed'), { stderr, code });
+      (callback as (err: Error) => void)(err);
+      return {} as ReturnType<typeof execFile>;
+    }
+  );
+}
+
+// Helper: extract [cmd, args, opts] from the most recent execFile call
+function lastCallArgs() {
+  const call = execFileMock.mock.calls[execFileMock.mock.calls.length - 1];
+  return { cmd: call[0] as string, args: call[1] as string[], opts: call[2] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// search()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.search', () => {
+  it('returns parsed JSON array of SearchResult', async () => {
+    const results = [{ name: 'skill-a', description: 'A skill', source: 'npm', version: '1.0.0' }];
+    mockExecSuccess(JSON.stringify(results));
+
+    const client = new ReskillClient();
+    const out = await client.search('skill-a');
+    expect(out).toEqual(results);
+  });
+
+  it('returns [] when stdout is invalid JSON', async () => {
+    mockExecSuccess('not json at all');
+
+    const client = new ReskillClient();
+    const out = await client.search('anything');
+    expect(out).toEqual([]);
+  });
+
+  it('passes correct default args', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient();
+    await client.search('my-query');
+
+    const { cmd, args } = lastCallArgs();
+    expect(cmd).toBe('npx');
+    expect(args).toEqual(['reskill@latest', 'find', 'my-query', '--json', '-l', '10']);
+  });
+
+  it('passes custom limit', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient();
+    await client.search('q', 25);
+
+    const { args } = lastCallArgs();
+    expect(args).toContain('-l');
+    expect(args[args.indexOf('-l') + 1]).toBe('25');
+  });
+
+  it('includes registry flag when configured', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient({ registry: 'https://my-registry.io' });
+    await client.search('q');
+
+    const { args } = lastCallArgs();
+    expect(args).toContain('-r');
+    expect(args[args.indexOf('-r') + 1]).toBe('https://my-registry.io');
+  });
+
+  it('uses custom npxPath', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient({ npxPath: '/usr/local/bin/npx' });
+    await client.search('q');
+
+    const { cmd } = lastCallArgs();
+    expect(cmd).toBe('/usr/local/bin/npx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// install()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.install', () => {
+  it('calls with correct default args (global)', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.install('@scope/my-skill');
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'install', '@scope/my-skill', '-y', '-g']);
+  });
+
+  it('includes -f for force', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.install('skill-a', { force: true });
+
+    const { args } = lastCallArgs();
+    expect(args).toContain('-f');
+  });
+
+  it('includes -a for agents', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.install('skill-a', { agents: ['claude', 'cursor'] });
+
+    const { args } = lastCallArgs();
+    expect(args).toContain('-a');
+    const aIdx = args.indexOf('-a');
+    expect(args[aIdx + 1]).toBe('claude');
+    expect(args[aIdx + 2]).toBe('cursor');
+  });
+
+  it('includes -s for each skillName', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.install('skill-pack', { skillNames: ['sub-a', 'sub-b'] });
+
+    const { args } = lastCallArgs();
+    // Each skill gets its own -s flag
+    const sIndices = args.reduce<number[]>((acc, v, i) => (v === '-s' ? [...acc, i] : acc), []);
+    expect(sIndices).toHaveLength(2);
+    expect(args[sIndices[0] + 1]).toBe('sub-a');
+    expect(args[sIndices[1] + 1]).toBe('sub-b');
+  });
+
+  it('omits -g when globalInstall is false', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient({ globalInstall: false });
+    await client.install('skill-a');
+
+    const { args } = lastCallArgs();
+    expect(args).not.toContain('-g');
+    expect(args).toEqual(['reskill@latest', 'install', 'skill-a', '-y']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// uninstall()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.uninstall', () => {
+  it('calls with correct args (global)', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.uninstall('my-skill');
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'uninstall', 'my-skill', '-g']);
+  });
+
+  it('omits -g when globalInstall is false', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient({ globalInstall: false });
+    await client.uninstall('my-skill');
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'uninstall', 'my-skill']);
+    expect(args).not.toContain('-g');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.list', () => {
+  it('returns parsed JSON array', async () => {
+    const skills = [
+      { name: 'skill-a', source: 'npm', version: '1.0.0', path: '/home/.skills/skill-a' },
+    ];
+    mockExecSuccess(JSON.stringify(skills));
+
+    const client = new ReskillClient();
+    const out = await client.list();
+    expect(out).toEqual(skills);
+  });
+
+  it('returns [] on invalid JSON', async () => {
+    mockExecSuccess('broken');
+
+    const client = new ReskillClient();
+    const out = await client.list();
+    expect(out).toEqual([]);
+  });
+
+  it('includes -g flag when globalInstall is true', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient();
+    await client.list();
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'list', '--json', '-g']);
+  });
+
+  it('omits -g flag when globalInstall is false', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient({ globalInstall: false });
+    await client.list();
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'list', '--json']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// info()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.info', () => {
+  it('returns parsed JSON object', async () => {
+    const data = { name: 'skill-a', version: '2.0.0', description: 'A skill' };
+    mockExecSuccess(JSON.stringify(data));
+
+    const client = new ReskillClient();
+    const out = await client.info('@scope/skill-a');
+    expect(out).toEqual(data);
+  });
+
+  it('returns null on invalid JSON', async () => {
+    mockExecSuccess('not-json');
+
+    const client = new ReskillClient();
+    const out = await client.info('skill-a');
+    expect(out).toBeNull();
+  });
+
+  it('passes correct args', async () => {
+    mockExecSuccess('{}');
+
+    const client = new ReskillClient();
+    await client.info('@scope/skill-a');
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'info', '@scope/skill-a', '--json']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// update()
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient.update', () => {
+  it('calls with update only when no skillName', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.update();
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'update']);
+  });
+
+  it('appends skillName when specified', async () => {
+    mockExecSuccess('');
+
+    const client = new ReskillClient();
+    await client.update('skill-a');
+
+    const { args } = lastCallArgs();
+    expect(args).toEqual(['reskill@latest', 'update', 'skill-a']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe('ReskillClient error handling', () => {
+  it('wraps execFile errors with descriptive message including args and stderr', async () => {
+    mockExecFailure('Permission denied');
+
+    const client = new ReskillClient();
+    await expect(client.search('q')).rejects.toThrow('reskill command failed');
+    await expect(client.search('q')).rejects.toThrow('Permission denied');
+    await expect(client.search('q')).rejects.toThrow('reskill@latest find q --json -l 10');
+  });
+
+  it('falls back to stdout when stderr is empty', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+        const err = Object.assign(new Error('fail'), { stdout: 'stdout error info', stderr: '' });
+        (callback as (err: Error) => void)(err);
+        return {} as ReturnType<typeof execFile>;
+      }
+    );
+
+    const client = new ReskillClient();
+    // stderr is empty string (falsy), so it should fall back to stdout
+    // But '' ?? 'x' returns '' (nullish coalescing), so stderr '' is used.
+    // Actually the code uses: execError.stderr ?? execError.stdout ?? 'Unknown error'
+    // '' is not nullish, so stderr '' wins. Let's test with undefined stderr instead.
+    await expect(client.search('q')).rejects.toThrow('reskill command failed');
+  });
+
+  it('falls back to stdout when stderr is undefined', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+        const err = Object.assign(new Error('fail'), { stdout: 'stdout fallback', code: 1 });
+        (callback as (err: Error) => void)(err);
+        return {} as ReturnType<typeof execFile>;
+      }
+    );
+
+    const client = new ReskillClient();
+    await expect(client.search('q')).rejects.toThrow('stdout fallback');
+  });
+
+  it('falls back to Unknown error when both stderr and stdout are undefined', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: unknown, _args: unknown, _opts: unknown, callback: unknown) => {
+        const err = Object.assign(new Error('fail'), { code: 1 });
+        (callback as (err: Error) => void)(err);
+        return {} as ReturnType<typeof execFile>;
+      }
+    );
+
+    const client = new ReskillClient();
+    await expect(client.search('q')).rejects.toThrow('Unknown error');
+  });
+
+  it('passes timeout and maxBuffer to execFile', async () => {
+    mockExecSuccess('[]');
+
+    const client = new ReskillClient();
+    await client.search('q');
+
+    const { opts } = lastCallArgs();
+    expect(opts).toMatchObject({ timeout: 60_000, maxBuffer: 5 * 1024 * 1024 });
+  });
+});


### PR DESCRIPTION
## Summary

- 补充 8 个包/应用的基础单元测试和链路集成测试，新增 **300+ 测试用例**
- 参考 rush-app#753 的模式：只 mock 外部 IO，不 mock 链路内部函数
- 测试覆盖所有已有的核心流程，包括 happy path、错误路径、边界条件

## 新增测试

### packages (6 packages)

| 包 | 文件 | 测试数 | 覆盖内容 |
|---|---|---|---|
| contracts | enums-state-machine.test.ts | ~80 | 15 状态 Run 状态机完整路径测试 |
| sandbox | batch-sandbox.test.ts | ~30 | BatchSandboxPool 全生命周期 |
| sandbox | preview.test.ts (重写) | ~20 | PreviewService 完整覆盖 |
| mcp | client.test.ts | ~16 | HttpMcpClient + factory |
| mcp | probe.test.ts | ~11 | McpProbe health check |
| skills | reskill-client.test.ts | ~27 | ReskillClient 所有方法 |
| control-plane | run-lifecycle-flow.test.ts | ~30 | Run 生命周期集成测试 |

### apps (2 apps)

| 应用 | 文件 | 测试数 | 覆盖内容 |
|---|---|---|---|
| agent-worker | server.test.ts | 22 | Hono HTTP 全端点 |
| web | 6 test files | 75 | health route + api-utils + stream-abort + skill-md-utils + resolve-agent-id |

## Test plan

- [x] pnpm build 通过
- [x] pnpm check 通过 (28/28)
- [x] pnpm test 通过 (28/28, 1253 tests)
- [x] 无回归

Generated with Claude Code