### PR TITLE
ci: remove lint step from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,5 @@ jobs:
       - name: Type check
         run: pnpm check
 
-      - name: Lint
-        run: pnpm lint
-
       - name: Test
         run: pnpm test


### PR DESCRIPTION
## Summary

- 从 CI workflow 中移除 lint step，lint 由本地 pre-commit hook 保证，无需远程重复验证

## Test plan

- [x] CI 仍保留 Build → Type check → Test 三步门禁

🤖 Generated with [Claude Code](https://claude.com/claude-code)