### PR TITLE
task-7: AgentDefinitionService (PATCH versioning + optimistic concurrency)

### DIFF
--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -91,7 +91,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
 
 ## M2: Registry API
 
-- [ ] `task-7-service-agent-definition` — **Agent-A**
+- [x] `task-7-service-agent-definition` — **Agent-A**
       域: `packages/control-plane/src/agent-definition-service.ts` + 测试
       依赖: task-1, task-4
       验收:

--- a/docs/execution/progress/agent-a.md
+++ b/docs/execution/progress/agent-a.md
@@ -1,0 +1,69 @@
+# Agent-A (Registry + Auth) Progress
+
+## Overview
+负责 task-7 → task-8 → task-9 串行。文件域:
+- `packages/control-plane/src/agent-definition-service.ts`
+- `apps/web/app/api/v1/{agent-definitions,vaults}/*`
+- (auth route 部分,task-5/6 已由 Agent-0-relay 完成)
+
+## task-7: AgentDefinitionService(PATCH 版本化 + 乐观并发)
+- **状态**: ✅ 完成,等 Sparring + PR
+- **分支**: `feat/task-7`
+- **文件域**:
+  - `packages/control-plane/src/agent-definition-service.ts`(新,~355 行实现)
+  - `packages/control-plane/src/__tests__/agent-definition-service.test.ts`(新,28 tests)
+  - `packages/control-plane/src/index.ts`(添加 exports,仅新增自己的符号)
+  - `docs/execution/TASKS.md`(勾选 checkbox)
+- **关键决策**:
+  - **Ports/Adapters**: 跟随 `ProjectAgentService` 模式,直接消费 `DbClient`(drizzle-orm 事务),不抽象 DB port。测试用 pglite(同 repo 其他测试约定)。
+  - **事务 & 悲观锁**: PATCH 和 archive 都在 `db.transaction` 内用 `.for('update')` 行锁,保证同 agent 的并发 PATCH 严格串行(spec §PATCH 流程 6 步原子)。
+  - **乐观并发**: `If-Match` 在行锁后与 `agents.current_version` 比较,不匹配 → `AgentDefinitionVersionConflictError`(API 层映射 409 VERSION_CONFLICT)。
+  - **Snapshot 格式**: 只存 editable 字段(13 个),排除 id / projectId / currentVersion / archivedAt / createdAt / updatedAt / lastActiveAt / activeStreamId / createdBy / isBuiltin / customTitle / status。测试 assertion 明确排除这些字段。与 `agentDefinitionEditableSchema`(contracts v1)对齐。
+  - **domain vs contract 类型**: 内部 `AgentDefinition` 保留 `Date` 对象,由 API 路由(task-8)转 ISO。避免在 service 层做 ISO 字符串转换(复用不方便)。
+  - **空 patch 快速拒绝**: `pickEditablePatch()` 过滤出真正要改的 editable 字段,空集直接抛 `EmptyAgentDefinitionPatchError`(400),不进事务 — 和 Zod `patchAgentDefinitionRequestSchema` 的 refine 语义完全对齐。
+  - **archive 幂等**: 已 archive 的再 archive 不 bump version、不更新 archived_at(测试覆盖)。归档是 metadata,不改 definition。
+  - **getByVersion 的 updatedAt**: 用 version 行的 `createdAt`(= 该版本写入时间),不是 agents 表的 updatedAt。这样客户端 sort history 的时间戳是"这个版本生成的时刻",语义一致。
+  - **listVersions cursor**: 用 `version` 数字本身作 opaque cursor,`lt(version, cursor)` 查下一页;`limit + 1` fetch 检测 hasMore。
+  - **NotFound 错误链**: `getByVersion` 先校验 agent 存在(`AgentDefinitionNotFoundError`),再校验 version(`AgentDefinitionVersionNotFoundError`)。
+  - **错误类设计**: 5 个专属错误类(NotFound / VersionNotFound / VersionConflict / Archived / EmptyPatch),API 层可按 `instanceof` 映射到 v1 ErrorCode + HTTP 状态。
+- **测试覆盖**(28 tests,分 6 section):
+  - create:v1 snapshot 一致性 / changeNote 默认 null / config 存 jsonb 往返
+  - get:正常 / NotFound / 归档后仍可 get
+  - getByVersion:snapshot 合并 / VersionNotFound / AgentNotFound 优先 / 非正整数拒绝
+  - listVersions:desc 排序无 snapshot / cursor 分页 3 页正确 / NotFound / limit clamp
+  - patch:原子 bump / 409 conflict / 并发 Promise.allSettled 只一个赢 / archive 后 patch 被拒 / 空 patch 拒绝 / 未覆盖字段保留 / 显式 null 允许
+  - archive:设置 archived_at / 幂等(二次 archive)/ NotFound / FK cascade sanity
+  - 不变量:两 agent 共用 version=1 / 单调 version per agent
+- **坑 / 经验**:
+  - **context 被 hijack 一次**: 中途有外部进程把我切到 `feat/task-5` 并且 pull origin main 合掉我的 branch。靠 `git fsck --lost-found` 在 dangling tree 里找回了 blob `16b01e92...`(service)+ `110291272...`(test),cat-file 存到 /tmp 后再 restore。教训:untracked 文件随时可能消失,尽早 commit。
+  - **biome 格式差异**: 写代码时没跑 format,第一次 verify.sh 被 lint 卡。`pnpm exec biome check --write` 修掉 import 排序 + line 折行。现在两文件都 clean。
+  - **FOR UPDATE 在 pglite**: `.for('update')` 在 pglite 单进程里是 no-op 但 syntax 合法,生产 PG 才真有行锁。测试里靠 Promise.allSettled 同步触发并发 — 由于 pglite 是单线程,两个 patch 会串行,但 version 检查仍保证只有一个成功。结论:测试逻辑覆盖 409,production lock 靠 PG。
+  - **drizzle update 的 undefined 清洗**: `.set({})` 里 undefined 字段 drizzle 会跳过,但安全起见在 patch 里手动 `delete updateValues[k]` 清掉 undefined 防止覆盖为 NULL。
+  - `Repo 隐性约定` 同 agent-0 笔记 §2/5:控制面 test 文件要 inline DDL 三处同步(但我只新加测试,不改 schema,所以只动自己这一个文件的 DDL block,保持和 pglite-helpers.ts 一致)。
+- **Sparring 轮 1**(Codex gpt-5.3-codex-xhigh):
+  - **MUST-FIX**: snapshot 字段 camelCase 与 0009 migration 回填的 snake_case 不一致,`getByVersion` 读旧 v1 会漏字段。
+    → 修:加 `readSnapshotField()` 容错读(两种 key 都试),同时加测试 `reads legacy snake_case v1 snapshot`。
+  - **SHOULD-FIX**: `getByVersion(0)` 抛 NotFound 不符合 VALIDATION 语义;同理 `patch(ifMatchVersion=-1)` 抛 Conflict 混淆。
+    → 修:新增 `InvalidAgentDefinitionInputError` 错误类,`getByVersion` + `patch` 前置校验用它,映射 VALIDATION_ERROR。
+  - **SHOULD-FIX**: PGlite 单线程不能证明 PG `FOR UPDATE` 行锁语义。
+    → 修:在并发 test 加 NOTE 注明这是 service 层 optimistic check 证据,真实 PG 锁留给 task-8 API 集成测试。
+- **Sparring 轮 2**: **APPROVE**(逐项确认 snake_case 兼容 / 错误分类可区分 / 并发证据 / 无回归)
+- **验证结果**(修复后):
+  - `pnpm --filter @open-rush/control-plane build` PASS(tsup + DTS)
+  - `pnpm --filter @open-rush/control-plane check` PASS
+  - `pnpm --filter @open-rush/control-plane lint` 无 error(3 warnings 都是 pre-existing)
+  - `pnpm --filter @open-rush/control-plane test` 35 files / 476 tests(含我的 1 file / 30 tests)全绿
+  - `./docs/execution/verify.sh task-7` PASS
+
+## task-8: API /api/v1/agent-definitions/*(待 task-7 merge 后)
+- 依赖 task-5(已 merged,可直接 `authenticate()` / `hasScope()`)+ task-7(本分支)
+- 计划消费 contracts v1 的 6 个 schema,由 route handler 层把 `Date` → ISO + 错误类 → 401/403/404/409/400
+
+## task-9: API /api/v1/vaults/entries/*(待 task-5 & task-4 — 都已 ready)
+- 等 task-7/8 合并后启动
+
+## 纪律 / 流程
+
+- 每 task 单独 branch、单独 PR、Sparring APPROVE 才 commit
+- context > 50% 通知 team-lead,> 70% 必换
+- 受保护文件不改;只勾 TASKS.md checkbox

--- a/packages/control-plane/src/__tests__/agent-definition-service.test.ts
+++ b/packages/control-plane/src/__tests__/agent-definition-service.test.ts
@@ -1,0 +1,600 @@
+/**
+ * AgentDefinitionService integration tests (PGlite-backed, no Docker).
+ *
+ * The schema bootstrap (users, projects, agents, agent_definition_versions)
+ * is inlined here on purpose — we use the same columns + indexes as
+ * `packages/db/test/pglite-helpers.ts`, but the control-plane tests have their
+ * own inline DDL, as established by drizzle-event-store.test.ts et al. If you
+ * touch this block, sync the matching columns in:
+ *   - packages/db/test/pglite-helpers.ts
+ *   - packages/control-plane/src/__tests__/drizzle-event-store.test.ts
+ *   - packages/control-plane/src/__tests__/drizzle-run-db.test.ts
+ * (see docs/execution/progress/agent-0.md §Repo 隐性约定 #2.)
+ */
+import { PGlite } from '@electric-sql/pglite';
+import * as schema from '@open-rush/db';
+import { agentDefinitionVersions, agents, projects, users } from '@open-rush/db';
+import { and, eq, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  AgentDefinitionArchivedError,
+  AgentDefinitionNotFoundError,
+  AgentDefinitionService,
+  AgentDefinitionVersionConflictError,
+  AgentDefinitionVersionNotFoundError,
+  type CreateAgentDefinitionInput,
+  EmptyAgentDefinitionPatchError,
+  InvalidAgentDefinitionInputError,
+} from '../agent-definition-service.js';
+
+type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+
+let pglite: PGlite;
+let db: TestDb;
+let service: AgentDefinitionService;
+let projectId: string;
+let userId: string;
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  db = drizzle(pglite, { schema });
+
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS users (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name TEXT,
+      email TEXT UNIQUE,
+      email_verified_at TIMESTAMPTZ,
+      image TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS projects (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      sandbox_provider VARCHAR(50) NOT NULL DEFAULT 'opensandbox',
+      default_model VARCHAR(255),
+      default_connection_mode VARCHAR(50) DEFAULT 'anthropic',
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      deleted_at TIMESTAMPTZ
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS agents (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      name VARCHAR(120) NOT NULL DEFAULT 'New Agent',
+      description TEXT,
+      icon VARCHAR(50),
+      provider_type VARCHAR(50) NOT NULL DEFAULT 'claude-code',
+      model VARCHAR(255),
+      system_prompt TEXT,
+      append_system_prompt TEXT,
+      allowed_tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+      skills JSONB NOT NULL DEFAULT '[]'::jsonb,
+      mcp_servers JSONB NOT NULL DEFAULT '[]'::jsonb,
+      max_steps INTEGER NOT NULL DEFAULT 30,
+      delivery_mode VARCHAR(20) NOT NULL DEFAULT 'chat',
+      is_builtin BOOLEAN NOT NULL DEFAULT false,
+      custom_title VARCHAR(200),
+      config JSONB,
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      active_stream_id TEXT,
+      current_version INTEGER NOT NULL DEFAULT 1,
+      archived_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      last_active_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS agent_definition_versions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      version INTEGER NOT NULL,
+      snapshot JSONB NOT NULL,
+      change_note TEXT,
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CONSTRAINT agent_definition_versions_agent_version_uniq UNIQUE(agent_id, version)
+    )
+  `);
+  await db.execute(sql`
+    CREATE INDEX IF NOT EXISTS agent_definition_versions_agent_idx
+    ON agent_definition_versions (agent_id, version DESC)
+  `);
+
+  service = new AgentDefinitionService(db as never);
+});
+
+afterAll(async () => {
+  await pglite.close();
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql`TRUNCATE TABLE agent_definition_versions, agents, projects, users RESTART IDENTITY CASCADE`
+  );
+  const [user] = await db
+    .insert(users)
+    .values({ name: 'Alice', email: `alice-${Math.random()}@ex.com` })
+    .returning();
+  userId = user.id;
+  const [project] = await db.insert(projects).values({ name: 'TP', createdBy: userId }).returning();
+  projectId = project.id;
+});
+
+function makeCreateInput(overrides: Partial<CreateAgentDefinitionInput> = {}) {
+  return {
+    projectId,
+    name: 'Agent 1',
+    description: 'desc',
+    icon: null,
+    providerType: 'claude-code',
+    model: null,
+    systemPrompt: 'be helpful',
+    appendSystemPrompt: null,
+    allowedTools: ['Read', 'Bash'],
+    skills: [],
+    mcpServers: [],
+    maxSteps: 30,
+    deliveryMode: 'chat',
+    config: null,
+    createdBy: userId,
+    ...overrides,
+  } satisfies CreateAgentDefinitionInput;
+}
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService.create', () => {
+  it('writes an agent row + v1 snapshot in one transaction', async () => {
+    const d = await service.create(makeCreateInput({ changeNote: 'initial' }));
+    expect(d.currentVersion).toBe(1);
+    expect(d.archivedAt).toBeNull();
+    expect(d.name).toBe('Agent 1');
+
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].version).toBe(1);
+    expect(rows[0].changeNote).toBe('initial');
+    expect(rows[0].createdBy).toBe(userId);
+
+    // Snapshot contains all editable fields, matching the returned definition.
+    const snap = rows[0].snapshot as Record<string, unknown>;
+    expect(snap.name).toBe('Agent 1');
+    expect(snap.systemPrompt).toBe('be helpful');
+    expect(snap.allowedTools).toEqual(['Read', 'Bash']);
+    // Must NOT leak bookkeeping columns into snapshot.
+    expect(snap).not.toHaveProperty('id');
+    expect(snap).not.toHaveProperty('currentVersion');
+    expect(snap).not.toHaveProperty('archivedAt');
+    expect(snap).not.toHaveProperty('createdAt');
+    expect(snap).not.toHaveProperty('updatedAt');
+  });
+
+  it('defaults changeNote to null when omitted', async () => {
+    const d = await service.create(makeCreateInput());
+    const [row] = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(row.changeNote).toBeNull();
+  });
+
+  it('stores an empty object config as {}', async () => {
+    const d = await service.create(makeCreateInput({ config: { region: 'us-west-2' } }));
+    const fresh = await service.get(d.id);
+    expect(fresh.config).toEqual({ region: 'us-west-2' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get / getByVersion / listVersions
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService.get', () => {
+  it('returns the latest row', async () => {
+    const d = await service.create(makeCreateInput());
+    const got = await service.get(d.id);
+    expect(got.id).toBe(d.id);
+    expect(got.currentVersion).toBe(1);
+  });
+
+  it('throws NotFound for unknown id', async () => {
+    await expect(service.get('00000000-0000-0000-0000-000000000000')).rejects.toBeInstanceOf(
+      AgentDefinitionNotFoundError
+    );
+  });
+
+  it('returns archived definitions (archived is a state, not a delete)', async () => {
+    const d = await service.create(makeCreateInput());
+    await service.archive(d.id);
+    const got = await service.get(d.id);
+    expect(got.archivedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('AgentDefinitionService.getByVersion', () => {
+  it('returns the historical snapshot merged with stable metadata', async () => {
+    const d = await service.create(makeCreateInput({ name: 'v1-name' }));
+    await service.patch(d.id, {
+      ifMatchVersion: 1,
+      name: 'v2-name',
+      changeNote: 'rename',
+    });
+
+    const v1 = await service.getByVersion(d.id, 1);
+    expect(v1.id).toBe(d.id);
+    expect(v1.projectId).toBe(projectId);
+    expect(v1.currentVersion).toBe(1);
+    expect(v1.name).toBe('v1-name');
+    // updatedAt on historical = the version row's created_at.
+    expect(v1.updatedAt).toBeInstanceOf(Date);
+
+    const v2 = await service.getByVersion(d.id, 2);
+    expect(v2.currentVersion).toBe(2);
+    expect(v2.name).toBe('v2-name');
+  });
+
+  it('throws VersionNotFound for unknown version', async () => {
+    const d = await service.create(makeCreateInput());
+    await expect(service.getByVersion(d.id, 99)).rejects.toBeInstanceOf(
+      AgentDefinitionVersionNotFoundError
+    );
+  });
+
+  it("throws AgentNotFound first if agent doesn't exist", async () => {
+    await expect(
+      service.getByVersion('00000000-0000-0000-0000-000000000000', 1)
+    ).rejects.toBeInstanceOf(AgentDefinitionNotFoundError);
+  });
+
+  it('rejects non-positive version values as VALIDATION_ERROR (not NOT_FOUND)', async () => {
+    const d = await service.create(makeCreateInput());
+    await expect(service.getByVersion(d.id, 0)).rejects.toBeInstanceOf(
+      InvalidAgentDefinitionInputError
+    );
+    await expect(service.getByVersion(d.id, -1)).rejects.toBeInstanceOf(
+      InvalidAgentDefinitionInputError
+    );
+    await expect(service.getByVersion(d.id, 1.5)).rejects.toBeInstanceOf(
+      InvalidAgentDefinitionInputError
+    );
+    await expect(service.getByVersion(d.id, Number.NaN)).rejects.toBeInstanceOf(
+      InvalidAgentDefinitionInputError
+    );
+  });
+
+  it('reads legacy snake_case v1 snapshot (from 0009 migration)', async () => {
+    // Simulate: agent_definition_versions row written by migration 0009 as
+    // `to_jsonb(agents.*)` — snake_case keys, including non-editable columns.
+    // Confirms getByVersion tolerates both formats without losing fields.
+    const d = await service.create(makeCreateInput({ name: 'row-name' }));
+    // Overwrite v1 snapshot with a legacy snake_case payload.
+    await db
+      .update(agentDefinitionVersions)
+      .set({
+        snapshot: {
+          name: 'legacy',
+          description: 'legacy-desc',
+          icon: 'legacy-icon',
+          provider_type: 'legacy-provider',
+          model: 'legacy-model',
+          system_prompt: 'legacy-prompt',
+          append_system_prompt: 'legacy-append',
+          allowed_tools: ['LegacyTool'],
+          skills: ['legacy-skill'],
+          mcp_servers: ['legacy-mcp'],
+          max_steps: 7,
+          delivery_mode: 'workspace',
+          config: { region: 'eu' },
+          // Extra non-editable keys that migration also writes (should be ignored).
+          status: 'active',
+          is_builtin: false,
+          custom_title: null,
+          created_by: null,
+        },
+      })
+      .where(
+        and(eq(agentDefinitionVersions.agentId, d.id), eq(agentDefinitionVersions.version, 1))
+      );
+
+    const v1 = await service.getByVersion(d.id, 1);
+    expect(v1.name).toBe('legacy');
+    expect(v1.description).toBe('legacy-desc');
+    expect(v1.icon).toBe('legacy-icon');
+    expect(v1.providerType).toBe('legacy-provider');
+    expect(v1.model).toBe('legacy-model');
+    expect(v1.systemPrompt).toBe('legacy-prompt');
+    expect(v1.appendSystemPrompt).toBe('legacy-append');
+    expect(v1.allowedTools).toEqual(['LegacyTool']);
+    expect(v1.skills).toEqual(['legacy-skill']);
+    expect(v1.mcpServers).toEqual(['legacy-mcp']);
+    expect(v1.maxSteps).toBe(7);
+    expect(v1.deliveryMode).toBe('workspace');
+    expect(v1.config).toEqual({ region: 'eu' });
+  });
+});
+
+describe('AgentDefinitionService.listVersions', () => {
+  it('returns versions in descending order without snapshots', async () => {
+    const d = await service.create(makeCreateInput({ changeNote: 'v1' }));
+    await service.patch(d.id, { ifMatchVersion: 1, name: 'v2', changeNote: 'v2' });
+    await service.patch(d.id, { ifMatchVersion: 2, name: 'v3', changeNote: 'v3' });
+
+    const res = await service.listVersions(d.id);
+    expect(res.items.map((v) => v.version)).toEqual([3, 2, 1]);
+    expect(res.items.map((v) => v.changeNote)).toEqual(['v3', 'v2', 'v1']);
+    // Summary must NOT carry snapshot payload.
+    expect(res.items[0]).not.toHaveProperty('snapshot');
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('paginates by version cursor (smaller than cursor → next page)', async () => {
+    const d = await service.create(makeCreateInput());
+    for (let v = 1; v < 5; v++) {
+      await service.patch(d.id, { ifMatchVersion: v, name: `v${v + 1}` });
+    }
+
+    const first = await service.listVersions(d.id, { limit: 2 });
+    expect(first.items.map((v) => v.version)).toEqual([5, 4]);
+    expect(first.nextCursor).toBe(4);
+
+    const second = await service.listVersions(d.id, { limit: 2, cursorVersion: 4 });
+    expect(second.items.map((v) => v.version)).toEqual([3, 2]);
+    expect(second.nextCursor).toBe(2);
+
+    const third = await service.listVersions(d.id, { limit: 2, cursorVersion: 2 });
+    expect(third.items.map((v) => v.version)).toEqual([1]);
+    expect(third.nextCursor).toBeNull();
+  });
+
+  it('throws NotFound when agent missing', async () => {
+    await expect(
+      service.listVersions('00000000-0000-0000-0000-000000000000')
+    ).rejects.toBeInstanceOf(AgentDefinitionNotFoundError);
+  });
+
+  it('clamps limit to 1..200', async () => {
+    const d = await service.create(makeCreateInput());
+    const res = await service.listVersions(d.id, { limit: 9999 });
+    expect(res.items.length).toBeLessThanOrEqual(200);
+    // limit=0 should fall back to default 50.
+    const res2 = await service.listVersions(d.id, { limit: 0 });
+    expect(res2.items).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// patch
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService.patch', () => {
+  it('bumps current_version and inserts snapshot atomically', async () => {
+    const d = await service.create(makeCreateInput());
+    const updated = await service.patch(d.id, {
+      ifMatchVersion: 1,
+      name: 'renamed',
+      maxSteps: 42,
+      changeNote: 'bumped',
+      updatedBy: userId,
+    });
+    expect(updated.currentVersion).toBe(2);
+    expect(updated.name).toBe('renamed');
+    expect(updated.maxSteps).toBe(42);
+
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id))
+      .orderBy(agentDefinitionVersions.version);
+    expect(rows).toHaveLength(2);
+    expect(rows[1].version).toBe(2);
+    expect(rows[1].changeNote).toBe('bumped');
+    expect((rows[1].snapshot as Record<string, unknown>).name).toBe('renamed');
+    expect((rows[1].snapshot as Record<string, unknown>).maxSteps).toBe(42);
+    // Unchanged fields carry forward from v1.
+    expect((rows[1].snapshot as Record<string, unknown>).systemPrompt).toBe('be helpful');
+  });
+
+  it('409 when If-Match mismatches current_version', async () => {
+    const d = await service.create(makeCreateInput());
+    await expect(service.patch(d.id, { ifMatchVersion: 99, name: 'x' })).rejects.toBeInstanceOf(
+      AgentDefinitionVersionConflictError
+    );
+
+    // Ensure nothing was written: still v1, one snapshot row.
+    const after = await service.get(d.id);
+    expect(after.currentVersion).toBe(1);
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('simulates concurrent PATCH — only one wins, the other 409s', async () => {
+    // NOTE: PGlite runs in a single in-process queue, so this test proves
+    // the **service-level optimistic concurrency check**: two PATCHes that
+    // both read If-Match=1 cannot both bump to v2, because the second
+    // transaction sees `current_version=2` and raises VERSION_CONFLICT.
+    //
+    // This does NOT prove the PG-level `FOR UPDATE` row lock behaves
+    // correctly under true multi-connection concurrency — that is covered
+    // by the integration layer (task-8 API route tests on real PG) once
+    // Agent-A's task-8 API handler is implemented.
+    const d = await service.create(makeCreateInput());
+    const first = service.patch(d.id, { ifMatchVersion: 1, name: 'A' });
+    const second = service.patch(d.id, { ifMatchVersion: 1, name: 'B' });
+    const results = await Promise.allSettled([first, second]);
+    const ok = results.filter((r) => r.status === 'fulfilled');
+    const failed = results.filter((r) => r.status === 'rejected');
+    expect(ok).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+    expect((failed[0] as PromiseRejectedResult).reason).toBeInstanceOf(
+      AgentDefinitionVersionConflictError
+    );
+    const after = await service.get(d.id);
+    expect(after.currentVersion).toBe(2);
+  });
+
+  it('rejects PATCH on archived definition', async () => {
+    const d = await service.create(makeCreateInput());
+    await service.archive(d.id);
+    await expect(service.patch(d.id, { ifMatchVersion: 1, name: 'x' })).rejects.toBeInstanceOf(
+      AgentDefinitionArchivedError
+    );
+  });
+
+  it('rejects empty patch (only changeNote / only updatedBy)', async () => {
+    const d = await service.create(makeCreateInput());
+    await expect(
+      service.patch(d.id, { ifMatchVersion: 1, changeNote: 'nothing' })
+    ).rejects.toBeInstanceOf(EmptyAgentDefinitionPatchError);
+    await expect(
+      service.patch(d.id, { ifMatchVersion: 1, updatedBy: userId })
+    ).rejects.toBeInstanceOf(EmptyAgentDefinitionPatchError);
+  });
+
+  it('rejects PATCH for unknown id', async () => {
+    await expect(
+      service.patch('00000000-0000-0000-0000-000000000000', {
+        ifMatchVersion: 1,
+        name: 'x',
+      })
+    ).rejects.toBeInstanceOf(AgentDefinitionNotFoundError);
+  });
+
+  it('rejects invalid ifMatchVersion as VALIDATION_ERROR (not VERSION_CONFLICT)', async () => {
+    const d = await service.create(makeCreateInput());
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      await expect(
+        service.patch(d.id, { ifMatchVersion: bad as number, name: 'x' })
+      ).rejects.toBeInstanceOf(InvalidAgentDefinitionInputError);
+    }
+    // The fact that no version row got appended confirms the short-circuit
+    // happened before the DB was touched.
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  it('does not overwrite fields absent from the patch body', async () => {
+    const d = await service.create(
+      makeCreateInput({ systemPrompt: 'keep me', allowedTools: ['Read'] })
+    );
+    const updated = await service.patch(d.id, {
+      ifMatchVersion: 1,
+      name: 'only-name-changed',
+    });
+    expect(updated.systemPrompt).toBe('keep me');
+    expect(updated.allowedTools).toEqual(['Read']);
+  });
+
+  it('allows explicit null for nullable fields', async () => {
+    const d = await service.create(makeCreateInput({ description: 'had one' }));
+    const updated = await service.patch(d.id, {
+      ifMatchVersion: 1,
+      description: null,
+    });
+    expect(updated.description).toBeNull();
+    const v2 = await service.getByVersion(d.id, 2);
+    expect(v2.description).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// archive
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService.archive', () => {
+  it('sets archived_at and keeps current_version unchanged', async () => {
+    const d = await service.create(makeCreateInput());
+    expect(d.archivedAt).toBeNull();
+    const archived = await service.archive(d.id);
+    expect(archived.archivedAt).toBeInstanceOf(Date);
+    expect(archived.currentVersion).toBe(1);
+  });
+
+  it('is idempotent on already-archived rows (no new version, no new archived_at)', async () => {
+    const d = await service.create(makeCreateInput());
+    const first = await service.archive(d.id);
+    const second = await service.archive(d.id);
+    expect(second.archivedAt?.getTime()).toBe(first.archivedAt?.getTime());
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(rows).toHaveLength(1); // archive must not bump versions.
+  });
+
+  it('throws NotFound for unknown id', async () => {
+    await expect(service.archive('00000000-0000-0000-0000-000000000000')).rejects.toBeInstanceOf(
+      AgentDefinitionNotFoundError
+    );
+  });
+
+  it('cascades to version rows on agent DELETE (FK cascade sanity-check)', async () => {
+    const d = await service.create(makeCreateInput());
+    await service.patch(d.id, { ifMatchVersion: 1, name: 'v2' });
+    await db.delete(agents).where(eq(agents.id, d.id));
+    const rows = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(eq(agentDefinitionVersions.agentId, d.id));
+    expect(rows).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting: ensure unique (agent_id, version) protects from dup versions
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService invariants', () => {
+  it('two different agents can share the same version number', async () => {
+    const a = await service.create(makeCreateInput({ name: 'A' }));
+    const b = await service.create(makeCreateInput({ name: 'B' }));
+    expect(a.currentVersion).toBe(1);
+    expect(b.currentVersion).toBe(1);
+    const rowsA = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(
+        and(eq(agentDefinitionVersions.agentId, a.id), eq(agentDefinitionVersions.version, 1))
+      );
+    const rowsB = await db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(
+        and(eq(agentDefinitionVersions.agentId, b.id), eq(agentDefinitionVersions.version, 1))
+      );
+    expect(rowsA).toHaveLength(1);
+    expect(rowsB).toHaveLength(1);
+  });
+
+  it('monotonic version per agent', async () => {
+    const d = await service.create(makeCreateInput());
+    for (let v = 1; v < 5; v++) {
+      const updated = await service.patch(d.id, {
+        ifMatchVersion: v,
+        name: `v${v + 1}`,
+      });
+      expect(updated.currentVersion).toBe(v + 1);
+    }
+  });
+});

--- a/packages/control-plane/src/agent-definition-service.ts
+++ b/packages/control-plane/src/agent-definition-service.ts
@@ -1,0 +1,592 @@
+/**
+ * AgentDefinitionService — versioned CRUD + optimistic concurrency (If-Match)
+ * for the AgentDefinition layer (the `agents` table; see
+ * specs/agent-definition-versioning.md §数据模型).
+ *
+ * Consumed by `/api/v1/agent-definitions/*` route handlers (task-8). The service
+ * raises domain-specific error classes rather than returning status codes or
+ * { ok, err } tuples; route handlers map these to the v1 error envelope.
+ *
+ * Design notes:
+ * - Mutation (create / patch / archive) runs in a single transaction. The PATCH
+ *   flow (spec §PATCH 流程) is 6 atomic steps: load current, check If-Match,
+ *   merge, insert version row, bump current_version, commit.
+ * - Row → domain mapping keeps Dates as `Date` objects. The API route layer
+ *   (task-8) converts to ISO strings when serialising with
+ *   `agentDefinitionSchema`. Keeping Dates in the service makes it reusable
+ *   from contexts that prefer native Date (logs, RunService).
+ * - The service accepts a drizzle `DbClient` directly (same pattern as
+ *   ProjectAgentService) to keep transaction boundaries explicit. Tests use
+ *   the pglite driver with the shared pglite-helpers schema.
+ */
+import { agentDefinitionVersions, agents, type DbClient } from '@open-rush/db';
+import { and, desc, eq, lt, sql } from 'drizzle-orm';
+
+type AgentRow = typeof agents.$inferSelect;
+type AgentVersionRow = typeof agentDefinitionVersions.$inferSelect;
+
+// ---------------------------------------------------------------------------
+// Domain types
+// ---------------------------------------------------------------------------
+
+/**
+ * Editable fields present in each version's `snapshot`. Mirrors
+ * `agentDefinitionEditableSchema` in `@open-rush/contracts/v1`. The ordering
+ * and set of keys must stay in sync; route handlers `.parse()` responses
+ * against the Zod schema.
+ */
+export interface AgentDefinitionEditable {
+  name: string;
+  description: string | null;
+  icon: string | null;
+  providerType: string;
+  model: string | null;
+  systemPrompt: string | null;
+  appendSystemPrompt: string | null;
+  allowedTools: string[];
+  skills: string[];
+  mcpServers: string[];
+  maxSteps: number;
+  deliveryMode: string;
+  config: Record<string, unknown> | null;
+}
+
+/** Full AgentDefinition as returned by service getters (Dates, not ISO). */
+export interface AgentDefinition extends AgentDefinitionEditable {
+  id: string;
+  projectId: string;
+  currentVersion: number;
+  archivedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Version history summary — no full snapshot payload. */
+export interface AgentDefinitionVersionSummary {
+  version: number;
+  changeNote: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+}
+
+/** Input for POST /api/v1/agent-definitions. */
+export interface CreateAgentDefinitionInput extends AgentDefinitionEditable {
+  projectId: string;
+  changeNote?: string | null;
+  createdBy?: string | null;
+}
+
+/** Input for PATCH /api/v1/agent-definitions/:id (with If-Match). */
+export interface PatchAgentDefinitionInput extends Partial<AgentDefinitionEditable> {
+  /**
+   * If-Match header value — the client-observed version. Must equal
+   * `agents.current_version` at the time of write, otherwise 409.
+   */
+  ifMatchVersion: number;
+  changeNote?: string | null;
+  updatedBy?: string | null;
+}
+
+export interface ListVersionsOptions {
+  /** Max rows (1..200), default 50. */
+  limit?: number;
+  /** Cursor = the lowest `version` returned in the previous page. */
+  cursorVersion?: number;
+}
+
+export interface ListVersionsResult {
+  items: AgentDefinitionVersionSummary[];
+  /**
+   * The version number to pass as `cursorVersion` in the next page, or `null`
+   * if no more rows. Smaller than the smallest `version` in `items`.
+   */
+  nextCursor: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class AgentDefinitionNotFoundError extends Error {
+  public readonly agentId: string;
+  constructor(agentId: string) {
+    super(`AgentDefinition ${agentId} not found`);
+    this.name = 'AgentDefinitionNotFoundError';
+    this.agentId = agentId;
+  }
+}
+
+/**
+ * 400 — caller passed a malformed numeric argument (`version`, `ifMatchVersion`,
+ * `limit`) where the service can cheaply validate before hitting the DB. Route
+ * handlers map this to `VALIDATION_ERROR` (as distinct from NOT_FOUND or
+ * VERSION_CONFLICT, which imply the record existed with a different state).
+ */
+export class InvalidAgentDefinitionInputError extends Error {
+  public readonly field: string;
+  public readonly value: unknown;
+  constructor(field: string, value: unknown, reason: string) {
+    super(`Invalid ${field}=${String(value)}: ${reason}`);
+    this.name = 'InvalidAgentDefinitionInputError';
+    this.field = field;
+    this.value = value;
+  }
+}
+
+export class AgentDefinitionVersionNotFoundError extends Error {
+  public readonly agentId: string;
+  public readonly version: number;
+  constructor(agentId: string, version: number) {
+    super(`AgentDefinition ${agentId} version ${version} not found`);
+    this.name = 'AgentDefinitionVersionNotFoundError';
+    this.agentId = agentId;
+    this.version = version;
+  }
+}
+
+/**
+ * 409 — PATCH If-Match did not match `agents.current_version` at write time.
+ * Clients should refetch the current version, merge, and retry.
+ */
+export class AgentDefinitionVersionConflictError extends Error {
+  public readonly agentId: string;
+  public readonly expected: number;
+  public readonly actual: number;
+  constructor(agentId: string, expected: number, actual: number) {
+    super(`AgentDefinition ${agentId} version conflict: If-Match=${expected}, current=${actual}`);
+    this.name = 'AgentDefinitionVersionConflictError';
+    this.agentId = agentId;
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+/**
+ * 400 — PATCH or archive attempted on an already-archived definition (spec
+ * §归档: "归档后不允许 PATCH").
+ */
+export class AgentDefinitionArchivedError extends Error {
+  public readonly agentId: string;
+  public readonly archivedAt: Date;
+  constructor(agentId: string, archivedAt: Date) {
+    super(`AgentDefinition ${agentId} is archived at ${archivedAt.toISOString()}`);
+    this.name = 'AgentDefinitionArchivedError';
+    this.agentId = agentId;
+    this.archivedAt = archivedAt;
+  }
+}
+
+/**
+ * 400 — PATCH body contained only bookkeeping fields (e.g. only changeNote)
+ * with no actual editable-field change. The contracts-level Zod refine catches
+ * this for HTTP, but service-level callers (RunService, tests) also hit it.
+ */
+export class EmptyAgentDefinitionPatchError extends Error {
+  constructor() {
+    super('PATCH must modify at least one editable field');
+    this.name = 'EmptyAgentDefinitionPatchError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row ↔ Domain mapping
+// ---------------------------------------------------------------------------
+
+const EDITABLE_KEYS: readonly (keyof AgentDefinitionEditable)[] = [
+  'name',
+  'description',
+  'icon',
+  'providerType',
+  'model',
+  'systemPrompt',
+  'appendSystemPrompt',
+  'allowedTools',
+  'skills',
+  'mcpServers',
+  'maxSteps',
+  'deliveryMode',
+  'config',
+] as const;
+
+function extractEditable(row: AgentRow): AgentDefinitionEditable {
+  return {
+    name: row.name,
+    description: row.description ?? null,
+    icon: row.icon ?? null,
+    providerType: row.providerType,
+    model: row.model ?? null,
+    systemPrompt: row.systemPrompt ?? null,
+    appendSystemPrompt: row.appendSystemPrompt ?? null,
+    allowedTools: row.allowedTools,
+    skills: row.skills,
+    mcpServers: row.mcpServers,
+    maxSteps: row.maxSteps,
+    deliveryMode: row.deliveryMode,
+    config:
+      row.config === null || row.config === undefined
+        ? null
+        : (row.config as Record<string, unknown>),
+  };
+}
+
+function rowToDefinition(row: AgentRow): AgentDefinition {
+  return {
+    ...extractEditable(row),
+    id: row.id,
+    projectId: row.projectId,
+    currentVersion: row.currentVersion,
+    archivedAt: row.archivedAt ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/**
+ * Keys that are valid for a snapshot payload. Used by the tolerant reader in
+ * {@link readSnapshotField} to check both `camelCase` (produced by this
+ * service from M2 onward) and `snake_case` (produced by the legacy v1
+ * migration — `to_jsonb(agents.*)` in `packages/db/drizzle/0009_...`).
+ *
+ * The dual-format support MUST remain even if we migrate old snapshots later:
+ * (a) existing deployments may never re-run the migration;
+ * (b) users may have exported/imported snapshots from elsewhere;
+ * (c) the two formats are the same shape, just different key casing.
+ */
+const SNAKE_KEYS: Record<keyof AgentDefinitionEditable, string> = {
+  name: 'name',
+  description: 'description',
+  icon: 'icon',
+  providerType: 'provider_type',
+  model: 'model',
+  systemPrompt: 'system_prompt',
+  appendSystemPrompt: 'append_system_prompt',
+  allowedTools: 'allowed_tools',
+  skills: 'skills',
+  mcpServers: 'mcp_servers',
+  maxSteps: 'max_steps',
+  deliveryMode: 'delivery_mode',
+  config: 'config',
+};
+
+function readSnapshotField<K extends keyof AgentDefinitionEditable>(
+  snapshot: Record<string, unknown>,
+  key: K
+): unknown {
+  if (key in snapshot) return snapshot[key];
+  const snake = SNAKE_KEYS[key];
+  if (snake in snapshot) return snapshot[snake];
+  return undefined;
+}
+
+/**
+ * Merge a historical snapshot with its owning agent row. Used by getByVersion:
+ * id/projectId/archivedAt/createdAt come from `agents`; the editable fields +
+ * `currentVersion` (= N) come from the snapshot row / its `version`.
+ *
+ * `updatedAt` on a historical snapshot = the version row's `created_at` (i.e.
+ * when that version was written). This keeps clients able to sort history by
+ * a meaningful timestamp without teaching them about `agent_definition_versions`.
+ *
+ * Reads BOTH camelCase and snake_case snapshot keys to stay compatible with
+ * the v1 migration (`to_jsonb(agents.*)`), which wrote snake_case columns.
+ * New snapshots written by {@link AgentDefinitionService.create} and
+ * {@link AgentDefinitionService.patch} use camelCase.
+ */
+function snapshotToDefinition(row: AgentRow, versionRow: AgentVersionRow): AgentDefinition {
+  const snapshot = (versionRow.snapshot ?? {}) as Record<string, unknown>;
+  const read = <K extends keyof AgentDefinitionEditable>(
+    key: K,
+    fallback: AgentDefinitionEditable[K]
+  ): AgentDefinitionEditable[K] => {
+    const v = readSnapshotField(snapshot, key);
+    return (v === undefined ? fallback : v) as AgentDefinitionEditable[K];
+  };
+
+  const editable: AgentDefinitionEditable = {
+    name: read('name', row.name),
+    description: read('description', null) as string | null,
+    icon: read('icon', null) as string | null,
+    providerType: read('providerType', row.providerType),
+    model: read('model', null) as string | null,
+    systemPrompt: read('systemPrompt', null) as string | null,
+    appendSystemPrompt: read('appendSystemPrompt', null) as string | null,
+    allowedTools: read('allowedTools', []) as string[],
+    skills: read('skills', []) as string[],
+    mcpServers: read('mcpServers', []) as string[],
+    maxSteps: read('maxSteps', row.maxSteps),
+    deliveryMode: read('deliveryMode', row.deliveryMode),
+    config: read('config', null) as Record<string, unknown> | null,
+  };
+  return {
+    ...editable,
+    id: row.id,
+    projectId: row.projectId,
+    currentVersion: versionRow.version,
+    archivedAt: row.archivedAt ?? null,
+    createdAt: row.createdAt,
+    updatedAt: versionRow.createdAt,
+  };
+}
+
+function versionRowToSummary(row: AgentVersionRow): AgentDefinitionVersionSummary {
+  return {
+    version: row.version,
+    changeNote: row.changeNote ?? null,
+    createdBy: row.createdBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Drop undefined-valued keys. Zod `.partial()` preserves undefined when used
+ * with `.extend({ changeNote })`, but we must NOT overwrite fields with
+ * `undefined` in the DB. Also strips the internal `changeNote` etc. which are
+ * not part of the snapshot.
+ */
+function pickEditablePatch(
+  input: Partial<AgentDefinitionEditable>
+): Partial<AgentDefinitionEditable> {
+  const out: Partial<AgentDefinitionEditable> = {};
+  for (const k of EDITABLE_KEYS) {
+    if (k in input && (input as Record<string, unknown>)[k] !== undefined) {
+      // @ts-expect-error -- key-based copy with dynamic TS
+      out[k] = input[k];
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class AgentDefinitionService {
+  constructor(private readonly db: DbClient) {}
+
+  /**
+   * POST /api/v1/agent-definitions — initial creation = v1 + inaugural snapshot.
+   * Runs in a single transaction: the `agents` row and its first
+   * `agent_definition_versions` row must be written atomically, otherwise a
+   * crash mid-way would leave an agent without history.
+   */
+  async create(input: CreateAgentDefinitionInput): Promise<AgentDefinition> {
+    return this.db.transaction(async (tx) => {
+      const insertValues: typeof agents.$inferInsert = {
+        projectId: input.projectId,
+        name: input.name,
+        description: input.description ?? null,
+        icon: input.icon ?? null,
+        providerType: input.providerType,
+        model: input.model ?? null,
+        systemPrompt: input.systemPrompt ?? null,
+        appendSystemPrompt: input.appendSystemPrompt ?? null,
+        allowedTools: input.allowedTools,
+        skills: input.skills,
+        mcpServers: input.mcpServers,
+        maxSteps: input.maxSteps,
+        deliveryMode: input.deliveryMode,
+        config: (input.config ?? null) as unknown as typeof agents.$inferInsert.config,
+        createdBy: input.createdBy ?? null,
+        currentVersion: 1,
+      };
+      const [row] = await tx.insert(agents).values(insertValues).returning();
+      if (!row) throw new Error('failed to insert agent row');
+
+      await tx.insert(agentDefinitionVersions).values({
+        agentId: row.id,
+        version: 1,
+        snapshot: extractEditable(row) as unknown as Record<string, unknown>,
+        changeNote: input.changeNote ?? null,
+        createdBy: input.createdBy ?? null,
+      });
+
+      return rowToDefinition(row);
+    });
+  }
+
+  /**
+   * GET /api/v1/agent-definitions/:id — returns the current row, = latest
+   * version. Archived rows are included (archived is a state, not a delete).
+   */
+  async get(agentId: string): Promise<AgentDefinition> {
+    const [row] = await this.db.select().from(agents).where(eq(agents.id, agentId)).limit(1);
+    if (!row) throw new AgentDefinitionNotFoundError(agentId);
+    return rowToDefinition(row);
+  }
+
+  /**
+   * GET /api/v1/agent-definitions/:id?version=N — returns the historical
+   * snapshot merged with the owning agent row's immutable metadata.
+   */
+  async getByVersion(agentId: string, version: number): Promise<AgentDefinition> {
+    if (!Number.isInteger(version) || version < 1) {
+      throw new InvalidAgentDefinitionInputError('version', version, 'must be a positive integer');
+    }
+    const [row] = await this.db.select().from(agents).where(eq(agents.id, agentId)).limit(1);
+    if (!row) throw new AgentDefinitionNotFoundError(agentId);
+    const [versionRow] = await this.db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(
+        and(
+          eq(agentDefinitionVersions.agentId, agentId),
+          eq(agentDefinitionVersions.version, version)
+        )
+      )
+      .limit(1);
+    if (!versionRow) throw new AgentDefinitionVersionNotFoundError(agentId, version);
+    return snapshotToDefinition(row, versionRow);
+  }
+
+  /**
+   * GET /api/v1/agent-definitions/:id/versions — descending version list,
+   * lightweight (no snapshot payload). Cursor-paginated by version number.
+   */
+  async listVersions(agentId: string, opts: ListVersionsOptions = {}): Promise<ListVersionsResult> {
+    const limit = clampLimit(opts.limit);
+    const [agentExists] = await this.db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .limit(1);
+    if (!agentExists) throw new AgentDefinitionNotFoundError(agentId);
+
+    const filters = [eq(agentDefinitionVersions.agentId, agentId)];
+    if (typeof opts.cursorVersion === 'number') {
+      filters.push(lt(agentDefinitionVersions.version, opts.cursorVersion));
+    }
+
+    // Fetch one extra to detect whether another page exists.
+    const rows = await this.db
+      .select()
+      .from(agentDefinitionVersions)
+      .where(and(...filters))
+      .orderBy(desc(agentDefinitionVersions.version))
+      .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const items = rows.slice(0, limit).map(versionRowToSummary);
+    const nextCursor = hasMore ? items[items.length - 1].version : null;
+    return { items, nextCursor };
+  }
+
+  /**
+   * PATCH /api/v1/agent-definitions/:id with If-Match: <N>.
+   *
+   * Implements spec §PATCH 流程 atomically:
+   *
+   *   1. Load current row (row-lock via `FOR UPDATE`).
+   *   2. Reject if archived.
+   *   3. Compare ifMatchVersion vs row.currentVersion → 409 on mismatch.
+   *   4. Merge current editable fields with the partial body.
+   *   5. Insert new `agent_definition_versions` row (version = current+1,
+   *      snapshot = merged editable).
+   *   6. Update `agents` with new fields + current_version = current+1.
+   *
+   * An empty patch (no non-changeNote keys) is rejected eagerly before the
+   * transaction to keep the semantics in sync with the Zod refine in
+   * `patchAgentDefinitionRequestSchema`.
+   */
+  async patch(agentId: string, input: PatchAgentDefinitionInput): Promise<AgentDefinition> {
+    if (!Number.isInteger(input.ifMatchVersion) || input.ifMatchVersion < 1) {
+      throw new InvalidAgentDefinitionInputError(
+        'ifMatchVersion',
+        input.ifMatchVersion,
+        'must be a positive integer'
+      );
+    }
+    const editablePatch = pickEditablePatch(input);
+    if (Object.keys(editablePatch).length === 0) {
+      throw new EmptyAgentDefinitionPatchError();
+    }
+
+    return this.db.transaction(async (tx) => {
+      // Acquire row lock so concurrent PATCHers serialise, preserving the
+      // invariant that `agent_definition_versions.version` is monotonic.
+      const [row] = await tx
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .for('update')
+        .limit(1);
+      if (!row) throw new AgentDefinitionNotFoundError(agentId);
+      if (row.archivedAt) {
+        throw new AgentDefinitionArchivedError(agentId, row.archivedAt);
+      }
+      if (row.currentVersion !== input.ifMatchVersion) {
+        throw new AgentDefinitionVersionConflictError(
+          agentId,
+          input.ifMatchVersion,
+          row.currentVersion
+        );
+      }
+
+      const nextVersion = row.currentVersion + 1;
+      const merged: AgentDefinitionEditable = {
+        ...extractEditable(row),
+        ...editablePatch,
+      };
+
+      await tx.insert(agentDefinitionVersions).values({
+        agentId,
+        version: nextVersion,
+        snapshot: merged as unknown as Record<string, unknown>,
+        changeNote: input.changeNote ?? null,
+        createdBy: input.updatedBy ?? null,
+      });
+
+      const now = new Date();
+      const updateValues: Partial<typeof agents.$inferInsert> = {
+        ...editablePatch,
+        config:
+          'config' in editablePatch
+            ? ((editablePatch.config ?? null) as unknown as typeof agents.$inferInsert.config)
+            : undefined,
+        currentVersion: nextVersion,
+        updatedAt: now,
+      };
+      // Strip undefined keys so drizzle doesn't overwrite columns with NULL.
+      for (const k of Object.keys(updateValues) as (keyof typeof updateValues)[]) {
+        if (updateValues[k] === undefined) delete updateValues[k];
+      }
+
+      const [updated] = await tx
+        .update(agents)
+        .set(updateValues)
+        .where(eq(agents.id, agentId))
+        .returning();
+      if (!updated) throw new AgentDefinitionNotFoundError(agentId);
+      return rowToDefinition(updated);
+    });
+  }
+
+  /**
+   * POST /api/v1/agent-definitions/:id/archive — sets `archived_at = now()`.
+   * Idempotent: archiving an already-archived row returns the existing record
+   * without bumping a version (archival is metadata, not a definition change).
+   */
+  async archive(agentId: string): Promise<AgentDefinition> {
+    return this.db.transaction(async (tx) => {
+      const [row] = await tx
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .for('update')
+        .limit(1);
+      if (!row) throw new AgentDefinitionNotFoundError(agentId);
+      if (row.archivedAt) return rowToDefinition(row);
+      const [updated] = await tx
+        .update(agents)
+        .set({ archivedAt: sql`now()`, updatedAt: sql`now()` })
+        .where(eq(agents.id, agentId))
+        .returning();
+      if (!updated) throw new AgentDefinitionNotFoundError(agentId);
+      return rowToDefinition(updated);
+    });
+  }
+}
+
+function clampLimit(raw: number | undefined): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 1) return 50;
+  return Math.min(Math.floor(raw), 200);
+}

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,5 +1,21 @@
 export * from './admin/index.js';
 export * from './agent/index.js';
+export {
+  type AgentDefinition,
+  AgentDefinitionArchivedError,
+  type AgentDefinitionEditable,
+  AgentDefinitionNotFoundError,
+  AgentDefinitionService,
+  AgentDefinitionVersionConflictError,
+  AgentDefinitionVersionNotFoundError,
+  type AgentDefinitionVersionSummary,
+  type CreateAgentDefinitionInput,
+  EmptyAgentDefinitionPatchError,
+  InvalidAgentDefinitionInputError,
+  type ListVersionsOptions,
+  type ListVersionsResult,
+  type PatchAgentDefinitionInput,
+} from './agent-definition-service.js';
 export * from './auth/index.js';
 export * from './conversation/index.js';
 export * from './deploy/index.js';


### PR DESCRIPTION
## Summary
- Implements `AgentDefinitionService` — versioned CRUD for the AgentDefinition layer with 6-step atomic PATCH flow, optimistic-concurrency `If-Match` guard, and archive semantics. Per `specs/agent-definition-versioning.md`.
- Tolerant snapshot reader handles BOTH camelCase (written by this service) and snake_case (written by migration `0009_agent_definition_versions.sql` via `to_jsonb(agents.*)`), so historical v1 snapshots remain readable.
- Domain error classes (InvalidInput / NotFound / VersionNotFound / VersionConflict / Archived / EmptyPatch) for 1:1 mapping to v1 `ErrorCode` in task-8 API route handlers.
- 30 PGlite integration tests covering create/get/getByVersion/listVersions/patch/archive + concurrency + legacy snake_case + invariants.

## Test plan
- [x] `pnpm --filter @open-rush/control-plane build` (tsup + DTS)
- [x] `pnpm --filter @open-rush/control-plane check`
- [x] `pnpm --filter @open-rush/control-plane lint` — no new errors (3 pre-existing warnings untouched)
- [x] `pnpm --filter @open-rush/control-plane test` — 35 files / 476 tests passing
- [x] `./docs/execution/verify.sh task-7` — PASS
- [x] Sparring review: round 1 CONCERNS (snake_case MUST-FIX + validation-vs-notfound SHOULD-FIX) → round 2 **APPROVE**

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)