### PR TITLE
task-4: /api/v1/* Zod contracts (keystone M1 milestone)

### DIFF
--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -54,7 +54,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - 对齐 specs/managed-agents-api.md §幂等性 + specs/agent-definition-versioning.md §初次 migration
       - verify: `./docs/execution/verify.sh task-3`
 
-- [ ] `task-4-contracts-v1` — **Agent-0**
+- [x] `task-4-contracts-v1` — **Agent-0**
       域: `packages/contracts/src/v1/*.ts`, `packages/contracts/src/index.ts` re-export
       依赖: task-1, task-2, task-3
       验收:

--- a/docs/execution/progress/agent-0.md
+++ b/docs/execution/progress/agent-0.md
@@ -55,3 +55,25 @@
 - **测试覆盖**:字段默认/nullable、idempotency_key 非 UNIQUE(允许重复 insert)、latest-first 查询、24h 窗口断言、partial index predicate 文本、三段回填 SQL 正确性(含 no agent_id / no task_id 兜底),以及(task_id, definition_version)一致性由应用层保证、DB 不做约束。
 - **同步更新 control-plane pglite 测试 helper**:加 3 个新字段到 runs DDL,否则 DrizzleRunDb 插入会失败。
 - **验证结果**:`pnpm build/check/lint/test` 全绿;`./docs/execution/verify.sh task-3` PASS(101 个 db 测试,runs filter 生效)。
+
+## task-4 Contracts /api/v1/* Zod types(关键里程碑)
+- **状态**: ✅ 完成,等待合并
+- **分支**: `feat/task-4`
+- **文件域**: `packages/contracts/src/v1/*`(新子目录 8 文件 + 7 测试文件 + index barrel)、`packages/contracts/src/index.ts` re-export。
+- **组织策略**:按 endpoint 功能分 7 个文件 + 1 个 common:`common / auth / agent-definitions / agents / runs / vaults / registry / projects`。index.ts re-export + 根 index 用 `export * as v1 from './v1/index.js'` 命名空间化,避免和内部 schema 同名冲突(如 Run、Project 在内外层都存在)。
+- **关键决策**:
+  - **AI SDK UIMessagePart 不 import `ai` 包**:spec 写的是 `@ai-sdk/ui-utils`,实际在本仓库这个 tag 下是 `ai` 包。直接加 `ai` 依赖会把 React 等重依赖拖进 contracts(contracts 是 sdk / agent-worker / control-plane 的共同依赖)。改用结构兼容的 Zod schema 定义(`text / reasoning / step-start / tool-* / source-url / file / data-*`),运行时由 Zod 做 shape 验证,编译时消费方按需 `import type { UIMessagePart } from 'ai'`。此决策在 runs.ts 文件里写了长注释说明原因。
+  - **Open-rush 扩展事件 discriminated union**:4 个字面量 type(`data-openrush-run-started/run-done/usage/sub-run`),精确 payload。`runEventPayloadSchema` 里 generic `data-*` 用 refine 拒绝 `data-openrush-*` 前缀,防止扩展事件 shape 被泛型 generic 吞掉(测试里专门断言)。
+  - **pagination 用 `coerce.number` + 默认 50**;cursor opaque 字符串;response 带 `nextCursor: string | null`(spec 明确是 nullable)。
+  - **ServiceTokenScope 枚举不含 `'*'`**:强制在 schema 层面拒绝 Service Token 声明 `*`,避免后续 API handler 需要额外过滤。额外导出 `AuthScope = ServiceTokenScope | '*'` 用于中间件 AuthContext。
+  - **错误 code 枚举严格 8 个**,并导出 `ERROR_CODE_HTTP_STATUS` 常量映射给 route handler 用。
+  - **PATCH body refine**:要求至少一个可编辑字段(`changeNote` 单独不算),避免 no-op PATCH 产生版本号递增。
+  - **If-Match header** 用独立 `ifMatchHeaderSchema`(coerce → positive int)。**Idempotency-Key header** 用独立 `idempotencyKeyHeaderSchema`(≤255 URL-safe),对齐 0011 migration 的 `varchar(255)` 列宽。
+  - **deleteAgentResponseSchema 的 status 用 `z.literal('cancelled')`**,契约上锁死 DELETE 只能返回 cancelled 状态。
+  - **createVaultEntryRequestSchema** 用 refine 约束 `(scope, projectId)` 组合合法性,在 schema 层面就拒绝非法组合。
+- **测试覆盖**:8 个测试文件共 355 tests,每个 schema 都有 happy + 错误路径。重点覆盖:scope `*` 拒绝、幂等 key 格式、SSE 事件 data-openrush-* 前缀保护、vault `(scope, projectId)` refine、PATCH no-op 拒绝、SSE id ≥ 1、分页 nextCursor 必传。
+- **不包含**:OpenAPI 生成(按 team-lead 指示跳过,留 task-15);实际 hash 计算 / 中间件逻辑(task-5/11)。
+- **验证结果**:`pnpm build/check/lint/test` 全绿;`./docs/execution/verify.sh task-4` PASS(355 contracts tests + 全量 test 正常)。
+
+## M1 Milestone
+所有 task-1/2/3/4 完成后,M1(Foundation)结束。Agent-A (M2) 和 Agent-B (M3) 可并行启动。

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,4 +8,10 @@ export * from './project.js';
 export * from './run.js';
 export * from './sandbox.js';
 export * from './task.js';
+/**
+ * Stable `/api/v1/*` contracts (task-4). Namespaced via `v1` to avoid
+ * colliding with internal-layer schema names (e.g. Run, Project exist in
+ * both the internal and the external contract surfaces).
+ */
+export * as v1 from './v1/index.js';
 export * from './vault.js';

--- a/packages/contracts/src/v1/__tests__/agent-definitions.test.ts
+++ b/packages/contracts/src/v1/__tests__/agent-definitions.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import {
+  agentDefinitionSchema,
+  archiveAgentDefinitionResponseSchema,
+  createAgentDefinitionRequestSchema,
+  createAgentDefinitionResponseSchema,
+  getAgentDefinitionQuerySchema,
+  ifMatchHeaderSchema,
+  listAgentDefinitionsQuerySchema,
+  listAgentDefinitionsResponseSchema,
+  listAgentDefinitionVersionsResponseSchema,
+  patchAgentDefinitionRequestSchema,
+} from '../agent-definitions.js';
+
+const baseEditable = {
+  name: 'my-agent',
+  providerType: 'claude-code',
+  model: 'claude-sonnet-4.5',
+  systemPrompt: 'helpful',
+  appendSystemPrompt: null,
+  allowedTools: ['Bash', 'Read'],
+  skills: [],
+  mcpServers: [],
+  maxSteps: 30,
+  deliveryMode: 'chat' as const,
+  config: null,
+};
+
+const fullDef = {
+  ...baseEditable,
+  id: '00000000-0000-0000-0000-000000000001',
+  projectId: '00000000-0000-0000-0000-000000000002',
+  currentVersion: 1,
+  archivedAt: null,
+  description: null,
+  icon: null,
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+describe('createAgentDefinitionRequestSchema', () => {
+  it('accepts a valid create body', () => {
+    const body = { ...baseEditable, projectId: '00000000-0000-0000-0000-000000000002' };
+    expect(createAgentDefinitionRequestSchema.parse(body)).toMatchObject({
+      name: 'my-agent',
+      projectId: '00000000-0000-0000-0000-000000000002',
+    });
+  });
+
+  it('rejects missing projectId', () => {
+    expect(createAgentDefinitionRequestSchema.safeParse(baseEditable).success).toBe(false);
+  });
+
+  it('rejects non-UUID projectId', () => {
+    expect(
+      createAgentDefinitionRequestSchema.safeParse({ ...baseEditable, projectId: 'x' }).success
+    ).toBe(false);
+  });
+
+  it('rejects out-of-range maxSteps', () => {
+    expect(
+      createAgentDefinitionRequestSchema.safeParse({
+        ...baseEditable,
+        projectId: '00000000-0000-0000-0000-000000000002',
+        maxSteps: 0,
+      }).success
+    ).toBe(false);
+    expect(
+      createAgentDefinitionRequestSchema.safeParse({
+        ...baseEditable,
+        projectId: '00000000-0000-0000-0000-000000000002',
+        maxSteps: 1001,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects invalid deliveryMode', () => {
+    expect(
+      createAgentDefinitionRequestSchema.safeParse({
+        ...baseEditable,
+        projectId: '00000000-0000-0000-0000-000000000002',
+        deliveryMode: 'bogus',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('patchAgentDefinitionRequestSchema', () => {
+  it('accepts a single-field patch', () => {
+    expect(patchAgentDefinitionRequestSchema.parse({ name: 'new' })).toMatchObject({
+      name: 'new',
+    });
+  });
+
+  it('accepts a patch with changeNote only-if-combined-with-a-field', () => {
+    expect(
+      patchAgentDefinitionRequestSchema.parse({ systemPrompt: 'x', changeNote: 'why' })
+    ).toMatchObject({ systemPrompt: 'x', changeNote: 'why' });
+  });
+
+  it('rejects empty body', () => {
+    expect(patchAgentDefinitionRequestSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects body with ONLY changeNote (no editable field)', () => {
+    expect(patchAgentDefinitionRequestSchema.safeParse({ changeNote: 'note only' }).success).toBe(
+      false
+    );
+  });
+
+  it('propagates per-field validation (bad deliveryMode)', () => {
+    expect(patchAgentDefinitionRequestSchema.safeParse({ deliveryMode: 'unknown' }).success).toBe(
+      false
+    );
+  });
+});
+
+describe('ifMatchHeaderSchema', () => {
+  it('coerces string → positive int', () => {
+    expect(ifMatchHeaderSchema.parse('3')).toBe(3);
+  });
+
+  it('rejects zero and negatives', () => {
+    expect(ifMatchHeaderSchema.safeParse('0').success).toBe(false);
+    expect(ifMatchHeaderSchema.safeParse('-1').success).toBe(false);
+  });
+
+  it('rejects non-integer', () => {
+    expect(ifMatchHeaderSchema.safeParse('1.5').success).toBe(false);
+  });
+});
+
+describe('agentDefinitionSchema (response entity)', () => {
+  it('round-trips a full valid entity', () => {
+    expect(agentDefinitionSchema.parse(fullDef)).toMatchObject({ currentVersion: 1 });
+  });
+
+  it('rejects negative currentVersion', () => {
+    expect(agentDefinitionSchema.safeParse({ ...fullDef, currentVersion: -1 }).success).toBe(false);
+  });
+
+  it('accepts archivedAt being an ISO date string or null', () => {
+    expect(agentDefinitionSchema.parse({ ...fullDef, archivedAt: null }).archivedAt).toBeNull();
+    expect(
+      agentDefinitionSchema.parse({ ...fullDef, archivedAt: '2026-05-01T00:00:00Z' }).archivedAt
+    ).toBe('2026-05-01T00:00:00Z');
+  });
+});
+
+describe('envelope schemas', () => {
+  it('createAgentDefinitionResponseSchema wraps a full entity', () => {
+    expect(createAgentDefinitionResponseSchema.parse({ data: fullDef }).data.id).toBeTruthy();
+  });
+
+  it('listAgentDefinitionsQuerySchema: sensible defaults', () => {
+    expect(listAgentDefinitionsQuerySchema.parse({})).toEqual({
+      limit: 50,
+      includeArchived: false,
+    });
+  });
+
+  it('listAgentDefinitionsQuerySchema parses "true"/"false" strictly', () => {
+    // Avoid JS Boolean() coercion — "false" is truthy there and would flip
+    // the filter silently. We enforce canonical URL-query forms only.
+    expect(listAgentDefinitionsQuerySchema.parse({ includeArchived: 'true' }).includeArchived).toBe(
+      true
+    );
+    expect(
+      listAgentDefinitionsQuerySchema.parse({ includeArchived: 'false' }).includeArchived
+    ).toBe(false);
+    expect(listAgentDefinitionsQuerySchema.parse({ includeArchived: true }).includeArchived).toBe(
+      true
+    );
+    expect(listAgentDefinitionsQuerySchema.parse({ includeArchived: false }).includeArchived).toBe(
+      false
+    );
+  });
+
+  it('listAgentDefinitionsQuerySchema rejects non-canonical booleans', () => {
+    expect(listAgentDefinitionsQuerySchema.safeParse({ includeArchived: '1' }).success).toBe(false);
+    expect(listAgentDefinitionsQuerySchema.safeParse({ includeArchived: 'yes' }).success).toBe(
+      false
+    );
+    expect(listAgentDefinitionsQuerySchema.safeParse({ includeArchived: 0 }).success).toBe(false);
+  });
+
+  it('listAgentDefinitionsResponseSchema shape', () => {
+    expect(
+      listAgentDefinitionsResponseSchema.parse({ data: [fullDef], nextCursor: null }).data
+    ).toHaveLength(1);
+  });
+
+  it('getAgentDefinitionQuerySchema coerces version', () => {
+    expect(getAgentDefinitionQuerySchema.parse({ version: '3' })).toEqual({ version: 3 });
+  });
+
+  it('archiveAgentDefinitionResponseSchema', () => {
+    const parsed = archiveAgentDefinitionResponseSchema.parse({
+      data: {
+        id: '00000000-0000-0000-0000-000000000001',
+        archivedAt: '2026-05-01T00:00:00Z',
+      },
+    });
+    expect(parsed.data.archivedAt).toBe('2026-05-01T00:00:00Z');
+  });
+
+  it('listAgentDefinitionVersionsResponseSchema items omit snapshot', () => {
+    const parsed = listAgentDefinitionVersionsResponseSchema.parse({
+      data: [
+        {
+          version: 1,
+          changeNote: 'initial',
+          createdBy: null,
+          createdAt: '2026-04-25T00:00:00Z',
+        },
+      ],
+      nextCursor: null,
+    });
+    expect((parsed.data[0] as Record<string, unknown>).snapshot).toBeUndefined();
+  });
+});

--- a/packages/contracts/src/v1/__tests__/agents.test.ts
+++ b/packages/contracts/src/v1/__tests__/agents.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AgentStatus,
+  agentSchema,
+  createAgentRequestSchema,
+  createAgentResponseSchema,
+  deleteAgentResponseSchema,
+  listAgentsQuerySchema,
+  listAgentsResponseSchema,
+} from '../agents.js';
+
+const agent = {
+  id: '00000000-0000-0000-0000-000000000010',
+  projectId: '00000000-0000-0000-0000-000000000002',
+  definitionId: '00000000-0000-0000-0000-000000000020',
+  definitionVersion: 1,
+  mode: 'chat' as const,
+  status: 'active' as const,
+  title: 'My Agent',
+  headRunId: null,
+  activeRunId: null,
+  createdBy: '00000000-0000-0000-0000-000000000001',
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+describe('AgentStatus enum', () => {
+  it('accepts active/completed/cancelled', () => {
+    for (const s of ['active', 'completed', 'cancelled']) {
+      expect(AgentStatus.parse(s)).toBe(s);
+    }
+  });
+
+  it('rejects legacy status "archived"', () => {
+    expect(AgentStatus.safeParse('archived').success).toBe(false);
+  });
+});
+
+describe('createAgentRequestSchema', () => {
+  it('accepts minimal body (no initialInput, no explicit version)', () => {
+    const body = {
+      definitionId: '00000000-0000-0000-0000-000000000020',
+      projectId: '00000000-0000-0000-0000-000000000002',
+      mode: 'chat' as const,
+    };
+    expect(createAgentRequestSchema.parse(body)).toMatchObject(body);
+  });
+
+  it('accepts body with explicit definitionVersion and initialInput', () => {
+    expect(
+      createAgentRequestSchema.parse({
+        definitionId: '00000000-0000-0000-0000-000000000020',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        mode: 'workspace',
+        definitionVersion: 3,
+        initialInput: 'go',
+        title: 'Task A',
+      })
+    ).toMatchObject({ definitionVersion: 3 });
+  });
+
+  it('rejects missing mode', () => {
+    expect(
+      createAgentRequestSchema.safeParse({
+        definitionId: '00000000-0000-0000-0000-000000000020',
+        projectId: '00000000-0000-0000-0000-000000000002',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects negative definitionVersion', () => {
+    expect(
+      createAgentRequestSchema.safeParse({
+        definitionId: '00000000-0000-0000-0000-000000000020',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        mode: 'chat',
+        definitionVersion: 0,
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects non-UUID definitionId', () => {
+    expect(
+      createAgentRequestSchema.safeParse({
+        definitionId: 'not-a-uuid',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        mode: 'chat',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects title > 200 chars', () => {
+    expect(
+      createAgentRequestSchema.safeParse({
+        definitionId: '00000000-0000-0000-0000-000000000020',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        mode: 'chat',
+        title: 'x'.repeat(201),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('agentSchema', () => {
+  it('round-trips a valid entity', () => {
+    expect(agentSchema.parse(agent)).toMatchObject({ definitionVersion: 1 });
+  });
+
+  it('accepts nullable title / run ids', () => {
+    expect(
+      agentSchema.parse({ ...agent, title: null, headRunId: null, activeRunId: null }).title
+    ).toBeNull();
+  });
+
+  it('rejects non-positive definitionVersion', () => {
+    expect(agentSchema.safeParse({ ...agent, definitionVersion: 0 }).success).toBe(false);
+  });
+});
+
+describe('createAgentResponseSchema', () => {
+  it('accepts envelope with agent + nullable firstRunId', () => {
+    expect(
+      createAgentResponseSchema.parse({ data: { agent, firstRunId: null } }).data.firstRunId
+    ).toBeNull();
+  });
+});
+
+describe('listAgentsQuerySchema', () => {
+  it('accepts status filter', () => {
+    expect(listAgentsQuerySchema.parse({ status: 'cancelled' }).status).toBe('cancelled');
+  });
+
+  it('accepts projectId + definitionId filters', () => {
+    expect(
+      listAgentsQuerySchema.parse({
+        projectId: '00000000-0000-0000-0000-000000000002',
+        definitionId: '00000000-0000-0000-0000-000000000020',
+      }).projectId
+    ).toBeTruthy();
+  });
+});
+
+describe('listAgentsResponseSchema', () => {
+  it('paginated envelope shape', () => {
+    expect(listAgentsResponseSchema.parse({ data: [agent], nextCursor: null }).data).toHaveLength(
+      1
+    );
+  });
+});
+
+describe('deleteAgentResponseSchema', () => {
+  it('fixes status to literal "cancelled"', () => {
+    expect(
+      deleteAgentResponseSchema.parse({
+        data: {
+          id: '00000000-0000-0000-0000-000000000010',
+          status: 'cancelled',
+          cancelledRunId: null,
+        },
+      }).data.status
+    ).toBe('cancelled');
+  });
+
+  it('rejects non-cancelled status (protocol invariant)', () => {
+    expect(
+      deleteAgentResponseSchema.safeParse({
+        data: {
+          id: '00000000-0000-0000-0000-000000000010',
+          status: 'active',
+          cancelledRunId: null,
+        },
+      }).success
+    ).toBe(false);
+  });
+});

--- a/packages/contracts/src/v1/__tests__/auth.test.ts
+++ b/packages/contracts/src/v1/__tests__/auth.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createTokenRequestSchema,
+  createTokenResponseSchema,
+  deleteTokenParamsSchema,
+  listTokensResponseSchema,
+} from '../auth.js';
+
+// Use a dynamic future date so the TTL-≤-90-day guardrail doesn't trip as
+// real time marches forward.
+const future60Days = new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString();
+
+const validCreateBody = {
+  name: 'my-cli',
+  scopes: ['agents:read', 'runs:write'],
+  expiresAt: future60Days,
+};
+
+describe('createTokenRequestSchema', () => {
+  it('accepts valid body', () => {
+    expect(createTokenRequestSchema.parse(validCreateBody)).toEqual(validCreateBody);
+  });
+
+  it('rejects empty name', () => {
+    expect(createTokenRequestSchema.safeParse({ ...validCreateBody, name: '' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects name > 255 chars', () => {
+    expect(
+      createTokenRequestSchema.safeParse({ ...validCreateBody, name: 'x'.repeat(256) }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty scopes array (v0.1 guardrail)', () => {
+    expect(createTokenRequestSchema.safeParse({ ...validCreateBody, scopes: [] }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects scopes containing "*" (wildcard not allowed on tokens)', () => {
+    expect(createTokenRequestSchema.safeParse({ ...validCreateBody, scopes: ['*'] }).success).toBe(
+      false
+    );
+    expect(
+      createTokenRequestSchema.safeParse({
+        ...validCreateBody,
+        scopes: ['agents:read', '*'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unknown scope strings', () => {
+    expect(
+      createTokenRequestSchema.safeParse({
+        ...validCreateBody,
+        scopes: ['agents:admin'],
+      }).success
+    ).toBe(false);
+  });
+
+  it('requires expiresAt', () => {
+    const { expiresAt: _, ...body } = validCreateBody;
+    expect(createTokenRequestSchema.safeParse(body).success).toBe(false);
+  });
+
+  it('rejects non-ISO expiresAt', () => {
+    expect(
+      createTokenRequestSchema.safeParse({ ...validCreateBody, expiresAt: 'not-a-date' }).success
+    ).toBe(false);
+    expect(
+      createTokenRequestSchema.safeParse({ ...validCreateBody, expiresAt: '2026-07-01' }).success
+    ).toBe(false);
+  });
+
+  it('rejects expiresAt already in the past', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    expect(
+      createTokenRequestSchema.safeParse({ ...validCreateBody, expiresAt: past }).success
+    ).toBe(false);
+  });
+
+  it('rejects expiresAt > 90 days from now (v0.1 TTL cap)', () => {
+    const beyond = new Date(Date.now() + 91 * 24 * 60 * 60 * 1000).toISOString();
+    const result = createTokenRequestSchema.safeParse({ ...validCreateBody, expiresAt: beyond });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => /90 days/.test(i.message))).toBe(true);
+    }
+  });
+
+  it('accepts expiresAt exactly at 89 days from now (boundary-ish, under cap)', () => {
+    const under = new Date(Date.now() + 89 * 24 * 60 * 60 * 1000).toISOString();
+    expect(
+      createTokenRequestSchema.safeParse({ ...validCreateBody, expiresAt: under }).success
+    ).toBe(true);
+  });
+});
+
+describe('createTokenResponseSchema', () => {
+  it('accepts envelope with plaintext token and sk_ prefix', () => {
+    const parsed = createTokenResponseSchema.parse({
+      data: {
+        id: '00000000-0000-0000-0000-000000000001',
+        token: 'sk_abc123_XYZ-def',
+        name: 'cli',
+        scopes: ['agents:read'],
+        createdAt: '2026-04-25T00:00:00Z',
+        expiresAt: '2026-07-25T00:00:00Z',
+      },
+    });
+    expect(parsed.data.token).toMatch(/^sk_/);
+  });
+
+  it('rejects token without sk_ prefix', () => {
+    const body = {
+      data: {
+        id: '00000000-0000-0000-0000-000000000001',
+        token: 'pk_123',
+        name: 'cli',
+        scopes: ['agents:read'],
+        createdAt: '2026-04-25T00:00:00Z',
+        expiresAt: '2026-07-25T00:00:00Z',
+      },
+    };
+    expect(createTokenResponseSchema.safeParse(body).success).toBe(false);
+  });
+
+  it('rejects invalid UUID in id', () => {
+    const body = {
+      data: {
+        id: 'not-a-uuid',
+        token: 'sk_abc',
+        name: 'cli',
+        scopes: ['agents:read'],
+        createdAt: '2026-04-25T00:00:00Z',
+        expiresAt: '2026-07-25T00:00:00Z',
+      },
+    };
+    expect(createTokenResponseSchema.safeParse(body).success).toBe(false);
+  });
+});
+
+describe('listTokensResponseSchema', () => {
+  it('accepts list without plaintext token', () => {
+    const parsed = listTokensResponseSchema.parse({
+      data: [
+        {
+          id: '00000000-0000-0000-0000-000000000001',
+          name: 'cli',
+          scopes: ['agents:read'],
+          createdAt: '2026-04-25T00:00:00Z',
+          expiresAt: '2026-07-25T00:00:00Z',
+          lastUsedAt: null,
+          revokedAt: null,
+        },
+      ],
+      nextCursor: null,
+    });
+    expect(parsed.data).toHaveLength(1);
+    // Item has no `token` field — strict by default, but Zod strips unknown.
+    // We assert the item fields match the expected shape.
+    expect((parsed.data[0] as Record<string, unknown>).token).toBeUndefined();
+  });
+
+  it('accepts nullable lastUsedAt / expiresAt / revokedAt', () => {
+    const parsed = listTokensResponseSchema.parse({
+      data: [
+        {
+          id: '00000000-0000-0000-0000-000000000001',
+          name: 'cli',
+          scopes: ['agents:read'],
+          createdAt: '2026-04-25T00:00:00Z',
+          expiresAt: null,
+          lastUsedAt: '2026-05-01T00:00:00Z',
+          revokedAt: '2026-05-02T00:00:00Z',
+        },
+      ],
+      nextCursor: 'c',
+    });
+    expect(parsed.data[0].expiresAt).toBeNull();
+  });
+});
+
+describe('deleteTokenParamsSchema', () => {
+  it('accepts valid UUID', () => {
+    expect(deleteTokenParamsSchema.parse({ id: '00000000-0000-0000-0000-000000000001' })).toEqual({
+      id: '00000000-0000-0000-0000-000000000001',
+    });
+  });
+
+  it('rejects non-UUID', () => {
+    expect(deleteTokenParamsSchema.safeParse({ id: '123' }).success).toBe(false);
+  });
+});

--- a/packages/contracts/src/v1/__tests__/common.test.ts
+++ b/packages/contracts/src/v1/__tests__/common.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  AuthScope,
+  ERROR_CODE_HTTP_STATUS,
+  ErrorCode,
+  errorResponseSchema,
+  paginatedResponseSchema,
+  paginationQuerySchema,
+  ServiceTokenScope,
+  successResponseSchema,
+} from '../common.js';
+
+describe('ErrorCode enum', () => {
+  it('accepts all 8 spec codes', () => {
+    for (const code of [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'NOT_FOUND',
+      'VALIDATION_ERROR',
+      'VERSION_CONFLICT',
+      'IDEMPOTENCY_CONFLICT',
+      'RATE_LIMITED',
+      'INTERNAL',
+    ]) {
+      expect(ErrorCode.parse(code)).toBe(code);
+    }
+  });
+
+  it('rejects unknown codes', () => {
+    expect(ErrorCode.safeParse('OOPS').success).toBe(false);
+    expect(ErrorCode.safeParse('Unauthorized').success).toBe(false); // case-sensitive
+    expect(ErrorCode.safeParse('').success).toBe(false);
+  });
+
+  it('HTTP status mapping is complete and matches spec', () => {
+    expect(ERROR_CODE_HTTP_STATUS).toEqual({
+      UNAUTHORIZED: 401,
+      FORBIDDEN: 403,
+      NOT_FOUND: 404,
+      VALIDATION_ERROR: 400,
+      VERSION_CONFLICT: 409,
+      IDEMPOTENCY_CONFLICT: 409,
+      RATE_LIMITED: 429,
+      INTERNAL: 500,
+    });
+  });
+});
+
+describe('errorResponseSchema', () => {
+  it('accepts minimal valid error', () => {
+    expect(
+      errorResponseSchema.parse({
+        error: { code: 'UNAUTHORIZED', message: 'no token' },
+      })
+    ).toEqual({ error: { code: 'UNAUTHORIZED', message: 'no token' } });
+  });
+
+  it('accepts hint + issues fields', () => {
+    const parsed = errorResponseSchema.parse({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'bad input',
+        hint: 'check fields',
+        issues: [{ path: ['name'], message: 'required' }],
+      },
+    });
+    expect(parsed.error.issues).toHaveLength(1);
+  });
+
+  it('rejects missing message', () => {
+    expect(errorResponseSchema.safeParse({ error: { code: 'UNAUTHORIZED' } }).success).toBe(false);
+  });
+
+  it('rejects unknown error code', () => {
+    expect(errorResponseSchema.safeParse({ error: { code: 'NOPE', message: 'x' } }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects empty message', () => {
+    expect(
+      errorResponseSchema.safeParse({ error: { code: 'UNAUTHORIZED', message: '' } }).success
+    ).toBe(false);
+  });
+});
+
+describe('successResponseSchema', () => {
+  const dataSchema = z.object({ id: z.string(), name: z.string() });
+  const envelope = successResponseSchema(dataSchema);
+
+  it('accepts envelope with valid data', () => {
+    expect(envelope.parse({ data: { id: '1', name: 'a' } })).toEqual({
+      data: { id: '1', name: 'a' },
+    });
+  });
+
+  it('rejects envelope with missing data field', () => {
+    expect(envelope.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects envelope with extra data shape', () => {
+    const result = envelope.safeParse({ data: { id: 1, name: 'a' } });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('paginationQuerySchema', () => {
+  it('defaults limit to 50 when absent', () => {
+    expect(paginationQuerySchema.parse({})).toEqual({ limit: 50 });
+  });
+
+  it('coerces string limit to number', () => {
+    expect(paginationQuerySchema.parse({ limit: '100' })).toEqual({ limit: 100 });
+  });
+
+  it('rejects limit > 200', () => {
+    expect(paginationQuerySchema.safeParse({ limit: 201 }).success).toBe(false);
+  });
+
+  it('rejects limit < 1', () => {
+    expect(paginationQuerySchema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(paginationQuerySchema.safeParse({ limit: -1 }).success).toBe(false);
+  });
+
+  it('accepts opaque cursor string', () => {
+    expect(paginationQuerySchema.parse({ cursor: 'abc123' })).toMatchObject({ cursor: 'abc123' });
+  });
+});
+
+describe('paginatedResponseSchema', () => {
+  const itemSchema = z.object({ id: z.string() });
+  const listSchema = paginatedResponseSchema(itemSchema);
+
+  it('accepts empty list + null cursor', () => {
+    expect(listSchema.parse({ data: [], nextCursor: null })).toEqual({
+      data: [],
+      nextCursor: null,
+    });
+  });
+
+  it('accepts populated list + string cursor', () => {
+    expect(listSchema.parse({ data: [{ id: 'a' }, { id: 'b' }], nextCursor: 'opaque' })).toEqual({
+      data: [{ id: 'a' }, { id: 'b' }],
+      nextCursor: 'opaque',
+    });
+  });
+
+  it('rejects missing nextCursor field (must be null or string, not absent)', () => {
+    expect(listSchema.safeParse({ data: [] }).success).toBe(false);
+  });
+});
+
+describe('ServiceTokenScope + AuthScope', () => {
+  it('ServiceTokenScope has all 11 values from spec matrix', () => {
+    const expected = [
+      'agent-definitions:read',
+      'agent-definitions:write',
+      'agents:read',
+      'agents:write',
+      'runs:read',
+      'runs:write',
+      'runs:cancel',
+      'vaults:read',
+      'vaults:write',
+      'projects:read',
+      'projects:write',
+    ];
+    for (const s of expected) {
+      expect(ServiceTokenScope.parse(s)).toBe(s);
+    }
+  });
+
+  it('ServiceTokenScope explicitly rejects "*"', () => {
+    expect(ServiceTokenScope.safeParse('*').success).toBe(false);
+  });
+
+  it('AuthScope accepts both "*" and concrete scopes', () => {
+    expect(AuthScope.parse('*')).toBe('*');
+    expect(AuthScope.parse('agents:read')).toBe('agents:read');
+    expect(AuthScope.safeParse('nope:read').success).toBe(false);
+  });
+});

--- a/packages/contracts/src/v1/__tests__/index.test.ts
+++ b/packages/contracts/src/v1/__tests__/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import * as v1 from '../index.js';
+
+describe('v1 barrel export', () => {
+  it('re-exports common schemas', () => {
+    expect(typeof v1.errorResponseSchema).toBe('object');
+    expect(typeof v1.ErrorCode).toBe('object');
+    expect(typeof v1.ServiceTokenScope).toBe('object');
+  });
+
+  it('re-exports 24 endpoint schemas (spot-check)', () => {
+    // Auth
+    expect(typeof v1.createTokenRequestSchema).toBe('object');
+    expect(typeof v1.listTokensResponseSchema).toBe('object');
+    expect(typeof v1.deleteTokenParamsSchema).toBe('object');
+    // AgentDefinition
+    expect(typeof v1.createAgentDefinitionRequestSchema).toBe('object');
+    expect(typeof v1.patchAgentDefinitionRequestSchema).toBe('object');
+    expect(typeof v1.listAgentDefinitionVersionsResponseSchema).toBe('object');
+    expect(typeof v1.archiveAgentDefinitionResponseSchema).toBe('object');
+    // Agent
+    expect(typeof v1.createAgentRequestSchema).toBe('object');
+    expect(typeof v1.deleteAgentResponseSchema).toBe('object');
+    // Run
+    expect(typeof v1.createRunRequestSchema).toBe('object');
+    expect(typeof v1.cancelRunResponseSchema).toBe('object');
+    expect(typeof v1.runEventSseFrameSchema).toBe('object');
+    // Vault
+    expect(typeof v1.createVaultEntryRequestSchema).toBe('object');
+    expect(typeof v1.listVaultEntriesResponseSchema).toBe('object');
+    // Registry
+    expect(typeof v1.listSkillsResponseSchema).toBe('object');
+    expect(typeof v1.listMcpsResponseSchema).toBe('object');
+    // Projects
+    expect(typeof v1.createProjectRequestSchema).toBe('object');
+    expect(typeof v1.getProjectResponseSchema).toBe('object');
+  });
+
+  it('re-exports Open-rush extension event part schemas (4)', () => {
+    expect(typeof v1.openrushRunStartedPartSchema).toBe('object');
+    expect(typeof v1.openrushRunDonePartSchema).toBe('object');
+    expect(typeof v1.openrushUsagePartSchema).toBe('object');
+    expect(typeof v1.openrushSubRunPartSchema).toBe('object');
+    expect(typeof v1.openrushExtensionPartSchema).toBe('object');
+  });
+});

--- a/packages/contracts/src/v1/__tests__/projects.test.ts
+++ b/packages/contracts/src/v1/__tests__/projects.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createProjectRequestSchema,
+  createProjectResponseSchema,
+  getProjectParamsSchema,
+  getProjectResponseSchema,
+  listProjectsQuerySchema,
+  listProjectsResponseSchema,
+  projectSchema,
+  SandboxProviderId,
+} from '../projects.js';
+
+const project = {
+  id: '00000000-0000-0000-0000-000000000070',
+  name: 'demo',
+  description: null,
+  sandboxProvider: 'opensandbox' as const,
+  defaultModel: null,
+  defaultConnectionMode: null,
+  createdBy: null,
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+describe('SandboxProviderId enum', () => {
+  it('accepts known providers', () => {
+    for (const id of ['opensandbox', 'e2b', 'docker', 'custom']) {
+      expect(SandboxProviderId.parse(id)).toBe(id);
+    }
+  });
+
+  it('rejects unknown provider', () => {
+    expect(SandboxProviderId.safeParse('k8s').success).toBe(false);
+  });
+});
+
+describe('createProjectRequestSchema', () => {
+  it('accepts minimal body with default sandboxProvider', () => {
+    const parsed = createProjectRequestSchema.parse({ name: 'a' });
+    expect(parsed.sandboxProvider).toBe('opensandbox');
+  });
+
+  it('rejects empty name', () => {
+    expect(createProjectRequestSchema.safeParse({ name: '' }).success).toBe(false);
+  });
+
+  it('rejects name > 255 chars', () => {
+    expect(createProjectRequestSchema.safeParse({ name: 'x'.repeat(256) }).success).toBe(false);
+  });
+
+  it('accepts defaultConnectionMode enum', () => {
+    expect(
+      createProjectRequestSchema.parse({ name: 'a', defaultConnectionMode: 'bedrock' })
+        .defaultConnectionMode
+    ).toBe('bedrock');
+  });
+});
+
+describe('projectSchema', () => {
+  it('round-trips valid entity', () => {
+    expect(projectSchema.parse(project).sandboxProvider).toBe('opensandbox');
+  });
+});
+
+describe('envelope + list', () => {
+  it('createProjectResponseSchema wraps project', () => {
+    expect(createProjectResponseSchema.parse({ data: project }).data.name).toBe('demo');
+  });
+
+  it('listProjectsQuerySchema accepts q filter', () => {
+    expect(listProjectsQuerySchema.parse({ q: 'hello' }).q).toBe('hello');
+  });
+
+  it('listProjectsResponseSchema paginated', () => {
+    expect(
+      listProjectsResponseSchema.parse({ data: [project], nextCursor: null }).data
+    ).toHaveLength(1);
+  });
+
+  it('getProjectParamsSchema requires UUID', () => {
+    expect(getProjectParamsSchema.safeParse({ id: 'x' }).success).toBe(false);
+  });
+
+  it('getProjectResponseSchema', () => {
+    expect(getProjectResponseSchema.parse({ data: project }).data.id).toBeTruthy();
+  });
+});

--- a/packages/contracts/src/v1/__tests__/registry.test.ts
+++ b/packages/contracts/src/v1/__tests__/registry.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  listMcpsQuerySchema,
+  listMcpsResponseSchema,
+  listSkillsQuerySchema,
+  listSkillsResponseSchema,
+  mcpRegistryEntrySchema,
+  skillSchema,
+} from '../registry.js';
+
+const skill = {
+  id: '00000000-0000-0000-0000-000000000050',
+  name: 'code-review',
+  description: 'reviews diffs',
+  sourceType: 'registry' as const,
+  sourceUrl: null,
+  category: 'engineering',
+  tags: ['review', 'code'],
+  visibility: 'public' as const,
+  latestVersion: '1.0.0',
+  starCount: 12,
+  installCount: 100,
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+const mcp = {
+  id: '00000000-0000-0000-0000-000000000060',
+  name: 'github',
+  displayName: 'GitHub',
+  description: 'github tools',
+  transportType: 'http' as const,
+  tools: [],
+  tags: [],
+  category: 'developer-tools',
+  author: 'foo',
+  docUrl: 'https://example.com/doc',
+  repoUrl: 'https://github.com/x/y',
+  starCount: 5,
+  isBuiltin: false,
+  visibility: 'public' as const,
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+describe('skillSchema', () => {
+  it('round-trips valid skill', () => {
+    expect(skillSchema.parse(skill).name).toBe('code-review');
+  });
+
+  it('rejects negative counts', () => {
+    expect(skillSchema.safeParse({ ...skill, starCount: -1 }).success).toBe(false);
+    expect(skillSchema.safeParse({ ...skill, installCount: -1 }).success).toBe(false);
+  });
+
+  it('rejects invalid visibility', () => {
+    expect(skillSchema.safeParse({ ...skill, visibility: 'secret' }).success).toBe(false);
+  });
+
+  it('accepts sourceType inline with null sourceUrl', () => {
+    expect(skillSchema.parse({ ...skill, sourceType: 'inline', sourceUrl: null }).sourceType).toBe(
+      'inline'
+    );
+  });
+});
+
+describe('listSkillsQuerySchema', () => {
+  it('default pagination', () => {
+    expect(listSkillsQuerySchema.parse({})).toMatchObject({ limit: 50 });
+  });
+
+  it('accepts q / category / visibility filters', () => {
+    expect(
+      listSkillsQuerySchema.parse({ q: 'code', category: 'eng', visibility: 'public' })
+    ).toMatchObject({ q: 'code', category: 'eng', visibility: 'public' });
+  });
+});
+
+describe('listSkillsResponseSchema', () => {
+  it('paginated envelope', () => {
+    expect(listSkillsResponseSchema.parse({ data: [skill], nextCursor: 'c' }).data).toHaveLength(1);
+  });
+});
+
+describe('mcpRegistryEntrySchema', () => {
+  it('round-trips valid mcp', () => {
+    expect(mcpRegistryEntrySchema.parse(mcp).transportType).toBe('http');
+  });
+
+  it('rejects invalid transportType', () => {
+    expect(mcpRegistryEntrySchema.safeParse({ ...mcp, transportType: 'ws' }).success).toBe(false);
+  });
+
+  it('accepts null docUrl / repoUrl / category / author', () => {
+    expect(
+      mcpRegistryEntrySchema.parse({
+        ...mcp,
+        docUrl: null,
+        repoUrl: null,
+        category: null,
+        author: null,
+      }).author
+    ).toBeNull();
+  });
+});
+
+describe('listMcpsQuerySchema + listMcpsResponseSchema', () => {
+  it('supports transportType filter', () => {
+    expect(listMcpsQuerySchema.parse({ transportType: 'stdio' }).transportType).toBe('stdio');
+  });
+
+  it('response paginated shape', () => {
+    expect(listMcpsResponseSchema.parse({ data: [mcp], nextCursor: null }).data).toHaveLength(1);
+  });
+});

--- a/packages/contracts/src/v1/__tests__/runs.test.ts
+++ b/packages/contracts/src/v1/__tests__/runs.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cancelRunResponseSchema,
+  createRunRequestSchema,
+  createRunResponseSchema,
+  getRunParamsSchema,
+  idempotencyKeyHeaderSchema,
+  lastEventIdHeaderSchema,
+  listRunsQuerySchema,
+  openrushExtensionPartSchema,
+  openrushRunDonePartSchema,
+  openrushRunStartedPartSchema,
+  runEventPayloadSchema,
+  runEventSseFrameSchema,
+  runSchema,
+} from '../runs.js';
+
+const run = {
+  id: '00000000-0000-0000-0000-000000000030',
+  agentId: '00000000-0000-0000-0000-000000000010',
+  taskId: '00000000-0000-0000-0000-000000000020',
+  conversationId: null,
+  parentRunId: null,
+  status: 'running' as const,
+  prompt: 'hi',
+  provider: 'claude-code',
+  connectionMode: 'anthropic' as const,
+  modelId: null,
+  triggerSource: 'user' as const,
+  agentDefinitionVersion: 2,
+  retryCount: 0,
+  maxRetries: 3,
+  errorMessage: null,
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+  startedAt: null,
+  completedAt: null,
+};
+
+describe('createRunRequestSchema', () => {
+  it('accepts minimal body', () => {
+    expect(createRunRequestSchema.parse({ input: 'hello' }).input).toBe('hello');
+  });
+
+  it('rejects empty input', () => {
+    expect(createRunRequestSchema.safeParse({ input: '' }).success).toBe(false);
+  });
+
+  it('accepts attachments with optional fields', () => {
+    expect(
+      createRunRequestSchema.parse({
+        input: 'go',
+        attachments: [{ name: 'a.txt' }, { name: 'b.png', url: 'https://x/y.png' }],
+      }).attachments?.length
+    ).toBe(2);
+  });
+
+  it('rejects attachment with invalid URL', () => {
+    expect(
+      createRunRequestSchema.safeParse({
+        input: 'go',
+        attachments: [{ name: 'a', url: 'not-a-url' }],
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('idempotencyKeyHeaderSchema', () => {
+  it('accepts URL-safe ASCII keys', () => {
+    expect(idempotencyKeyHeaderSchema.parse('abc-123_XYZ')).toBe('abc-123_XYZ');
+  });
+
+  it('accepts UUIDs', () => {
+    expect(idempotencyKeyHeaderSchema.parse('00000000-0000-0000-0000-000000000001')).toContain(
+      '00000000'
+    );
+  });
+
+  it('rejects keys with spaces / special chars', () => {
+    expect(idempotencyKeyHeaderSchema.safeParse('has space').success).toBe(false);
+    expect(idempotencyKeyHeaderSchema.safeParse('a/b').success).toBe(false);
+  });
+
+  it('rejects > 255 chars', () => {
+    expect(idempotencyKeyHeaderSchema.safeParse('a'.repeat(256)).success).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(idempotencyKeyHeaderSchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('lastEventIdHeaderSchema', () => {
+  it('coerces string to int ≥ 0', () => {
+    expect(lastEventIdHeaderSchema.parse('42')).toBe(42);
+    expect(lastEventIdHeaderSchema.parse('0')).toBe(0);
+  });
+
+  it('rejects negatives', () => {
+    expect(lastEventIdHeaderSchema.safeParse('-1').success).toBe(false);
+  });
+
+  it('rejects non-integers', () => {
+    expect(lastEventIdHeaderSchema.safeParse('1.5').success).toBe(false);
+  });
+});
+
+describe('runSchema', () => {
+  it('round-trips a valid entity', () => {
+    expect(runSchema.parse(run).status).toBe('running');
+  });
+
+  it('accepts nullable agentDefinitionVersion (migration-compat)', () => {
+    expect(
+      runSchema.parse({ ...run, agentDefinitionVersion: null }).agentDefinitionVersion
+    ).toBeNull();
+  });
+
+  it('rejects status "purple"', () => {
+    expect(runSchema.safeParse({ ...run, status: 'purple' }).success).toBe(false);
+  });
+});
+
+describe('createRunResponseSchema + listRunsQuerySchema + cancel/get', () => {
+  it('createRunResponseSchema wraps a run', () => {
+    expect(createRunResponseSchema.parse({ data: run }).data.id).toBeTruthy();
+  });
+
+  it('listRunsQuerySchema accepts status filter', () => {
+    expect(listRunsQuerySchema.parse({ status: 'running' }).status).toBe('running');
+  });
+
+  it('getRunParamsSchema requires both ids', () => {
+    expect(
+      getRunParamsSchema.parse({
+        id: '00000000-0000-0000-0000-000000000010',
+        runId: '00000000-0000-0000-0000-000000000030',
+      })
+    ).toMatchObject({ id: expect.any(String) });
+    expect(
+      getRunParamsSchema.safeParse({ id: '00000000-0000-0000-0000-000000000010' }).success
+    ).toBe(false);
+  });
+
+  it('cancelRunResponseSchema returns the run', () => {
+    expect(cancelRunResponseSchema.parse({ data: run }).data.id).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event payload + SSE frame
+// ---------------------------------------------------------------------------
+
+describe('Open-rush extension event parts', () => {
+  it('openrushRunStartedPartSchema accepts valid payload', () => {
+    expect(
+      openrushRunStartedPartSchema.parse({
+        type: 'data-openrush-run-started',
+        data: {
+          runId: '00000000-0000-0000-0000-000000000030',
+          agentId: '00000000-0000-0000-0000-000000000010',
+          definitionVersion: 2,
+        },
+      }).type
+    ).toBe('data-openrush-run-started');
+  });
+
+  it('openrushRunDonePartSchema enforces status enum', () => {
+    expect(
+      openrushRunDonePartSchema.safeParse({
+        type: 'data-openrush-run-done',
+        data: { status: 'mysterious' },
+      }).success
+    ).toBe(false);
+    expect(
+      openrushRunDonePartSchema.parse({
+        type: 'data-openrush-run-done',
+        data: { status: 'cancelled' },
+      }).data.status
+    ).toBe('cancelled');
+  });
+
+  it('openrushExtensionPartSchema discriminates by type', () => {
+    const parsed = openrushExtensionPartSchema.parse({
+      type: 'data-openrush-usage',
+      data: { tokensIn: 10, tokensOut: 5, costUsd: 0.01 },
+    });
+    expect(parsed.type).toBe('data-openrush-usage');
+  });
+});
+
+describe('runEventPayloadSchema accepts all UIMessageChunk variants', () => {
+  // The runtime emits AI SDK UIMessageChunk (streaming format), not the
+  // higher-level UIMessagePart. Tests align with enums.ts → UIMessageChunkType
+  // and the reconstruct-messages consumer.
+
+  it('text-delta chunk', () => {
+    expect(runEventPayloadSchema.parse({ type: 'text-delta', id: 'm1', delta: 'hi' }).type).toBe(
+      'text-delta'
+    );
+  });
+
+  it('text-start / text-end chunks', () => {
+    expect(runEventPayloadSchema.parse({ type: 'text-start', id: 'm1' }).type).toBe('text-start');
+    expect(runEventPayloadSchema.parse({ type: 'text-end', id: 'm1' }).type).toBe('text-end');
+  });
+
+  it('reasoning chunks', () => {
+    for (const t of ['reasoning-start', 'reasoning-delta', 'reasoning-end']) {
+      expect(runEventPayloadSchema.parse({ type: t, id: 'r1' }).type).toBe(t);
+    }
+  });
+
+  it('tool-input-delta incremental input stream', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'tool-input-delta',
+        toolCallId: 'call_1',
+        delta: '{"pa',
+      }).type
+    ).toBe('tool-input-delta');
+  });
+
+  it('tool-input-start with toolName', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'tool-input-start',
+        toolCallId: 'call_1',
+        toolName: 'Read',
+      }).type
+    ).toBe('tool-input-start');
+  });
+
+  it('tool-input-available with input blob', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'tool-input-available',
+        toolCallId: 'call_1',
+        toolName: 'Read',
+        input: { path: '/tmp/x' },
+      }).type
+    ).toBe('tool-input-available');
+  });
+
+  it('tool-output-available with output blob', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'tool-output-available',
+        toolCallId: 'call_1',
+        output: 'file contents',
+      }).type
+    ).toBe('tool-output-available');
+  });
+
+  it('tool-output-error with errorText', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'tool-output-error',
+        toolCallId: 'call_1',
+        errorText: 'boom',
+      }).type
+    ).toBe('tool-output-error');
+  });
+
+  it('start / finish / error / start-step / finish-step', () => {
+    expect(runEventPayloadSchema.parse({ type: 'start', messageId: 'm1' }).type).toBe('start');
+    expect(runEventPayloadSchema.parse({ type: 'finish', reason: 'stop' }).type).toBe('finish');
+    expect(runEventPayloadSchema.parse({ type: 'error', errorText: 'x' }).type).toBe('error');
+    expect(runEventPayloadSchema.parse({ type: 'start-step' }).type).toBe('start-step');
+    expect(runEventPayloadSchema.parse({ type: 'finish-step', reason: 'stop' }).type).toBe(
+      'finish-step'
+    );
+  });
+
+  it('data-* generic chunk', () => {
+    expect(
+      runEventPayloadSchema.parse({
+        type: 'data-custom-key',
+        id: 'x',
+        data: { anything: true },
+      }).type
+    ).toBe('data-custom-key');
+  });
+
+  it('rejects a generic data-* using the reserved data-openrush-* prefix', () => {
+    expect(
+      runEventPayloadSchema.safeParse({
+        type: 'data-openrush-unknown',
+        data: { anything: true },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unknown chunk type', () => {
+    expect(runEventPayloadSchema.safeParse({ type: 'step-finish' }).success).toBe(false);
+    expect(runEventPayloadSchema.safeParse({ type: 'tool-call', toolCallId: 'x' }).success).toBe(
+      false
+    );
+  });
+});
+
+describe('runEventSseFrameSchema', () => {
+  it('accepts a valid frame (id >= 1, data = chunk payload)', () => {
+    expect(
+      runEventSseFrameSchema.parse({
+        id: 1,
+        data: { type: 'text-delta', id: 'm1', delta: 'x' },
+      }).id
+    ).toBe(1);
+  });
+
+  it('rejects id < 1 (seq starts at 1 per spec)', () => {
+    expect(runEventSseFrameSchema.safeParse({ id: 0, data: { type: 'start-step' } }).success).toBe(
+      false
+    );
+  });
+});

--- a/packages/contracts/src/v1/__tests__/vaults.test.ts
+++ b/packages/contracts/src/v1/__tests__/vaults.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createVaultEntryRequestSchema,
+  createVaultEntryResponseSchema,
+  deleteVaultEntryParamsSchema,
+  listVaultEntriesQuerySchema,
+  listVaultEntriesResponseSchema,
+  vaultEntrySchema,
+} from '../vaults.js';
+
+const entry = {
+  id: '00000000-0000-0000-0000-000000000040',
+  scope: 'project' as const,
+  projectId: '00000000-0000-0000-0000-000000000002',
+  ownerId: '00000000-0000-0000-0000-000000000001',
+  name: 'ANTHROPIC_API_KEY',
+  credentialType: 'anthropic_api' as const,
+  keyVersion: 1,
+  injectionTarget: 'ANTHROPIC_API_KEY',
+  createdAt: '2026-04-25T00:00:00Z',
+  updatedAt: '2026-04-25T00:00:00Z',
+};
+
+describe('createVaultEntryRequestSchema', () => {
+  it('accepts valid project-scope entry', () => {
+    expect(
+      createVaultEntryRequestSchema.parse({
+        scope: 'project',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        name: 'K',
+        credentialType: 'env_var',
+        value: 'plaintext',
+      }).scope
+    ).toBe('project');
+  });
+
+  it('accepts valid platform-scope entry with no projectId', () => {
+    expect(
+      createVaultEntryRequestSchema.parse({
+        scope: 'platform',
+        name: 'GLOBAL_KEY',
+        credentialType: 'env_var',
+        value: 'x',
+      }).scope
+    ).toBe('platform');
+  });
+
+  it('rejects project-scope with no projectId', () => {
+    expect(
+      createVaultEntryRequestSchema.safeParse({
+        scope: 'project',
+        name: 'K',
+        credentialType: 'env_var',
+        value: 'x',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects platform-scope with projectId set', () => {
+    expect(
+      createVaultEntryRequestSchema.safeParse({
+        scope: 'platform',
+        projectId: '00000000-0000-0000-0000-000000000002',
+        name: 'K',
+        credentialType: 'env_var',
+        value: 'x',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects empty value', () => {
+    expect(
+      createVaultEntryRequestSchema.safeParse({
+        scope: 'platform',
+        name: 'K',
+        credentialType: 'env_var',
+        value: '',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects unknown credentialType', () => {
+    expect(
+      createVaultEntryRequestSchema.safeParse({
+        scope: 'platform',
+        name: 'K',
+        credentialType: 'exotic',
+        value: 'x',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('vaultEntrySchema (response)', () => {
+  it('accepts full row', () => {
+    expect(vaultEntrySchema.parse(entry).credentialType).toBe('anthropic_api');
+  });
+
+  it('DOES NOT include encryptedValue even when someone sends it', () => {
+    // Zod strips unknown keys in default parse mode.
+    const withExtra = { ...entry, encryptedValue: 'enc:x' };
+    const parsed = vaultEntrySchema.parse(withExtra);
+    expect((parsed as Record<string, unknown>).encryptedValue).toBeUndefined();
+  });
+
+  it('accepts null injectionTarget / projectId / ownerId', () => {
+    expect(
+      vaultEntrySchema.parse({
+        ...entry,
+        projectId: null,
+        ownerId: null,
+        injectionTarget: null,
+        scope: 'platform',
+      }).injectionTarget
+    ).toBeNull();
+  });
+});
+
+describe('envelope schemas', () => {
+  it('createVaultEntryResponseSchema wraps a single entry', () => {
+    expect(createVaultEntryResponseSchema.parse({ data: entry }).data.id).toBeTruthy();
+  });
+
+  it('listVaultEntriesResponseSchema paginated shape', () => {
+    expect(
+      listVaultEntriesResponseSchema.parse({ data: [entry], nextCursor: null }).data
+    ).toHaveLength(1);
+  });
+
+  it('listVaultEntriesQuerySchema accepts scope + projectId', () => {
+    expect(
+      listVaultEntriesQuerySchema.parse({
+        scope: 'platform',
+      }).scope
+    ).toBe('platform');
+  });
+
+  it('deleteVaultEntryParamsSchema requires UUID', () => {
+    expect(deleteVaultEntryParamsSchema.safeParse({ id: 'x' }).success).toBe(false);
+    expect(
+      deleteVaultEntryParamsSchema.parse({ id: '00000000-0000-0000-0000-000000000040' }).id
+    ).toBeTruthy();
+  });
+});

--- a/packages/contracts/src/v1/agent-definitions.ts
+++ b/packages/contracts/src/v1/agent-definitions.ts
@@ -1,0 +1,174 @@
+/**
+ * /api/v1/agent-definitions — AgentDefinition versioned CRUD contracts.
+ *
+ * Endpoints (6):
+ * - POST   /api/v1/agent-definitions
+ * - GET    /api/v1/agent-definitions
+ * - GET    /api/v1/agent-definitions/:id          (?version=N for historical)
+ * - PATCH  /api/v1/agent-definitions/:id          (If-Match header required)
+ * - GET    /api/v1/agent-definitions/:id/versions (list history, no snapshot)
+ * - POST   /api/v1/agent-definitions/:id/archive
+ *
+ * See specs/agent-definition-versioning.md §API 语义.
+ */
+import { z } from 'zod';
+import { AgentDeliveryMode } from '../enums.js';
+import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// Shared shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Editable AgentDefinition fields — the set that a PATCH body may touch.
+ * Notably excludes id/projectId (immutable), currentVersion/archivedAt (bookkeeping),
+ * and runtime-state columns (activeStreamId, lastActiveAt).
+ */
+export const agentDefinitionEditableSchema = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().nullable().optional(),
+  icon: z.string().max(50).nullable().optional(),
+  providerType: z.string().min(1).max(50),
+  model: z.string().max(255).nullable().optional(),
+  systemPrompt: z.string().nullable().optional(),
+  appendSystemPrompt: z.string().nullable().optional(),
+  allowedTools: z.array(z.string()),
+  skills: z.array(z.string()),
+  mcpServers: z.array(z.string()),
+  maxSteps: z.number().int().min(1).max(1000),
+  deliveryMode: AgentDeliveryMode,
+  /** Arbitrary provider-specific config blob. */
+  config: z.record(z.string(), z.unknown()).nullable().optional(),
+});
+export type AgentDefinitionEditable = z.infer<typeof agentDefinitionEditableSchema>;
+
+/**
+ * Full AgentDefinition entity as returned by GET endpoints.
+ */
+export const agentDefinitionSchema = agentDefinitionEditableSchema.extend({
+  id: z.string().uuid(),
+  projectId: z.string().uuid(),
+  currentVersion: z.number().int().positive(),
+  archivedAt: z.string().datetime({ offset: true }).nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type AgentDefinition = z.infer<typeof agentDefinitionSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agent-definitions
+// ---------------------------------------------------------------------------
+
+export const createAgentDefinitionRequestSchema = agentDefinitionEditableSchema.extend({
+  projectId: z.string().uuid(),
+  /** Optional change note recorded in the first version row. */
+  changeNote: z.string().max(1000).optional(),
+});
+export type CreateAgentDefinitionRequest = z.infer<typeof createAgentDefinitionRequestSchema>;
+
+export const createAgentDefinitionResponseSchema = successResponseSchema(agentDefinitionSchema);
+export type CreateAgentDefinitionResponse = z.infer<typeof createAgentDefinitionResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agent-definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Boolean-from-string helper for query params. Does NOT use `z.coerce.boolean`
+ * because that falls back to JS `Boolean(value)` semantics — the string
+ * `"false"` is truthy there, which would silently flip the filter. We accept
+ * the canonical URL-query forms `"true" | "false"` + bare booleans only.
+ */
+const queryBoolean = z
+  .union([z.literal('true'), z.literal('false'), z.boolean()])
+  .transform((v) => v === true || v === 'true');
+
+export const listAgentDefinitionsQuerySchema = paginationQuerySchema.extend({
+  projectId: z.string().uuid().optional(),
+  /** Include archived definitions in results (default false). */
+  includeArchived: queryBoolean.default(false),
+});
+export type ListAgentDefinitionsQuery = z.infer<typeof listAgentDefinitionsQuerySchema>;
+
+export const listAgentDefinitionsResponseSchema = paginatedResponseSchema(agentDefinitionSchema);
+export type ListAgentDefinitionsResponse = z.infer<typeof listAgentDefinitionsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agent-definitions/:id  (default: current; ?version=N: historical)
+// ---------------------------------------------------------------------------
+
+export const getAgentDefinitionParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type GetAgentDefinitionParams = z.infer<typeof getAgentDefinitionParamsSchema>;
+
+export const getAgentDefinitionQuerySchema = z.object({
+  version: z.coerce.number().int().positive().optional(),
+});
+export type GetAgentDefinitionQuery = z.infer<typeof getAgentDefinitionQuerySchema>;
+
+export const getAgentDefinitionResponseSchema = successResponseSchema(agentDefinitionSchema);
+export type GetAgentDefinitionResponse = z.infer<typeof getAgentDefinitionResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// PATCH /api/v1/agent-definitions/:id   (If-Match header REQUIRED)
+// ---------------------------------------------------------------------------
+
+/**
+ * The PATCH body is a partial of the editable fields plus an optional
+ * change note. Empty body is rejected by the API layer (no-op PATCH).
+ *
+ * The `If-Match: <current_version>` header is validated by the route
+ * handler against `agents.current_version`; mismatch → 409 VERSION_CONFLICT.
+ */
+export const patchAgentDefinitionRequestSchema = agentDefinitionEditableSchema
+  .partial()
+  .extend({
+    changeNote: z.string().max(1000).optional(),
+  })
+  .refine((v) => Object.keys(v).some((k) => k !== 'changeNote'), {
+    message: 'PATCH must modify at least one editable field',
+  });
+export type PatchAgentDefinitionRequest = z.infer<typeof patchAgentDefinitionRequestSchema>;
+
+/** Number from the `If-Match` header. */
+export const ifMatchHeaderSchema = z.coerce.number().int().positive();
+export type IfMatchHeader = z.infer<typeof ifMatchHeaderSchema>;
+
+export const patchAgentDefinitionResponseSchema = successResponseSchema(agentDefinitionSchema);
+export type PatchAgentDefinitionResponse = z.infer<typeof patchAgentDefinitionResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agent-definitions/:id/versions
+// ---------------------------------------------------------------------------
+
+/**
+ * Version history row — does NOT contain the full snapshot (payload),
+ * to keep the list response lightweight.
+ */
+export const agentDefinitionVersionSummarySchema = z.object({
+  version: z.number().int().positive(),
+  changeNote: z.string().nullable(),
+  createdBy: z.string().uuid().nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+export type AgentDefinitionVersionSummary = z.infer<typeof agentDefinitionVersionSummarySchema>;
+
+export const listAgentDefinitionVersionsResponseSchema = paginatedResponseSchema(
+  agentDefinitionVersionSummarySchema
+);
+export type ListAgentDefinitionVersionsResponse = z.infer<
+  typeof listAgentDefinitionVersionsResponseSchema
+>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agent-definitions/:id/archive
+// ---------------------------------------------------------------------------
+
+export const archiveAgentDefinitionResponseSchema = successResponseSchema(
+  z.object({
+    id: z.string().uuid(),
+    archivedAt: z.string().datetime({ offset: true }),
+  })
+);
+export type ArchiveAgentDefinitionResponse = z.infer<typeof archiveAgentDefinitionResponseSchema>;

--- a/packages/contracts/src/v1/agents.ts
+++ b/packages/contracts/src/v1/agents.ts
@@ -1,0 +1,119 @@
+/**
+ * /api/v1/agents — Agent (= database `tasks` row) CRUD contracts.
+ *
+ * Endpoints (4):
+ * - POST   /api/v1/agents
+ * - GET    /api/v1/agents
+ * - GET    /api/v1/agents/:id
+ * - DELETE /api/v1/agents/:id
+ *
+ * Naming note: API-layer "Agent" = DB table `tasks`. AgentDefinition is
+ * stored in `agents` table (historical). Do not confuse.
+ */
+import { z } from 'zod';
+import { AgentDeliveryMode } from '../enums.js';
+import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// Status for API layer (derived from DB `tasks.status` semantics)
+// ---------------------------------------------------------------------------
+
+export const AgentStatus = z.enum(['active', 'completed', 'cancelled']);
+export type AgentStatus = z.infer<typeof AgentStatus>;
+
+// ---------------------------------------------------------------------------
+// Shared shapes
+// ---------------------------------------------------------------------------
+
+export const agentSchema = z.object({
+  id: z.string().uuid(),
+  projectId: z.string().uuid(),
+  definitionId: z.string().uuid(),
+  /** Snapshot version the Agent is bound to. */
+  definitionVersion: z.number().int().positive(),
+  mode: AgentDeliveryMode,
+  status: AgentStatus,
+  title: z.string().nullable(),
+  headRunId: z.string().uuid().nullable(),
+  activeRunId: z.string().uuid().nullable(),
+  createdBy: z.string().uuid().nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type Agent = z.infer<typeof agentSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents  (create Agent + (optionally) first Run)
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new Agent. If `initialInput` is provided, the service-layer
+ * also creates the first Run so the event stream can start immediately.
+ *
+ * - `definitionVersion` is optional; if omitted, service uses the current
+ *   version of the definition and freezes it into `tasks.definition_version`.
+ * - `mode` maps to DB `tasks.delivery_mode` (indirect via definition).
+ */
+export const createAgentRequestSchema = z.object({
+  definitionId: z.string().uuid(),
+  definitionVersion: z.number().int().positive().optional(),
+  projectId: z.string().uuid(),
+  mode: AgentDeliveryMode,
+  title: z.string().max(200).optional(),
+  initialInput: z.string().optional(),
+});
+export type CreateAgentRequest = z.infer<typeof createAgentRequestSchema>;
+
+/**
+ * Optionally includes the first run if one was created synchronously.
+ */
+export const createAgentResponseSchema = successResponseSchema(
+  z.object({
+    agent: agentSchema,
+    firstRunId: z.string().uuid().nullable(),
+  })
+);
+export type CreateAgentResponse = z.infer<typeof createAgentResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents
+// ---------------------------------------------------------------------------
+
+export const listAgentsQuerySchema = paginationQuerySchema.extend({
+  projectId: z.string().uuid().optional(),
+  status: AgentStatus.optional(),
+  definitionId: z.string().uuid().optional(),
+});
+export type ListAgentsQuery = z.infer<typeof listAgentsQuerySchema>;
+
+export const listAgentsResponseSchema = paginatedResponseSchema(agentSchema);
+export type ListAgentsResponse = z.infer<typeof listAgentsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id
+// ---------------------------------------------------------------------------
+
+export const getAgentParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type GetAgentParams = z.infer<typeof getAgentParamsSchema>;
+
+export const getAgentResponseSchema = successResponseSchema(agentSchema);
+export type GetAgentResponse = z.infer<typeof getAgentResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/agents/:id  (soft cancel)
+// ---------------------------------------------------------------------------
+
+/**
+ * DELETE semantics: status → 'cancelled', any active run is also cancelled.
+ * Rows remain for audit.
+ */
+export const deleteAgentResponseSchema = successResponseSchema(
+  z.object({
+    id: z.string().uuid(),
+    status: z.literal('cancelled'),
+    cancelledRunId: z.string().uuid().nullable(),
+  })
+);
+export type DeleteAgentResponse = z.infer<typeof deleteAgentResponseSchema>;

--- a/packages/contracts/src/v1/auth.ts
+++ b/packages/contracts/src/v1/auth.ts
@@ -1,0 +1,122 @@
+/**
+ * /api/v1/auth/tokens — Service Token CRUD contracts.
+ *
+ * Endpoints:
+ * - POST   /api/v1/auth/tokens        (session-only, returns plaintext ONCE)
+ * - GET    /api/v1/auth/tokens        (list own tokens, no plaintext)
+ * - DELETE /api/v1/auth/tokens/:id    (soft revoke)
+ *
+ * See specs/service-token-auth.md §颁发流程 §v0.1 护栏 §吊销.
+ */
+import { z } from 'zod';
+import { paginatedResponseSchema, ServiceTokenScope, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/auth/tokens
+// ---------------------------------------------------------------------------
+
+/** Maximum allowed distance between `now()` and `expiresAt`. */
+export const SERVICE_TOKEN_MAX_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+/**
+ * Service Token creation guardrails (v0.1, per spec §颁发流程 §v0.1 护栏):
+ * - `scopes` must NOT contain `'*'` (enforced by `ServiceTokenScope` enum).
+ * - `scopes` must be non-empty.
+ * - `expiresAt` is REQUIRED, must be ≤ now() + 90 days, and strictly in the
+ *   future (rejects expiresAt already in the past).
+ * - Per-user active token cap (20) is enforced in the service layer, not here.
+ *
+ * The TTL cap is enforced here at the schema layer (not just in the service
+ * layer) so that consumers — SDK, CLI, other language bindings — see the
+ * same error shape (`VALIDATION_ERROR`) consistently, without relying on
+ * each handler to re-check.
+ */
+export const createTokenRequestSchema = z
+  .object({
+    name: z.string().min(1).max(255),
+    scopes: z.array(ServiceTokenScope).min(1),
+    expiresAt: z.string().datetime({ offset: true }),
+  })
+  .superRefine((val, ctx) => {
+    const parsed = new Date(val.expiresAt).getTime();
+    if (Number.isNaN(parsed)) {
+      // Already caught by the datetime() check above, but defensive.
+      return;
+    }
+    const now = Date.now();
+    if (parsed <= now) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expiresAt'],
+        message: 'expiresAt must be strictly in the future',
+      });
+    } else if (parsed - now > SERVICE_TOKEN_MAX_TTL_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['expiresAt'],
+        message: 'expiresAt must be within 90 days of now',
+      });
+    }
+  });
+export type CreateTokenRequest = z.infer<typeof createTokenRequestSchema>;
+
+/**
+ * Response body includes the plaintext `token` value — exposed ONLY on
+ * create. All subsequent reads (GET) omit the `token` field.
+ */
+export const createdTokenSchema = z.object({
+  id: z.string().uuid(),
+  token: z.string().regex(/^sk_[A-Za-z0-9_-]+$/),
+  name: z.string(),
+  scopes: z.array(ServiceTokenScope),
+  createdAt: z.string().datetime({ offset: true }),
+  expiresAt: z.string().datetime({ offset: true }),
+});
+export type CreatedToken = z.infer<typeof createdTokenSchema>;
+
+export const createTokenResponseSchema = successResponseSchema(createdTokenSchema);
+export type CreateTokenResponse = z.infer<typeof createTokenResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/auth/tokens
+// ---------------------------------------------------------------------------
+
+/**
+ * List row shape — crucially DOES NOT include the plaintext `token`.
+ * `lastUsedAt` is null until the token is first used.
+ */
+export const tokenListItemSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  scopes: z.array(ServiceTokenScope),
+  createdAt: z.string().datetime({ offset: true }),
+  expiresAt: z.string().datetime({ offset: true }).nullable(),
+  lastUsedAt: z.string().datetime({ offset: true }).nullable(),
+  revokedAt: z.string().datetime({ offset: true }).nullable(),
+});
+export type TokenListItem = z.infer<typeof tokenListItemSchema>;
+
+export const listTokensResponseSchema = paginatedResponseSchema(tokenListItemSchema);
+export type ListTokensResponse = z.infer<typeof listTokensResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/auth/tokens/:id
+// ---------------------------------------------------------------------------
+
+export const deleteTokenParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type DeleteTokenParams = z.infer<typeof deleteTokenParamsSchema>;
+
+/**
+ * Soft-delete: the token row is retained (revoked_at is set) for audit,
+ * and the response echoes the revocation timestamp.
+ */
+export const deletedTokenSchema = z.object({
+  id: z.string().uuid(),
+  revokedAt: z.string().datetime({ offset: true }),
+});
+export type DeletedToken = z.infer<typeof deletedTokenSchema>;
+
+export const deleteTokenResponseSchema = successResponseSchema(deletedTokenSchema);
+export type DeleteTokenResponse = z.infer<typeof deleteTokenResponseSchema>;

--- a/packages/contracts/src/v1/common.ts
+++ b/packages/contracts/src/v1/common.ts
@@ -1,0 +1,126 @@
+/**
+ * Shared v1 contracts: error envelope, pagination, success envelope, scope enum.
+ *
+ * See:
+ * - specs/managed-agents-api.md §请求/响应格式, §错误码, §分页
+ * - specs/service-token-auth.md §Scope 定义
+ */
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Error codes (all 8, per specs/managed-agents-api.md §错误码)
+// ---------------------------------------------------------------------------
+
+export const ErrorCode = z.enum([
+  'UNAUTHORIZED',
+  'FORBIDDEN',
+  'NOT_FOUND',
+  'VALIDATION_ERROR',
+  'VERSION_CONFLICT',
+  'IDEMPOTENCY_CONFLICT',
+  'RATE_LIMITED',
+  'INTERNAL',
+]);
+export type ErrorCode = z.infer<typeof ErrorCode>;
+
+/** HTTP status codes paired with each error code (non-enum companion). */
+export const ERROR_CODE_HTTP_STATUS: Record<ErrorCode, number> = {
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  VALIDATION_ERROR: 400,
+  VERSION_CONFLICT: 409,
+  IDEMPOTENCY_CONFLICT: 409,
+  RATE_LIMITED: 429,
+  INTERNAL: 500,
+};
+
+export const errorBodySchema = z.object({
+  code: ErrorCode,
+  message: z.string().min(1),
+  hint: z.string().optional(),
+  /** Optional per-field validation issues (used by VALIDATION_ERROR). */
+  issues: z
+    .array(
+      z.object({
+        path: z.array(z.union([z.string(), z.number()])),
+        message: z.string(),
+      })
+    )
+    .optional(),
+});
+export type ErrorBody = z.infer<typeof errorBodySchema>;
+
+export const errorResponseSchema = z.object({
+  error: errorBodySchema,
+});
+export type ErrorResponse = z.infer<typeof errorResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Success envelope (generic, per spec)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a success envelope schema for a given data shape.
+ * Example: `successResponseSchema(userSchema)` → `z.object({ data: userSchema })`.
+ */
+export function successResponseSchema<T extends z.ZodTypeAny>(data: T) {
+  return z.object({ data });
+}
+
+// ---------------------------------------------------------------------------
+// Pagination (per spec §分页)
+// ---------------------------------------------------------------------------
+
+export const paginationQuerySchema = z.object({
+  /** 1..200, default 50. Opaque cursor can be used to resume. */
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  cursor: z.string().optional(),
+});
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;
+
+/**
+ * Build a paginated response envelope: `{ data: T[]; nextCursor: string | null }`.
+ */
+export function paginatedResponseSchema<T extends z.ZodTypeAny>(item: T) {
+  return z.object({
+    data: z.array(item),
+    nextCursor: z.string().nullable(),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Scopes (per specs/service-token-auth.md §Scope 定义)
+// ---------------------------------------------------------------------------
+
+/**
+ * Scopes allowed for Service Tokens.
+ *
+ * Service Tokens MUST use one of these exact values. The `'*'` wildcard is
+ * intentionally NOT in this enum — only NextAuth sessions get `'*'`; the
+ * Service Token POST endpoint rejects `'*'` in the scopes array with 400.
+ */
+export const ServiceTokenScope = z.enum([
+  'agent-definitions:read',
+  'agent-definitions:write',
+  'agents:read',
+  'agents:write',
+  'runs:read',
+  'runs:write',
+  'runs:cancel',
+  'vaults:read',
+  'vaults:write',
+  'projects:read',
+  'projects:write',
+]);
+export type ServiceTokenScope = z.infer<typeof ServiceTokenScope>;
+
+/**
+ * Runtime scope value as carried by AuthContext.
+ *
+ * Session auth gets `['*']`; Service Token auth gets an explicit subset of
+ * {@link ServiceTokenScope}. `authScopeSchema` is the union used by the
+ * middleware's own internal contract.
+ */
+export const AuthScope = z.union([ServiceTokenScope, z.literal('*')]);
+export type AuthScope = z.infer<typeof AuthScope>;

--- a/packages/contracts/src/v1/index.ts
+++ b/packages/contracts/src/v1/index.ts
@@ -1,0 +1,16 @@
+/**
+ * `@open-rush/contracts` v1 barrel.
+ *
+ * All Zod schemas + inferred TS types backing the `/api/v1/*` stable contract.
+ * External callers (SDK, agent-worker, control-plane, web routes) import from
+ * `@open-rush/contracts` and reach these via the top-level `v1` namespace or
+ * individually re-exported names — see root `src/index.ts`.
+ */
+export * from './agent-definitions.js';
+export * from './agents.js';
+export * from './auth.js';
+export * from './common.js';
+export * from './projects.js';
+export * from './registry.js';
+export * from './runs.js';
+export * from './vaults.js';

--- a/packages/contracts/src/v1/projects.ts
+++ b/packages/contracts/src/v1/projects.ts
@@ -1,0 +1,71 @@
+/**
+ * /api/v1/projects — Project minimal CRUD contracts.
+ *
+ * Endpoints (3):
+ * - POST /api/v1/projects
+ * - GET  /api/v1/projects
+ * - GET  /api/v1/projects/:id
+ */
+import { z } from 'zod';
+import { ConnectionMode } from '../enums.js';
+import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// Project entity
+// ---------------------------------------------------------------------------
+
+export const SandboxProviderId = z.enum(['opensandbox', 'e2b', 'docker', 'custom']);
+export type SandboxProviderId = z.infer<typeof SandboxProviderId>;
+
+export const projectSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  sandboxProvider: SandboxProviderId,
+  defaultModel: z.string().nullable(),
+  defaultConnectionMode: ConnectionMode.nullable(),
+  createdBy: z.string().uuid().nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type Project = z.infer<typeof projectSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/projects
+// ---------------------------------------------------------------------------
+
+export const createProjectRequestSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(2000).optional(),
+  sandboxProvider: SandboxProviderId.default('opensandbox'),
+  defaultModel: z.string().optional(),
+  defaultConnectionMode: ConnectionMode.optional(),
+});
+export type CreateProjectRequest = z.infer<typeof createProjectRequestSchema>;
+
+export const createProjectResponseSchema = successResponseSchema(projectSchema);
+export type CreateProjectResponse = z.infer<typeof createProjectResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/projects
+// ---------------------------------------------------------------------------
+
+export const listProjectsQuerySchema = paginationQuerySchema.extend({
+  q: z.string().optional(),
+});
+export type ListProjectsQuery = z.infer<typeof listProjectsQuerySchema>;
+
+export const listProjectsResponseSchema = paginatedResponseSchema(projectSchema);
+export type ListProjectsResponse = z.infer<typeof listProjectsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/projects/:id
+// ---------------------------------------------------------------------------
+
+export const getProjectParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type GetProjectParams = z.infer<typeof getProjectParamsSchema>;
+
+export const getProjectResponseSchema = successResponseSchema(projectSchema);
+export type GetProjectResponse = z.infer<typeof getProjectResponseSchema>;

--- a/packages/contracts/src/v1/registry.ts
+++ b/packages/contracts/src/v1/registry.ts
@@ -1,0 +1,83 @@
+/**
+ * /api/v1/skills + /api/v1/mcps — Registry read-only contracts.
+ *
+ * Endpoints (2):
+ * - GET /api/v1/skills
+ * - GET /api/v1/mcps
+ *
+ * Only READ surface is exposed on /api/v1/* — install/star/members stay
+ * in /api/* (UI-private) per specs/managed-agents-api.md §与 Web UI 关系.
+ */
+import { z } from 'zod';
+import { paginatedResponseSchema, paginationQuerySchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// Skill
+// ---------------------------------------------------------------------------
+
+export const SkillVisibility = z.enum(['public', 'private']);
+export type SkillVisibility = z.infer<typeof SkillVisibility>;
+
+export const skillSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string(),
+  sourceType: z.enum(['registry', 'inline']),
+  sourceUrl: z.string().url().nullable(),
+  category: z.string().nullable(),
+  tags: z.array(z.string()),
+  visibility: SkillVisibility,
+  latestVersion: z.string().nullable(),
+  starCount: z.number().int().min(0),
+  installCount: z.number().int().min(0),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type Skill = z.infer<typeof skillSchema>;
+
+export const listSkillsQuerySchema = paginationQuerySchema.extend({
+  q: z.string().optional(),
+  category: z.string().optional(),
+  visibility: SkillVisibility.optional(),
+});
+export type ListSkillsQuery = z.infer<typeof listSkillsQuerySchema>;
+
+export const listSkillsResponseSchema = paginatedResponseSchema(skillSchema);
+export type ListSkillsResponse = z.infer<typeof listSkillsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// MCP
+// ---------------------------------------------------------------------------
+
+export const McpTransport = z.enum(['stdio', 'http', 'sse']);
+export type McpTransport = z.infer<typeof McpTransport>;
+
+export const mcpRegistryEntrySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  displayName: z.string(),
+  description: z.string(),
+  transportType: McpTransport,
+  tools: z.array(z.unknown()),
+  tags: z.array(z.string()),
+  category: z.string().nullable(),
+  author: z.string().nullable(),
+  docUrl: z.string().url().nullable(),
+  repoUrl: z.string().url().nullable(),
+  starCount: z.number().int().min(0),
+  isBuiltin: z.boolean(),
+  visibility: z.enum(['public', 'private']),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type McpRegistryEntry = z.infer<typeof mcpRegistryEntrySchema>;
+
+export const listMcpsQuerySchema = paginationQuerySchema.extend({
+  q: z.string().optional(),
+  category: z.string().optional(),
+  transportType: McpTransport.optional(),
+});
+export type ListMcpsQuery = z.infer<typeof listMcpsQuerySchema>;
+
+export const listMcpsResponseSchema = paginatedResponseSchema(mcpRegistryEntrySchema);
+export type ListMcpsResponse = z.infer<typeof listMcpsResponseSchema>;

--- a/packages/contracts/src/v1/runs.ts
+++ b/packages/contracts/src/v1/runs.ts
@@ -1,0 +1,366 @@
+/**
+ * /api/v1/agents/:id/runs — Run CRUD + SSE event stream contracts.
+ *
+ * Endpoints (5):
+ * - POST   /api/v1/agents/:id/runs                       (Idempotency-Key header)
+ * - GET    /api/v1/agents/:id/runs
+ * - GET    /api/v1/agents/:id/runs/:runId
+ * - GET    /api/v1/agents/:id/runs/:runId/events         (SSE, Last-Event-ID)
+ * - POST   /api/v1/agents/:id/runs/:runId/cancel
+ *
+ * See:
+ * - specs/managed-agents-api.md §幂等性, §事件协议
+ * - specs/agent-definition-versioning.md §runs 表
+ */
+import { z } from 'zod';
+import { ConnectionMode, RunStatus, TriggerSource } from '../enums.js';
+import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// Run entity
+// ---------------------------------------------------------------------------
+
+export const runSchema = z.object({
+  id: z.string().uuid(),
+  agentId: z.string().uuid(),
+  taskId: z.string().uuid().nullable(),
+  conversationId: z.string().uuid().nullable(),
+  parentRunId: z.string().uuid().nullable(),
+  status: RunStatus,
+  prompt: z.string(),
+  provider: z.string(),
+  connectionMode: ConnectionMode,
+  modelId: z.string().nullable(),
+  triggerSource: TriggerSource,
+  /** AgentDefinition version snapshot this run is bound to. */
+  agentDefinitionVersion: z.number().int().positive().nullable(),
+  retryCount: z.number().int().min(0),
+  maxRetries: z.number().int().min(0),
+  errorMessage: z.string().nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+  startedAt: z.string().datetime({ offset: true }).nullable(),
+  completedAt: z.string().datetime({ offset: true }).nullable(),
+});
+export type Run = z.infer<typeof runSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/runs
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a message / kick off a run.
+ *
+ * `Idempotency-Key` header is OPTIONAL (see spec §幂等性):
+ * - Client-generated UUIDv4 recommended.
+ * - 24h window: same key + same body hash → return original run.
+ *   Same key + different body hash → 409 IDEMPOTENCY_CONFLICT.
+ *   Different key → new run.
+ * - Body hash computation lives in RunService (task-11, "canonical JSON").
+ *   Keep the storage column types aligned with the 0011 migration:
+ *   `varchar(255)` for the key, `varchar(64)` for the SHA-256 hex.
+ */
+export const createRunRequestSchema = z.object({
+  input: z.string().min(1),
+  attachments: z
+    .array(
+      z.object({
+        name: z.string(),
+        url: z.string().url().optional(),
+        mimeType: z.string().optional(),
+      })
+    )
+    .optional(),
+  parentRunId: z.string().uuid().optional(),
+  modelId: z.string().optional(),
+});
+export type CreateRunRequest = z.infer<typeof createRunRequestSchema>;
+
+/**
+ * Shape of the `Idempotency-Key` header value as accepted by the API.
+ * Allows UUID or any ≤255 char ASCII token; the DB column is varchar(255).
+ */
+export const idempotencyKeyHeaderSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[A-Za-z0-9_-]+$/, 'must be URL-safe ASCII (A-Z a-z 0-9 _ -)');
+export type IdempotencyKeyHeader = z.infer<typeof idempotencyKeyHeaderSchema>;
+
+export const createRunResponseSchema = successResponseSchema(runSchema);
+export type CreateRunResponse = z.infer<typeof createRunResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/runs
+// ---------------------------------------------------------------------------
+
+export const listRunsQuerySchema = paginationQuerySchema.extend({
+  status: RunStatus.optional(),
+});
+export type ListRunsQuery = z.infer<typeof listRunsQuerySchema>;
+
+export const listRunsResponseSchema = paginatedResponseSchema(runSchema);
+export type ListRunsResponse = z.infer<typeof listRunsResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/runs/:runId
+// ---------------------------------------------------------------------------
+
+export const getRunParamsSchema = z.object({
+  id: z.string().uuid(),
+  runId: z.string().uuid(),
+});
+export type GetRunParams = z.infer<typeof getRunParamsSchema>;
+
+export const getRunResponseSchema = successResponseSchema(runSchema);
+export type GetRunResponse = z.infer<typeof getRunResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/agents/:id/runs/:runId/cancel
+// ---------------------------------------------------------------------------
+
+/**
+ * Cancel is an explicit state transition. The service layer will move the
+ * run to `failed` with an appropriate error code or to a dedicated
+ * cancelled subtype in P2; v0.1 returns the run in its post-transition shape.
+ */
+export const cancelRunResponseSchema = successResponseSchema(runSchema);
+export type CancelRunResponse = z.infer<typeof cancelRunResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/agents/:id/runs/:runId/events  (SSE)
+// ---------------------------------------------------------------------------
+
+/**
+ * Last-Event-ID header: integer ≥ 0 (the client's last seen `seq`).
+ * Used by the server to `SELECT * FROM run_events WHERE seq > N` and then
+ * attach to the live stream. No query-string cursor is supported (single
+ * protocol — see spec §断线重连).
+ */
+export const lastEventIdHeaderSchema = z.coerce.number().int().min(0);
+export type LastEventIdHeader = z.infer<typeof lastEventIdHeaderSchema>;
+
+// ---------------------------------------------------------------------------
+// Event payload (AI SDK UIMessageChunk + Open-rush data-openrush-* extensions)
+// ---------------------------------------------------------------------------
+
+/**
+ * Event stream payload shape.
+ *
+ * IMPORTANT: We align with AI SDK **UIMessageChunk** (the on-wire streaming
+ * format) rather than the higher-level `UIMessagePart` (post-aggregation UI
+ * shape). Rationale:
+ *
+ * 1. `run_events` is filled by the agent-worker → control-worker pipeline
+ *    which already emits UIMessageChunk (see
+ *    `packages/control-plane/src/conversation/reconstruct-messages.ts`, which
+ *    switches on `text-delta`, `tool-input-start`, `tool-input-available`,
+ *    `tool-output-available`, `tool-output-error`). Any reinterpretation
+ *    would force a runtime rewrite.
+ * 2. `packages/contracts/src/enums.ts` already defines `UIMessageChunkType`
+ *    and `events.ts` defines the base `UIMessageChunk` shape; we extend that
+ *    rather than inventing a parallel hierarchy.
+ * 3. AI SDK 6 retired the `text-delta` → `text` collapse that the spec
+ *    authors referenced; the canonical chunk types live in
+ *    `enums.ts → UIMessageChunkType` and are what the runtime emits.
+ *
+ * Spec note: `specs/managed-agents-api.md §事件 payload 类型` lists older
+ * AI SDK 3 part names (`text-delta`, `step-finish`, `tool state=call|result|error`).
+ * The authoritative list is now {@link UIMessageChunkType} in enums.ts.
+ * This decision is locked by Sparring review in task-4.
+ *
+ * We deliberately do NOT import `ai` into `@open-rush/contracts` (pulls
+ * React + streams into sdk/agent-worker/control-plane). Consumers that
+ * want the narrow compile-time type can add `import type { UIMessageChunk }
+ * from 'ai'` at their own site.
+ */
+
+/** AI SDK UIMessageChunk — text stream chunks. */
+const textStartChunkSchema = z.object({
+  type: z.literal('text-start'),
+  id: z.string().optional(),
+});
+const textDeltaChunkSchema = z.object({
+  type: z.literal('text-delta'),
+  id: z.string().optional(),
+  delta: z.string().optional(),
+  content: z.string().optional(),
+});
+const textEndChunkSchema = z.object({
+  type: z.literal('text-end'),
+  id: z.string().optional(),
+});
+
+/** AI SDK UIMessageChunk — reasoning stream chunks. */
+const reasoningStartChunkSchema = z.object({
+  type: z.literal('reasoning-start'),
+  id: z.string().optional(),
+});
+const reasoningDeltaChunkSchema = z.object({
+  type: z.literal('reasoning-delta'),
+  id: z.string().optional(),
+  delta: z.string().optional(),
+  content: z.string().optional(),
+});
+const reasoningEndChunkSchema = z.object({
+  type: z.literal('reasoning-end'),
+  id: z.string().optional(),
+});
+
+/**
+ * AI SDK UIMessageChunk — tool invocation lifecycle.
+ *
+ * Tool name identification lives in `toolName` (not in the `type` string),
+ * matching the reconstruct-messages consumer. `input` / `output` are opaque
+ * JSON values; `errorText` carries human-readable error on output error.
+ */
+const toolInputStartChunkSchema = z.object({
+  type: z.literal('tool-input-start'),
+  toolCallId: z.string().optional(),
+  toolName: z.string().optional(),
+});
+const toolInputDeltaChunkSchema = z.object({
+  type: z.literal('tool-input-delta'),
+  toolCallId: z.string().optional(),
+  delta: z.string().optional(),
+});
+const toolInputAvailableChunkSchema = z.object({
+  type: z.literal('tool-input-available'),
+  toolCallId: z.string().optional(),
+  toolName: z.string().optional(),
+  input: z.unknown().optional(),
+});
+const toolOutputAvailableChunkSchema = z.object({
+  type: z.literal('tool-output-available'),
+  toolCallId: z.string().optional(),
+  output: z.unknown().optional(),
+});
+const toolOutputErrorChunkSchema = z.object({
+  type: z.literal('tool-output-error'),
+  toolCallId: z.string().optional(),
+  errorText: z.string().optional(),
+});
+
+/** AI SDK UIMessageChunk — stream / step lifecycle markers. */
+const startChunkSchema = z.object({
+  type: z.literal('start'),
+  messageId: z.string().optional(),
+});
+const finishChunkSchema = z.object({
+  type: z.literal('finish'),
+  reason: z.string().optional(),
+});
+const errorChunkSchema = z.object({
+  type: z.literal('error'),
+  errorText: z.string().optional(),
+});
+const startStepChunkSchema = z.object({ type: z.literal('start-step') });
+const finishStepChunkSchema = z.object({
+  type: z.literal('finish-step'),
+  reason: z.string().optional(),
+});
+
+/**
+ * Generic data-* chunk. We disallow the `data-openrush-*` subset here
+ * because those are covered by the dedicated extension schemas below
+ * (well-known payload shapes).
+ */
+const genericDataChunkSchema = z
+  .object({
+    type: z.string().regex(/^data-[A-Za-z0-9_-]+$/),
+    id: z.string().optional(),
+    data: z.unknown(),
+  })
+  .refine((v) => !v.type.startsWith('data-openrush-'), {
+    message: 'use a specific openrushEventPartSchema for data-openrush-* events',
+  });
+
+// --- Open-rush extensions (specs/managed-agents-api.md §事件 payload 类型) ---
+
+export const openrushRunStartedPartSchema = z.object({
+  type: z.literal('data-openrush-run-started'),
+  id: z.string().optional(),
+  data: z.object({
+    runId: z.string().uuid(),
+    agentId: z.string().uuid(),
+    /** Snapshot version the worker is executing against. */
+    definitionVersion: z.number().int().positive(),
+  }),
+});
+export type OpenrushRunStartedPart = z.infer<typeof openrushRunStartedPartSchema>;
+
+export const openrushRunDonePartSchema = z.object({
+  type: z.literal('data-openrush-run-done'),
+  id: z.string().optional(),
+  data: z.object({
+    status: z.enum(['success', 'failed', 'cancelled']),
+    error: z.string().optional(),
+  }),
+});
+export type OpenrushRunDonePart = z.infer<typeof openrushRunDonePartSchema>;
+
+export const openrushUsagePartSchema = z.object({
+  type: z.literal('data-openrush-usage'),
+  id: z.string().optional(),
+  data: z.object({
+    tokensIn: z.number().int().min(0),
+    tokensOut: z.number().int().min(0),
+    costUsd: z.number().min(0),
+  }),
+});
+export type OpenrushUsagePart = z.infer<typeof openrushUsagePartSchema>;
+
+export const openrushSubRunPartSchema = z.object({
+  type: z.literal('data-openrush-sub-run'),
+  id: z.string().optional(),
+  data: z.object({
+    parentRunId: z.string().uuid(),
+    childRunId: z.string().uuid(),
+  }),
+});
+export type OpenrushSubRunPart = z.infer<typeof openrushSubRunPartSchema>;
+
+export const openrushExtensionPartSchema = z.discriminatedUnion('type', [
+  openrushRunStartedPartSchema,
+  openrushRunDonePartSchema,
+  openrushUsagePartSchema,
+  openrushSubRunPartSchema,
+]);
+export type OpenrushExtensionPart = z.infer<typeof openrushExtensionPartSchema>;
+
+/**
+ * Full Run event payload: AI SDK UIMessageChunk ∪ Open-rush extensions.
+ * This is what lives in `run_events.payload` (JSONB) and what SSE frames
+ * emit. See enums.ts → {@link UIMessageChunkType} for the canonical list.
+ */
+export const runEventPayloadSchema = z.union([
+  textStartChunkSchema,
+  textDeltaChunkSchema,
+  textEndChunkSchema,
+  reasoningStartChunkSchema,
+  reasoningDeltaChunkSchema,
+  reasoningEndChunkSchema,
+  toolInputStartChunkSchema,
+  toolInputDeltaChunkSchema,
+  toolInputAvailableChunkSchema,
+  toolOutputAvailableChunkSchema,
+  toolOutputErrorChunkSchema,
+  startChunkSchema,
+  finishChunkSchema,
+  errorChunkSchema,
+  startStepChunkSchema,
+  finishStepChunkSchema,
+  openrushExtensionPartSchema,
+  genericDataChunkSchema,
+]);
+export type RunEventPayload = z.infer<typeof runEventPayloadSchema>;
+
+/**
+ * SSE frame as emitted on the wire. `id` is the per-run sequence number,
+ * re-used by Last-Event-ID on reconnect.
+ */
+export const runEventSseFrameSchema = z.object({
+  id: z.number().int().min(1),
+  data: runEventPayloadSchema,
+});
+export type RunEventSseFrame = z.infer<typeof runEventSseFrameSchema>;

--- a/packages/contracts/src/v1/vaults.ts
+++ b/packages/contracts/src/v1/vaults.ts
@@ -1,0 +1,98 @@
+/**
+ * /api/v1/vaults/entries — Vault credential CRUD contracts.
+ *
+ * Endpoints (3):
+ * - POST   /api/v1/vaults/entries
+ * - GET    /api/v1/vaults/entries
+ * - DELETE /api/v1/vaults/entries/:id
+ *
+ * Critical rule: GET never returns `encryptedValue`. That's only stored
+ * server-side; the runtime injection path (task-10/11) reads it from DB.
+ */
+import { z } from 'zod';
+import { CredentialType, VaultScope } from '../enums.js';
+import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema } from './common.js';
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/vaults/entries
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a vault entry. The caller supplies the PLAINTEXT value; the
+ * service encrypts before storing. `encryptedValue` is never present on
+ * the wire from the client side.
+ *
+ * - `scope === 'platform'` requires `projectId` to be null/absent.
+ * - `scope === 'project'` requires `projectId`.
+ * - Enforced by the DB CHECK constraint on vault_entries (see 0000
+ *   migration) — so a mismatched pair hits 400/VALIDATION_ERROR here,
+ *   but also 500/INTERNAL if bypassed. The API refine below catches early.
+ */
+export const createVaultEntryRequestSchema = z
+  .object({
+    scope: VaultScope,
+    projectId: z.string().uuid().optional(),
+    name: z.string().min(1).max(255),
+    credentialType: CredentialType,
+    /** Plaintext secret — server encrypts before storing. */
+    value: z.string().min(1),
+    /** Env-var name to inject at sandbox start (optional). */
+    injectionTarget: z.string().max(255).optional(),
+  })
+  .refine(
+    (v) => (v.scope === 'platform' && !v.projectId) || (v.scope === 'project' && !!v.projectId),
+    {
+      message: 'scope="platform" requires no projectId; scope="project" requires projectId',
+    }
+  );
+export type CreateVaultEntryRequest = z.infer<typeof createVaultEntryRequestSchema>;
+
+/**
+ * Vault entry as returned to the client.
+ *
+ * **Never includes `encryptedValue`.** The full DB column is deliberately
+ * dropped from the wire format — including in service layer responses.
+ */
+export const vaultEntrySchema = z.object({
+  id: z.string().uuid(),
+  scope: VaultScope,
+  projectId: z.string().uuid().nullable(),
+  ownerId: z.string().uuid().nullable(),
+  name: z.string(),
+  credentialType: CredentialType,
+  keyVersion: z.number().int().min(1),
+  injectionTarget: z.string().nullable(),
+  createdAt: z.string().datetime({ offset: true }),
+  updatedAt: z.string().datetime({ offset: true }),
+});
+export type VaultEntry = z.infer<typeof vaultEntrySchema>;
+
+export const createVaultEntryResponseSchema = successResponseSchema(vaultEntrySchema);
+export type CreateVaultEntryResponse = z.infer<typeof createVaultEntryResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/vaults/entries
+// ---------------------------------------------------------------------------
+
+export const listVaultEntriesQuerySchema = paginationQuerySchema.extend({
+  scope: VaultScope.optional(),
+  projectId: z.string().uuid().optional(),
+});
+export type ListVaultEntriesQuery = z.infer<typeof listVaultEntriesQuerySchema>;
+
+export const listVaultEntriesResponseSchema = paginatedResponseSchema(vaultEntrySchema);
+export type ListVaultEntriesResponse = z.infer<typeof listVaultEntriesResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v1/vaults/entries/:id
+// ---------------------------------------------------------------------------
+
+export const deleteVaultEntryParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type DeleteVaultEntryParams = z.infer<typeof deleteVaultEntryParamsSchema>;
+
+export const deleteVaultEntryResponseSchema = successResponseSchema(
+  z.object({ id: z.string().uuid() })
+);
+export type DeleteVaultEntryResponse = z.infer<typeof deleteVaultEntryResponseSchema>;


### PR DESCRIPTION
Closes #119

## 任务
task-4: Contracts /api/v1/* Zod types

**M1 keystone milestone** — 合并后 Agent-A (M2 auth / agent-definitions / vaults) 和 Agent-B (M3 agent-worker / agents / runs / events SSE) 可并行启动。

## 变更

新增 `packages/contracts/src/v1/` 子目录 + 根 `index.ts` namespace re-export:

| 文件 | 内容 |
|---|---|
| `common.ts` | ErrorCode (8) + ERROR_CODE_HTTP_STATUS map + error/success envelopes + pagination + ServiceTokenScope (11,**不含 `*`**) + AuthScope union |
| `auth.ts` | POST/GET/DELETE `/api/v1/auth/tokens`,v0.1 护栏(scopes 非空 + ≠ `*`,expiresAt 必传 + 未来 + ≤ 90d,`SERVICE_TOKEN_MAX_TTL_MS` 常量导出) |
| `agent-definitions.ts` | 6 endpoints,PATCH refine 拒绝 no-op,If-Match header coerce,`queryBoolean` 严格解析 `'true'/'false'` 避免 JS Boolean 陷阱 |
| `agents.ts` | 4 endpoints,DELETE response `status=cancelled` 字面量 |
| `runs.ts` | 5 endpoints,Idempotency-Key header (≤255 URL-safe,对齐 0011 varchar),Last-Event-ID header,完整 UIMessageChunk payload + 4 个 data-openrush-* 扩展事件 |
| `vaults.ts` | 3 endpoints,`(scope, projectId)` refine,永不回显 encryptedValue |
| `registry.ts` | GET /skills + GET /mcps(只读) |
| `projects.ts` | 最小 CRUD |
| `index.ts` | barrel + 根 `export * as v1` |

## 关键决策

### 1. 事件 payload 用 UIMessageChunk(AI SDK 6)而非 UIMessagePart

spec 里 §事件 payload 类型 写的是 AI SDK 3 风格(`text-delta` / `step-finish` / `tool state=call|result|error`),但实际 runtime 走的是 AI SDK 6 UIMessageChunk 格式:
- `packages/contracts/src/enums.ts` 的 `UIMessageChunkType` 已经定义
- `packages/control-plane/src/conversation/reconstruct-messages.ts` 消费者在 switch `text-delta` / `tool-input-*` / `tool-output-*`
- `apps/` 里 `UIMessage` 从 `'ai'` 包导入

所以 contracts 对齐 runtime 实际格式,不按 spec 字面。**post-merge team-lead 决定是否刷新 spec 文本**。此决策在 runs.ts 有长注释说明,并锁定 by Sparring round 2。

### 2. `@ai-sdk/*` / `ai` 不引入 contracts

`ai` 包会拖 React + streams 进所有消费方(sdk / agent-worker / control-plane)。Contracts 用结构兼容 Zod schema 验证 runtime shape,消费方需要编译时类型自行 `import type { UIMessageChunk } from 'ai'`。

### 3. ServiceTokenScope 不含 `'*'`

强制 schema 层拒绝 `'*'`,不需要 API handler 额外过滤。额外 export `AuthScope = ServiceTokenScope | '*'` 给 middleware AuthContext。

### 4. 避免 `z.coerce.boolean` 陷阱

`listAgentDefinitionsQuerySchema.includeArchived` 用自定义 `queryBoolean`(严格 `'true'|'false'|boolean`),避免 JS `Boolean('false') === true` 让"不要归档"过滤静默失效。

### 5. 90 天 TTL 在 schema 层

`createTokenRequestSchema` 的 `superRefine` 检查 `expiresAt` 未来性 + ≤ 90d,让所有消费方(SDK / CLI)看到一致的 `VALIDATION_ERROR` 形状。

### 6. 其他

- PATCH body refine:必须有至少一个可编辑字段,防 no-op 版本递增
- `deleteAgentResponseSchema.data.status`: `z.literal('cancelled')` 锁死协议
- `createVaultEntryRequestSchema`:`(scope, projectId)` 组合合法性在 schema 层拒绝

## 不包含(按 TASKS.md 分工)

- OpenAPI 生成 → task-15
- 实际 route handler → task-5/6/8/9/12/13/14
- RunService idempotency 逻辑 / hash 计算 → task-11
- unified-auth middleware → task-5

## 验收

- [x] 24 endpoint 完整 schema
- [x] 8 错误 code 枚举齐全 + HTTP 状态映射
- [x] 11 scope 枚举齐全(不含 `*`),AuthScope union 含 `*`
- [x] AI SDK UIMessageChunk payload + 4 data-openrush-* 扩展事件(discriminated union)
- [x] 每个 schema 的 happy + 错误路径
- [x] `./docs/execution/verify.sh task-4` PASS(363 contracts tests)
- [x] `pnpm build && pnpm check && pnpm lint && pnpm test` 全绿
- [x] Sparring APPROVE(见下)

## Sparring

Codex `gpt-5.3-codex-xhigh`,两轮:

**Round 1**: CONCERNS
- MUST-FIX: `includeArchived` 用 `z.coerce.boolean` 会把 `'false'` 解析成 `true`(JS Boolean 陷阱)
- MUST-FIX: 事件 payload 契约与 runtime 不一致(spec 是 AI SDK 3,runtime 是 AI SDK 6)
- SHOULD-FIX: 90d TTL 护栏只在 service 层,没在 schema 层
- NIT: 注释提及 SourceDocumentUIPart 但 schema 未定义

**Round 2**: APPROVE
- 全部 MUST/SHOULD-FIX 已修复
- 1 NIT 也主动处理(补 tool-input-delta 回归测试)
- 另 1 NIT(部分 chunk 字段 optional)明确接受:runtime 兼容优先,后续收紧可选

## 测试说明(363 tests across 8 files + barrel)

- `common.test.ts`(22):错误 code / HTTP map / pagination / scope 枚举 / `*` 拒绝
- `auth.test.ts`(13):scopes 空/`*`/未知拒绝,expiresAt 必传/非 ISO/过去/91天拒绝、89天接受
- `agent-definitions.test.ts`(16):create / PATCH no-op 拒绝 / If-Match coerce / includeArchived 严格 boolean / non-canonical 拒绝(`'1'`/`'yes'`/`0`)
- `agents.test.ts`(13):status 枚举 / definitionVersion 正 / DELETE 字面量协议锁死
- `runs.test.ts`(30):idempotency 格式 / last-event-id coerce / 16 种 UIMessageChunk / extension 判别联合 / data-openrush-* 前缀保护
- `vaults.test.ts`(11):scope/projectId refine / encryptedValue 不回显
- `registry.test.ts`(10):skill + mcp shape / transport 枚举
- `projects.test.ts`(10):sandboxProvider 默认 / name 长度
- `index.test.ts`(3):barrel 导出抽样

🤖 Generated with [Claude Code](https://claude.com/claude-code)