### PR TITLE
chore(verify): fix pnpm workspace scope name @openrush → @open-rush

### DIFF
--- a/docs/execution/verify.sh
+++ b/docs/execution/verify.sh
@@ -64,42 +64,42 @@ done
 step "Task-specific checks: $TASK"
 case "$TASK" in
   task-1)
-    pnpm --filter @openrush/db test -- agent-definition-versions 2>&1 | tail -30 \
+    pnpm --filter @open-rush/db test -- agent-definition-versions 2>&1 | tail -30 \
       && ok "db agent-definition-versions tests" \
       || fail "db agent-definition-versions tests"
     ;;
   task-2)
-    pnpm --filter @openrush/db test -- service-tokens 2>&1 | tail -30 \
+    pnpm --filter @open-rush/db test -- service-tokens 2>&1 | tail -30 \
       && ok "db service-tokens tests" \
       || fail "db service-tokens tests"
     ;;
   task-3)
-    pnpm --filter @openrush/db test -- runs 2>&1 | tail -30 \
+    pnpm --filter @open-rush/db test -- runs 2>&1 | tail -30 \
       && ok "db runs tests" \
       || fail "db runs tests"
     ;;
   task-4)
-    pnpm --filter @openrush/contracts test 2>&1 | tail -40 \
+    pnpm --filter @open-rush/contracts test 2>&1 | tail -40 \
       && ok "contracts v1 tests" \
       || fail "contracts v1 tests"
     ;;
   task-5)
-    pnpm --filter @openrush/web test -- unified-auth 2>&1 | tail -30 \
+    pnpm --filter @open-rush/web test -- unified-auth 2>&1 | tail -30 \
       && ok "unified-auth tests" \
       || fail "unified-auth tests"
     ;;
   task-6|task-8|task-9|task-12|task-13|task-14)
-    pnpm --filter @openrush/web test -- "api/v1" 2>&1 | tail -40 \
+    pnpm --filter @open-rush/web test -- "api/v1" 2>&1 | tail -40 \
       && ok "v1 api tests" \
       || fail "v1 api tests"
     ;;
   task-7|task-11)
-    pnpm --filter @openrush/control-plane test 2>&1 | tail -40 \
+    pnpm --filter @open-rush/control-plane test 2>&1 | tail -40 \
       && ok "control-plane tests" \
       || fail "control-plane tests"
     ;;
   task-10)
-    pnpm --filter @openrush/agent-worker test 2>&1 | tail -40 \
+    pnpm --filter @open-rush/agent-worker test 2>&1 | tail -40 \
       && ok "agent-worker tests" \
       || fail "agent-worker tests"
     ;;
@@ -133,7 +133,7 @@ case "$TASK" in
       ok "e2e spec exists"
       # 跑 E2E(需要 postgres + redis 容器就绪,见 AGENTS.md)
       step "Running E2E (task-18 gate)"
-      pnpm --filter @openrush/web test:e2e -- v1-api 2>&1 | tail -60 \
+      pnpm --filter @open-rush/web test:e2e -- v1-api 2>&1 | tail -60 \
         && ok "e2e v1-api passes (6 scenarios)" \
         || fail "e2e v1-api failed - 必须覆盖 specs/managed-agents-api.md §E2E 6 场景"
     fi


### PR DESCRIPTION
## 背景

Agent-0 在执行 task-1 时发现 `docs/execution/verify.sh` 里 9 处 `pnpm --filter @openrush/*` 使用了错误的 workspace scope 名。仓库实际包名是 `@open-rush/*`(带连字符),错误 scope 导致:

```
$ pnpm --filter @openrush/db test -- agent-definition-versions
No projects matched the filters in "/Users/kris/develop/open-rush"
```

意味着 task-2 到 task-19 的 **task-specific 验证一直是 no-op**,只靠通用 `pnpm test` 兜底。这绕过了每个任务单独的测试名过滤,会削弱 verify.sh 的早期失败发现能力。

因 verify.sh 是 `.claude/plans/managed-agents-p0-p1.md` 标记的受保护文件,Agent-0 正确地没改动,交给 coordinator 统一修复。

## 变更

纯 `sed`-style 替换:9 处 `@openrush/*` → `@open-rush/*`。无方案语义 / 门禁顺序 / 任务清单 / task 描述的变更。

## 实证

| | 命令 | 结果 |
|---|---|---|
| Before | `pnpm --filter '@openrush/db' test -- agent-definition-versions` | `No projects matched the filters` |
| After  | `pnpm --filter '@open-rush/db' test -- agent-definition-versions` | `69 passed in 1.62s` |

## 本地验证

- `pnpm build`: ✅ FULL TURBO
- `pnpm check`: ✅ FULL TURBO
- `pnpm lint`:  ✅ FULL TURBO
- `pnpm test`:  ✅ all packages pass

## Sparring Review

**APPROVE** (gpt-5.3-codex-xhigh):
> 纯 scope typo 修复,未引入分支逻辑、门禁顺序或任务清单语义变化。文件内不再存在 `@openrush` 残留,与仓库实际包名一致,修复了 task-2 到 task-19 中 task-specific 检查 no-op 的问题。低风险字符串替换,行为方向正确。

剩余风险(Codex 提示 / 不在本 PR 范围):当前没有针对 verify.sh filter scope 的自动化防回归断言,未来若再写错 scope 仍需人工发现 — 记录后续可考虑给 verify.sh 加 scope 验证 smoke test。

🤖 Generated with [Claude Code](https://claude.com/claude-code)