### PR TITLE
docs: update README contributor GitHub handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ pnpm dev                # http://localhost:3000
 | GitHub                                                                                   | 方向                                                                               |
 | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | [@pandoralink](https://github.com/pandoralink)                                           | Web 交互体验、AI 对话链路、可观测平台前端                                          |
-| [@fwxhn](https://github.com/fwxhn)                                                       | CLI 工具链、[reskill](https://github.com/nicepkg/reskill) 包管理器、可观测平台前端 |
+| [@yanglx-lara](https://github.com/yanglx-lara)                                           | CLI 工具链、[reskill](https://github.com/nicepkg/reskill) 包管理器、可观测平台前端 |
 | [@yongchaoo](https://github.com/yongchaoo) · [luocy010@163.com](mailto:luocy010@163.com) | MCP 运行时、Agent 交付模式、前端可观测性                                           |
 
 以上贡献者目前正在看新的机会，欢迎联系。


### PR DESCRIPTION
## Summary
- update the README contributor table to use the current GitHub handle `@yanglx-lara`
- keep contributor contact information aligned with the latest account ownership

## Test plan
- [x] verify `README.md` contributor row is updated
- [x] confirm branch contains only the README change

Made with [Cursor](https://cursor.com)