### PR TITLE
chore(db-test): bump beforeAll/afterAll timeout to 30s for PGlite tests

### DIFF
--- a/packages/db/src/__tests__/agent-definition-versions.test.ts
+++ b/packages/db/src/__tests__/agent-definition-versions.test.ts
@@ -12,11 +12,11 @@ beforeAll(async () => {
   const result = await createTestDb();
   db = result.db;
   pglite = result.pglite;
-});
+}, 30000);
 
 afterAll(async () => {
   await closeTestDb(pglite);
-});
+}, 30000);
 
 beforeEach(async () => {
   await truncateAll(db);

--- a/packages/db/src/__tests__/crud.test.ts
+++ b/packages/db/src/__tests__/crud.test.ts
@@ -31,11 +31,11 @@ beforeAll(async () => {
   const result = await createTestDb();
   db = result.db;
   pglite = result.pglite;
-});
+}, 30000);
 
 afterAll(async () => {
   await closeTestDb(pglite);
-});
+}, 30000);
 
 beforeEach(async () => {
   await truncateAll(db);

--- a/packages/db/src/__tests__/runs-extension.test.ts
+++ b/packages/db/src/__tests__/runs-extension.test.ts
@@ -23,11 +23,11 @@ beforeAll(async () => {
   const result = await createTestDb();
   db = result.db;
   pglite = result.pglite;
-});
+}, 30000);
 
 afterAll(async () => {
   await closeTestDb(pglite);
-});
+}, 30000);
 
 beforeEach(async () => {
   await truncateAll(db);

--- a/packages/db/src/__tests__/service-tokens.test.ts
+++ b/packages/db/src/__tests__/service-tokens.test.ts
@@ -13,11 +13,11 @@ beforeAll(async () => {
   const result = await createTestDb();
   db = result.db;
   pglite = result.pglite;
-});
+}, 30000);
 
 afterAll(async () => {
   await closeTestDb(pglite);
-});
+}, 30000);
 
 beforeEach(async () => {
   await truncateAll(db);


### PR DESCRIPTION
## 背景

PR #145 (task-11) CI failed on \`@open-rush/db#test\`:

\`\`\`
FAIL  src/__tests__/crud.test.ts
Error: Hook timed out in 10000ms.
 ❯ src/__tests__/crud.test.ts:30:1
    beforeAll(async () => { const result = await createTestDb() ... });
\`\`\`

\`createTestDb()\` 在 \`packages/db/test/pglite-helpers.ts\` 累积了 440+ 行 inline CREATE TABLE + 15+ indexes(跨 task-1/2/3/10/11 的 schema 增改)。CI 机器 PGlite 冷启动 + DDL 压力交叉越过 Vitest 默认 10s hookTimeout。

**不是 task-11 引入** — 预先存在的技术债,task-11 恰好让曲线越过阈值。

## 变更范围

4 个使用 \`createTestDb()\` 的 test 文件,\`beforeAll\` / \`afterAll\` 加 \`, 30000\`:

- \`packages/db/src/__tests__/crud.test.ts\`(失败的)
- \`packages/db/src/__tests__/service-tokens.test.ts\`(~12s 接近)
- \`packages/db/src/__tests__/runs-extension.test.ts\`(接近阈值)
- \`packages/db/src/__tests__/agent-definition-versions.test.ts\`(~8s)

共 4 files, +8/-8。**纯 test infra,无 business logic / schema / helper / contracts 改动**。

## 替代方案考虑

全局调整 \`vitest.config.ts\` hookTimeout → 拒绝。显式 per-hook 覆盖保持成本可见 + 局部,未来 grep \`30000\` 就能找到 pattern。

## 长期方向

\`pglite-helpers.ts\` 的 440 行 inline CREATE 长远应替换为"跑 drizzle migrations"(task-11 agent-b 在 \`migration.test.ts\` 已经示范)。这次 chore 不包括,留给后续。

## Sparring Review

**APPROVE** (gpt-5.3-codex-xhigh):
- 修复命中根因(Vitest hookTimeout 10s 被 PGlite cold-start + DDL 超了)
- 风险可控(纯 hook timeout,不改 schema / helper / 业务)
- 策略一致("局部显式覆盖" > 全局放宽)
- 残余风险:未来 schema 增长可能再到 30s,长期 migration-based 初始化仍是更彻底方案

## 影响

- unblocks PR #145 (task-11) rebase + CI 重跑
- 不阻塞其他 in-flight PR(Agent-A task-8,Agent-B 后续 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)