### PR TITLE
task-5: unified auth middleware for /api/v1/*

### DIFF
--- a/apps/web/lib/auth/unified-auth.test.ts
+++ b/apps/web/lib/auth/unified-auth.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for the unified `/api/v1/*` auth middleware.
+ *
+ * We mock `@/auth` (NextAuth wrapper) and `@open-rush/db` (Drizzle chain) so
+ * the middleware can be exercised without a real Next.js runtime or PG.
+ *
+ * The goal is behavioural, not structural: each scenario describes a caller
+ * condition and asserts the resulting {@link AuthContext} (or `null`).
+ */
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockAuth = vi.fn();
+vi.mock('@/auth', () => ({
+  auth: () => mockAuth(),
+}));
+
+// Drizzle chain capture: db.select(...).from(...).where(...).limit(1)
+const selectRowsQueue: unknown[][] = [];
+const selectCalls: Array<{ where: unknown }> = [];
+const mockLimit = vi.fn();
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+
+// Update chain: db.update(...).set(...).where(...).execute()
+const updateExecuteMock = vi.fn();
+const mockUpdateWhere = vi.fn();
+const mockUpdateSet = vi.fn();
+const mockUpdate = vi.fn();
+
+function resetDbChain() {
+  selectRowsQueue.length = 0;
+  selectCalls.length = 0;
+
+  mockLimit.mockReset();
+  mockWhere.mockReset();
+  mockFrom.mockReset();
+  mockSelect.mockReset();
+
+  updateExecuteMock.mockReset();
+  mockUpdateWhere.mockReset();
+  mockUpdateSet.mockReset();
+  mockUpdate.mockReset();
+
+  mockLimit.mockImplementation(async () => {
+    return selectRowsQueue.shift() ?? [];
+  });
+  mockWhere.mockImplementation((condition: unknown) => {
+    selectCalls.push({ where: condition });
+    return { limit: mockLimit };
+  });
+  mockFrom.mockReturnValue({ where: mockWhere });
+  mockSelect.mockReturnValue({ from: mockFrom });
+
+  updateExecuteMock.mockResolvedValue(undefined);
+  mockUpdateWhere.mockReturnValue({ execute: updateExecuteMock });
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdate.mockReturnValue({ set: mockUpdateSet });
+}
+
+resetDbChain();
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({
+    select: mockSelect,
+    update: mockUpdate,
+  }),
+  serviceTokens: {
+    id: 'service_tokens.id',
+    tokenHash: 'service_tokens.token_hash',
+    ownerUserId: 'service_tokens.owner_user_id',
+    scopes: 'service_tokens.scopes',
+    lastUsedAt: 'service_tokens.last_used_at',
+    expiresAt: 'service_tokens.expires_at',
+    revokedAt: 'service_tokens.revoked_at',
+  },
+}));
+
+// drizzle-orm: we don't care about exact query shape in these tests — just
+// that filters were composed. Return predictable tokens.
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ type: 'and', parts }),
+  or: (...parts: unknown[]) => ({ type: 'or', parts }),
+  eq: (col: unknown, val: unknown) => ({ type: 'eq', col, val }),
+  gt: (col: unknown, val: unknown) => ({ type: 'gt', col, val }),
+  isNull: (col: unknown) => ({ type: 'isNull', col }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ..._values: unknown[]) => ({
+      type: 'sql',
+      strings: [...strings],
+    }),
+    {
+      raw: (s: string) => ({ type: 'sql.raw', sql: s }),
+    }
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { type AuthContext, authenticate, hasScope } from './unified-auth';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDbChain();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.test/api/v1/ping', { headers });
+}
+
+function expectHash(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Session path
+// ---------------------------------------------------------------------------
+
+describe('authenticate — NextAuth session', () => {
+  it('returns session context with wildcard scope when user is logged in', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-1' } });
+
+    const ctx = await authenticate(request());
+
+    expect(ctx).toEqual({
+      userId: 'user-1',
+      scopes: ['*'],
+      authType: 'session',
+    });
+    // No DB lookup when no Authorization header.
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('falls back to session when Authorization is present but not "Bearer sk_…"', async () => {
+    mockAuth.mockResolvedValue({ user: { id: 'user-2' } });
+
+    const ctx = await authenticate(request({ authorization: 'Bearer something-else' }));
+
+    expect(ctx).toEqual({ userId: 'user-2', scopes: ['*'], authType: 'session' });
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service Token happy path
+// ---------------------------------------------------------------------------
+
+describe('authenticate — Service Token', () => {
+  it('returns service-token context with declared scopes when token is valid', async () => {
+    const raw = 'sk_valid_abc';
+    selectRowsQueue.push([
+      {
+        id: 'token-1',
+        ownerUserId: 'user-42',
+        scopes: ['agents:read', 'runs:read'],
+      },
+    ]);
+
+    const ctx = await authenticate(request({ authorization: `Bearer ${raw}` }));
+
+    expect(ctx).toEqual({
+      userId: 'user-42',
+      scopes: ['agents:read', 'runs:read'],
+      authType: 'service-token',
+    });
+
+    // Session path must NOT be consulted when the token matched.
+    expect(mockAuth).not.toHaveBeenCalled();
+
+    // Query used the SHA-256 of the plaintext (plaintext must not appear).
+    const eqHashCall = mockWhereInvocations().flatPartsContaining(
+      'eq',
+      'service_tokens.token_hash'
+    );
+    expect(eqHashCall?.val).toBe(expectHash(raw));
+    expect(eqHashCall?.val).not.toBe(raw);
+  });
+
+  it('bumps last_used_at asynchronously without awaiting', async () => {
+    const raw = 'sk_async_1';
+    selectRowsQueue.push([{ id: 'token-async', ownerUserId: 'user-1', scopes: ['runs:read'] }]);
+
+    // Make the update resolve on the next microtask tick so we can observe
+    // that authenticate() returned before it settled.
+    let settled = false;
+    updateExecuteMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          // Simulate async work: flip flag after current microtask.
+          queueMicrotask(() => {
+            settled = true;
+            resolve();
+          });
+        })
+    );
+
+    const ctx = await authenticate(request({ authorization: `Bearer ${raw}` }));
+
+    // authenticate() resolved immediately — the update might still be pending.
+    expect(ctx?.authType).toBe('service-token');
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWhere).toHaveBeenCalledTimes(1);
+    expect(updateExecuteMock).toHaveBeenCalledTimes(1);
+
+    // Before flushing microtasks, the update may or may not have resolved —
+    // but after flushing one tick it definitely has.
+    await Promise.resolve();
+    expect(settled).toBe(true);
+  });
+
+  it('does not throw when the async last_used_at update rejects', async () => {
+    const raw = 'sk_reject_1';
+    selectRowsQueue.push([{ id: 'token-rej', ownerUserId: 'user-1', scopes: ['agents:read'] }]);
+    updateExecuteMock.mockRejectedValue(new Error('db down'));
+
+    // Must resolve without throwing even though the update rejects.
+    const ctx = await authenticate(request({ authorization: `Bearer ${raw}` }));
+    expect(ctx?.authType).toBe('service-token');
+
+    // Flush the rejected promise so Node sees the attached catch.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Service Token negative cases
+// ---------------------------------------------------------------------------
+
+describe('authenticate — Service Token rejections', () => {
+  it('returns null when the token is unknown (no matching row)', async () => {
+    selectRowsQueue.push([]);
+    mockAuth.mockResolvedValue(null);
+
+    const ctx = await authenticate(request({ authorization: 'Bearer sk_unknown' }));
+
+    expect(ctx).toBeNull();
+    // Once the Bearer sk_ path fails, we MUST NOT silently grant a session
+    // context: session is reserved for cookie-based callers.
+    expect(mockAuth).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('revoked tokens are filtered out (null row → null ctx)', async () => {
+    // Filter happens in SQL via isNull(revoked_at); here we just assert that
+    // a DB returning no row yields null.
+    selectRowsQueue.push([]);
+    const ctx = await authenticate(request({ authorization: 'Bearer sk_revoked' }));
+    expect(ctx).toBeNull();
+    // Assert the compiled WHERE included both isNull(revoked_at) and a gt() /
+    // isNull(expires_at) branch, so the SQL layer is the source of truth.
+    const invocations = mockWhereInvocations();
+    expect(invocations.hasCondition('isNull', 'service_tokens.revoked_at')).toBe(true);
+    expect(
+      invocations.hasCondition('isNull', 'service_tokens.expires_at') ||
+        invocations.hasCondition('gt', 'service_tokens.expires_at')
+    ).toBe(true);
+  });
+
+  it('expired tokens are filtered out (null row → null ctx)', async () => {
+    selectRowsQueue.push([]);
+    const ctx = await authenticate(request({ authorization: 'Bearer sk_expired' }));
+    expect(ctx).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No auth
+// ---------------------------------------------------------------------------
+
+describe('authenticate — no credentials', () => {
+  it('returns null when no Authorization header and no session', async () => {
+    mockAuth.mockResolvedValue(null);
+    const ctx = await authenticate(request());
+    expect(ctx).toBeNull();
+  });
+
+  it('returns null when session resolves but has no user id', async () => {
+    mockAuth.mockResolvedValue({ user: { name: 'Anonymous' } });
+    const ctx = await authenticate(request());
+    expect(ctx).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasScope
+// ---------------------------------------------------------------------------
+
+describe('hasScope', () => {
+  it('session wildcard grants any scope', () => {
+    const ctx: AuthContext = {
+      userId: 'u',
+      scopes: ['*'],
+      authType: 'session',
+    };
+    expect(hasScope(ctx, 'agents:read')).toBe(true);
+    expect(hasScope(ctx, 'runs:cancel')).toBe(true);
+    expect(hasScope(ctx, 'vaults:write')).toBe(true);
+  });
+
+  it('service-token matches only explicitly declared scopes', () => {
+    const ctx: AuthContext = {
+      userId: 'u',
+      scopes: ['agents:read', 'runs:read'],
+      authType: 'service-token',
+    };
+    expect(hasScope(ctx, 'agents:read')).toBe(true);
+    expect(hasScope(ctx, 'runs:read')).toBe(true);
+  });
+
+  it('service-token without required scope → false', () => {
+    const ctx: AuthContext = {
+      userId: 'u',
+      scopes: ['agents:read'],
+      authType: 'service-token',
+    };
+    expect(hasScope(ctx, 'agents:write')).toBe(false);
+    expect(hasScope(ctx, 'runs:cancel')).toBe(false);
+  });
+
+  it('empty scope list rejects everything', () => {
+    const ctx: AuthContext = {
+      userId: 'u',
+      scopes: [],
+      authType: 'service-token',
+    };
+    expect(hasScope(ctx, 'agents:read')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: read captured where() invocations to assert the compiled SQL AST.
+// ---------------------------------------------------------------------------
+
+type ConditionPart = { type: string; col?: unknown; val?: unknown; parts?: ConditionPart[] };
+
+function mockWhereInvocations() {
+  const flat: ConditionPart[] = [];
+  const visit = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as ConditionPart;
+    flat.push(n);
+    if (Array.isArray(n.parts)) {
+      for (const part of n.parts) visit(part);
+    }
+  };
+  for (const c of selectCalls) visit(c.where);
+  return {
+    flatPartsContaining(type: string, col: string) {
+      return flat.find((p) => p.type === type && p.col === col);
+    },
+    hasCondition(type: string, col: string) {
+      return flat.some((p) => p.type === type && p.col === col);
+    },
+  };
+}

--- a/apps/web/lib/auth/unified-auth.ts
+++ b/apps/web/lib/auth/unified-auth.ts
@@ -1,0 +1,139 @@
+/**
+ * Unified authentication middleware for `/api/v1/*` routes.
+ *
+ * Implements the dual-track scheme defined in `specs/service-token-auth.md`:
+ * - Service Token  — `Authorization: Bearer sk_*` (machine-to-machine)
+ * - NextAuth       — browser session cookies (web UI)
+ *
+ * Rules:
+ * - Service Token is detected first when the Authorization header starts with
+ *   `Bearer sk_`. Hashes of the plaintext are compared against
+ *   `service_tokens.token_hash`; we never persist or log the plaintext.
+ * - A matching row must have `revoked_at IS NULL` AND (`expires_at IS NULL` OR
+ *   `expires_at > now()`). Anything else returns `null`.
+ * - On a successful token lookup we fire a best-effort `UPDATE … SET
+ *   last_used_at = now()`. It is intentionally NOT awaited so it never adds
+ *   latency or failure modes to the authenticated request.
+ * - If no Service Token matches, we fall back to `auth()` from `@/auth`
+ *   (NextAuth v5 + local dev bypass).
+ *
+ * Security invariants:
+ * - The plaintext token is only referenced inline, never logged, never echoed.
+ * - Scope `'*'` is exclusive to session auth; Service Tokens carry their
+ *   explicit declared scope list (the POST issuance endpoint rejects `'*'`).
+ */
+import { createHash } from 'node:crypto';
+import type { v1 } from '@open-rush/contracts';
+import { getDbClient, serviceTokens } from '@open-rush/db';
+import { and, eq, gt, isNull, or, sql } from 'drizzle-orm';
+import { auth } from '@/auth';
+
+type AuthScope = v1.AuthScope;
+type ServiceTokenScope = v1.ServiceTokenScope;
+
+/**
+ * Normalized authentication result carried through the route handler.
+ *
+ * - `scopes` is `['*']` for sessions, an explicit subset of
+ *   {@link ServiceTokenScope} for Service Tokens.
+ */
+export type AuthContext = {
+  userId: string;
+  scopes: AuthScope[];
+  authType: 'session' | 'service-token';
+};
+
+const BEARER_PREFIX = 'Bearer ';
+const SERVICE_TOKEN_PREFIX = 'sk_';
+
+/** SHA-256 hex digest — matches the format stored in `service_tokens.token_hash`. */
+function hashServiceToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/**
+ * Identify the caller. Returns the resolved {@link AuthContext} or `null`
+ * when neither auth method matches.
+ *
+ * Never throws for normal auth failures — callers translate `null` into an
+ * `UNAUTHORIZED` response.
+ */
+export async function authenticate(req: Request): Promise<AuthContext | null> {
+  const header = req.headers.get('authorization') ?? req.headers.get('Authorization');
+
+  // --- Path 1: Service Token ------------------------------------------------
+  if (header?.startsWith(BEARER_PREFIX)) {
+    const raw = header.slice(BEARER_PREFIX.length).trim();
+    if (raw.startsWith(SERVICE_TOKEN_PREFIX)) {
+      const tokenHash = hashServiceToken(raw);
+      const db = getDbClient();
+
+      const [row] = await db
+        .select({
+          id: serviceTokens.id,
+          ownerUserId: serviceTokens.ownerUserId,
+          scopes: serviceTokens.scopes,
+        })
+        .from(serviceTokens)
+        .where(
+          and(
+            eq(serviceTokens.tokenHash, tokenHash),
+            isNull(serviceTokens.revokedAt),
+            or(isNull(serviceTokens.expiresAt), gt(serviceTokens.expiresAt, new Date()))
+          )
+        )
+        .limit(1);
+
+      if (!row) return null;
+
+      // Fire-and-forget: bump last_used_at without awaiting. We swallow errors
+      // so DB hiccups never break an otherwise authenticated request.
+      //
+      // Using `.execute()` (promise) with an attached `.catch(() => {})` so
+      // unhandled-rejection noise is suppressed; we intentionally do NOT
+      // propagate the promise to the caller.
+      const pending = db
+        .update(serviceTokens)
+        .set({ lastUsedAt: sql`now()` })
+        .where(eq(serviceTokens.id, row.id))
+        .execute();
+      // Some fakes return a thenable without `.catch`; guard to avoid throwing.
+      if (pending && typeof (pending as Promise<unknown>).catch === 'function') {
+        (pending as Promise<unknown>).catch(() => {
+          // Intentionally swallow; this is a best-effort bookkeeping write.
+        });
+      }
+
+      const scopes = (row.scopes ?? []) as AuthScope[];
+      return {
+        userId: row.ownerUserId,
+        scopes,
+        authType: 'service-token',
+      };
+    }
+    // Header was `Bearer …` but not a Service Token; fall through to session.
+  }
+
+  // --- Path 2: NextAuth session --------------------------------------------
+  const session = await auth();
+  const sessionUserId = session?.user?.id;
+  if (sessionUserId) {
+    return {
+      userId: sessionUserId,
+      scopes: ['*'],
+      authType: 'session',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Check whether `ctx` is allowed to perform an action gated by `required`.
+ *
+ * - Sessions hold `'*'` which matches every scope.
+ * - Service Tokens must list the required scope explicitly.
+ */
+export function hasScope(ctx: AuthContext, required: ServiceTokenScope): boolean {
+  return ctx.scopes.includes('*') || ctx.scopes.includes(required);
+}

--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -65,7 +65,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - 同步生成 OpenAPI 基础(可后置到 task-15 完善)
       - verify: `./docs/execution/verify.sh task-4`
 
-- [ ] `task-5-unified-auth-middleware` — **Agent-0**
+- [x] `task-5-unified-auth-middleware` — **Agent-0**
       域: `apps/web/lib/auth/unified-auth.ts`, `apps/web/lib/auth/unified-auth.test.ts`
       依赖: task-2
       验收:

--- a/docs/execution/progress/agent-0-relay.md
+++ b/docs/execution/progress/agent-0-relay.md
@@ -1,0 +1,57 @@
+# Agent-0-relay 进度(M1 收尾)
+
+接 agent-0-foundation,只管 task-5 + task-6。
+
+## task-5 Unified auth middleware
+
+- **状态**: ✅ 完成,等待合并
+- **分支**: `feat/task-5`
+- **文件域**: `apps/web/lib/auth/unified-auth.ts`(新)、`apps/web/lib/auth/unified-auth.test.ts`(新)
+- **关键决策**:
+  - 本地不 re-export `AuthContext`。`AuthScope` / `ServiceTokenScope` 从 `@open-rush/contracts`
+    的 `v1` 命名空间别名引入(`import type { v1 } from '@open-rush/contracts'`),
+    避免根 barrel 冲突(根 barrel 的具名 `AuthScope` 不存在,只有 v1 namespace 导出)。
+  - Service Token 路径先判断 `Authorization: Bearer sk_` 前缀;否则回落 session,
+    这样"Bearer 其它形式"(未来可能的新 scheme)不影响当前双轨语义。
+  - `last_used_at` 更新用 Drizzle 的 `.execute()` promise,**不 await**,并附 `.catch(() => {})`
+    吞掉 rejection,避免 DB 写入波动影响已完成的认证响应(spec §验证流程 伪代码一致)。
+    `sql\`now()\`` 直接走 DB 当前时间,和 spec 一致。
+  - 不在任何地方 `console.log` 原始 header / 明文 token。只在内存中哈希后查询,
+    测试里还专门断言 "SQL 查询里传的是 hash 不是 plaintext"。
+  - `hasScope(ctx, required)` 仅接受 `ServiceTokenScope`(不含 `'*'`)作为 required,
+    防止调用方意外要求 `'*'`(`'*'` 是 runtime 结果,不该做 required 入参)。
+- **测试覆盖**(14 个用例,全在 `unified-auth.test.ts`):
+  - session happy path + wildcard scope
+  - Authorization 非 `Bearer sk_` → 回落 session
+  - service-token happy path + scopes 原样传回 + SQL 用 hash(plaintext 不泄漏)
+  - last_used_at 异步更新不阻塞 authenticate() 返回(microtask 观察)
+  - last_used_at update reject 不抛出
+  - token 不存在 → null
+  - revoked token → null + SQL 含 `isNull(revoked_at)`
+  - expired token → null + SQL 含 `gt(expires_at, now)` 或 `isNull(expires_at)` 分支
+  - 无 Authorization + 无 session → null
+  - session 无 user.id → null
+  - hasScope session `*` 通配任何 scope
+  - hasScope service-token 显式匹配
+  - hasScope service-token 不匹配 → false
+  - hasScope empty scopes → 全拒
+- **Lint 坑**:
+  - biome 的 `useOptionalChain`:`header && header.startsWith(...)` 必须写 `header?.startsWith(...)`
+  - biome 的 `noArrayForEach`:`.forEach(visit)` 在函数内要改 `for..of`
+  - biome 的 organizeImports 对 `type` + 值混合 import 有特殊排序(`import { type X, y }` 不是 `import { y, type X }`),
+    让 biome `--write` 自动修
+  - `createHash from 'node:crypto'` 要在 workspace imports 之前
+- **验证结果**:`pnpm build/check/lint/test` 全绿;`./docs/execution/verify.sh task-5` PASS(149 个 web 测试,含新增 14 个)。
+
+## task-6 API /api/v1/auth/tokens CRUD
+
+- **状态**: 待启动(task-5 merge 后开工)
+
+---
+
+## 注意事项(继承 agent-0)
+
+- Sparring 铁律:commit 前必须 APPROVE
+- 受保护文件 check:`.claude/plans/managed-agents-p0-p1.md` / `specs/*` / `docs/execution/verify.sh` / `docs/execution/TASKS.md`(只勾 checkbox)
+- lint-staged 改文件要 `git add -A` 再 commit 一次
+- 不 `--no-verify`


### PR DESCRIPTION
## Summary

- Implements `apps/web/lib/auth/unified-auth.ts` — the dual-track `authenticate(req)` + `hasScope()` helper per `specs/service-token-auth.md`.
- Service Token path is checked first when `Authorization: Bearer sk_*` is present (SHA-256 hash lookup, `revoked_at IS NULL` + expiry filter); otherwise falls back to NextAuth `auth()`.
- `last_used_at` is bumped fire-and-forget — never awaited and rejections are swallowed, so DB hiccups cannot break an otherwise authenticated request.
- Plaintext tokens never reach logs or persistence. Tests assert the SQL path uses only the SHA-256 hex.
- Consumes `AuthScope` / `ServiceTokenScope` from `@open-rush/contracts` v1 namespace (task-4) — no parallel enum.

## Test plan

- [x] `pnpm build` — all 16 tasks green
- [x] `pnpm check` — all 32 tasks green
- [x] `pnpm lint` — all 16 tasks green (only pre-existing unrelated warnings)
- [x] `pnpm test` — all 32 tasks green (+14 new `unified-auth.test.ts` cases)
- [x] `./docs/execution/verify.sh task-5` — PASS
- [x] Sparring Review via Codex (`gpt-5.3-codex-xhigh`) — **APPROVE**, no MUST-FIX / SHOULD-FIX / NIT

### New test cases (14 total, all required from handoff covered)

- session happy path → `authType='session'`, `scopes=['*']`
- Authorization non-`Bearer sk_` → falls back to session
- service-token happy path → scopes passed through, SQL queried with SHA-256 hash (never plaintext)
- `last_used_at` update is async / non-blocking
- `last_used_at` update rejection does not throw
- unknown / revoked / expired tokens → `null`
- no Authorization + no session → `null`
- session without `user.id` → `null`
- `hasScope`: session `'*'` wildcard, service-token explicit match, no-match, empty scopes

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)