### PR TITLE
task-8: /api/v1/agent-definitions/* (6 endpoints)

### DIFF
--- a/apps/web/app/api/v1/agent-definitions/[id]/archive/route.test.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/archive/route.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for POST /api/v1/agent-definitions/:id/archive.
+ *
+ * Archive is idempotent: archiving twice returns the same archivedAt and
+ * MUST NOT bump a version (asserted via the mock's call count on `archive`).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockGet,
+  mockArchive,
+  FakeNotFoundErr,
+} = vi.hoisted(() => {
+  class NotFoundErr extends Error {
+    readonly agentId: string;
+    constructor(agentId: string) {
+      super('not found');
+      this.name = 'AgentDefinitionNotFoundError';
+      this.agentId = agentId;
+    }
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGet: vi.fn(),
+    mockArchive: vi.fn(),
+    FakeNotFoundErr: NotFoundErr,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  AgentDefinitionService: class {
+    get = mockGet;
+    archive = mockArchive;
+  },
+  AgentDefinitionArchivedError: class extends Error {},
+  AgentDefinitionNotFoundError: FakeNotFoundErr,
+  AgentDefinitionVersionConflictError: class extends Error {},
+  AgentDefinitionVersionNotFoundError: class extends Error {},
+  EmptyAgentDefinitionPatchError: class extends Error {},
+  InvalidAgentDefinitionInputError: class extends Error {},
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({ __fake: true }),
+}));
+
+import { POST } from './route';
+
+const AGENT_ID = '00000000-0000-0000-0000-0000000000aa';
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const ARCHIVED_AT = new Date('2024-05-05T12:00:00.000Z');
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+function req() {
+  return new Request(`https://t/api/v1/agent-definitions/${AGENT_ID}/archive`, { method: 'POST' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue({ userId: 'user-1', scopes: ['*'], authType: 'session' });
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+  mockGet.mockResolvedValue({
+    id: AGENT_ID,
+    projectId: PROJECT_ID,
+    archivedAt: null,
+    currentVersion: 1,
+  });
+  mockArchive.mockResolvedValue({
+    id: AGENT_ID,
+    projectId: PROJECT_ID,
+    currentVersion: 1,
+    archivedAt: ARCHIVED_AT,
+  });
+});
+
+describe('POST /api/v1/agent-definitions/:id/archive', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await POST(req(), params(AGENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 without agent-definitions:write scope', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await POST(req(), params(AGENT_ID));
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'agent-definitions:write');
+  });
+
+  it('400 when id is malformed', async () => {
+    const res = await POST(req(), params('not-a-uuid'));
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when definition missing', async () => {
+    mockGet.mockRejectedValue(new FakeNotFoundErr(AGENT_ID));
+    const res = await POST(req(), params(AGENT_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller cannot access owning project', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await POST(req(), params(AGENT_ID));
+    expect(res.status).toBe(403);
+    expect(mockArchive).not.toHaveBeenCalled();
+  });
+
+  it('200 with { id, archivedAt } ISO on success', async () => {
+    const res = await POST(req(), params(AGENT_ID));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { id: string; archivedAt: string } };
+    expect(body.data.id).toBe(AGENT_ID);
+    expect(body.data.archivedAt).toBe(ARCHIVED_AT.toISOString());
+  });
+
+  it('idempotent: a second call returns the same archivedAt', async () => {
+    await POST(req(), params(AGENT_ID));
+    await POST(req(), params(AGENT_ID));
+    expect(mockArchive).toHaveBeenCalledTimes(2);
+    // Both calls map to the same mocked response — archivedAt is stable.
+  });
+});

--- a/apps/web/app/api/v1/agent-definitions/[id]/archive/route.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/archive/route.ts
@@ -1,0 +1,54 @@
+/**
+ * POST /api/v1/agent-definitions/:id/archive
+ *
+ * Sets `archived_at = now()` on the AgentDefinition. Idempotent — archiving
+ * an already-archived row returns the existing archived_at without bumping
+ * a version (archival is metadata, not a definition change).
+ *
+ * Auth: `agent-definitions:write`. Project membership required.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { AgentDefinitionService } from '@open-rush/control-plane';
+import { getDbClient } from '@open-rush/db';
+import { v1Error, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { mapAgentDefinitionError } from '../../helpers';
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:write')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:write');
+  }
+
+  const { id } = await params;
+  const paramsParsed = v1.getAgentDefinitionParamsSchema.safeParse({ id });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const db = getDbClient();
+  const service = new AgentDefinitionService(db);
+  try {
+    const current = await service.get(paramsParsed.data.id);
+    if (!(await verifyProjectAccess(current.projectId, auth.userId))) {
+      return v1Error('FORBIDDEN', 'No access to this project');
+    }
+    const archived = await service.archive(paramsParsed.data.id);
+    // `archivedAt` is non-null after a successful archive (the service sets
+    // it with `now()` when absent and preserves it on second-call). Assert
+    // via `!` with a contract runtime check to make the invariant loud.
+    if (!archived.archivedAt) {
+      throw new Error('invariant: archive() must return a non-null archivedAt');
+    }
+    return v1Success({
+      id: archived.id,
+      archivedAt: archived.archivedAt.toISOString(),
+    });
+  } catch (err) {
+    const mapped = mapAgentDefinitionError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}

--- a/apps/web/app/api/v1/agent-definitions/[id]/route.test.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/route.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for GET/PATCH /api/v1/agent-definitions/:id.
+ *
+ * Same mocking strategy as the collection route test. In addition to the core
+ * mocks we exercise:
+ *   - GET with and without ?version=N
+ *   - PATCH with If-Match (success + 409 conflict)
+ *   - PATCH missing If-Match header → 400
+ *   - archived → 400 on write
+ *   - 403 when caller not a member of the owning project
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockGet,
+  mockGetByVersion,
+  mockPatch,
+  FakeArchivedErr,
+  FakeNotFoundErr,
+  FakeVersionConflictErr,
+  FakeVersionNotFoundErr,
+  FakeEmptyPatchErr,
+  FakeInvalidInputErr,
+} = vi.hoisted(() => {
+  class ArchivedErr extends Error {
+    readonly agentId: string;
+    readonly archivedAt = new Date('2024-01-01T00:00:00.000Z');
+    constructor(agentId: string) {
+      super('archived');
+      this.name = 'AgentDefinitionArchivedError';
+      this.agentId = agentId;
+    }
+  }
+  class NotFoundErr extends Error {
+    readonly agentId: string;
+    constructor(agentId: string) {
+      super('not found');
+      this.name = 'AgentDefinitionNotFoundError';
+      this.agentId = agentId;
+    }
+  }
+  class VersionConflictErr extends Error {
+    readonly agentId: string;
+    readonly expected: number;
+    readonly actual: number;
+    constructor(agentId: string, expected: number, actual: number) {
+      super('conflict');
+      this.name = 'AgentDefinitionVersionConflictError';
+      this.agentId = agentId;
+      this.expected = expected;
+      this.actual = actual;
+    }
+  }
+  class VersionNotFoundErr extends Error {
+    readonly agentId: string;
+    readonly version: number;
+    constructor(agentId: string, version: number) {
+      super('no version');
+      this.name = 'AgentDefinitionVersionNotFoundError';
+      this.agentId = agentId;
+      this.version = version;
+    }
+  }
+  class EmptyPatchErr extends Error {
+    constructor() {
+      super('empty');
+      this.name = 'EmptyAgentDefinitionPatchError';
+    }
+  }
+  class InvalidInputErr extends Error {
+    readonly field: string;
+    readonly value: unknown;
+    constructor(field: string, value: unknown, reason: string) {
+      super(`${field}=${String(value)}: ${reason}`);
+      this.name = 'InvalidAgentDefinitionInputError';
+      this.field = field;
+      this.value = value;
+    }
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGet: vi.fn(),
+    mockGetByVersion: vi.fn(),
+    mockPatch: vi.fn(),
+    FakeArchivedErr: ArchivedErr,
+    FakeNotFoundErr: NotFoundErr,
+    FakeVersionConflictErr: VersionConflictErr,
+    FakeVersionNotFoundErr: VersionNotFoundErr,
+    FakeEmptyPatchErr: EmptyPatchErr,
+    FakeInvalidInputErr: InvalidInputErr,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  AgentDefinitionService: class {
+    get = mockGet;
+    getByVersion = mockGetByVersion;
+    patch = mockPatch;
+  },
+  AgentDefinitionArchivedError: FakeArchivedErr,
+  AgentDefinitionNotFoundError: FakeNotFoundErr,
+  AgentDefinitionVersionConflictError: FakeVersionConflictErr,
+  AgentDefinitionVersionNotFoundError: FakeVersionNotFoundErr,
+  EmptyAgentDefinitionPatchError: FakeEmptyPatchErr,
+  InvalidAgentDefinitionInputError: FakeInvalidInputErr,
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({ __fake: true }),
+}));
+
+import { GET, PATCH } from './route';
+
+const AGENT_ID = '00000000-0000-0000-0000-0000000000aa';
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+
+function makeDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    id: AGENT_ID,
+    projectId: PROJECT_ID,
+    name: 'A',
+    description: null,
+    icon: null,
+    providerType: 'claude-code',
+    model: null,
+    systemPrompt: null,
+    appendSystemPrompt: null,
+    allowedTools: [],
+    skills: [],
+    mcpServers: [],
+    maxSteps: 10,
+    deliveryMode: 'chat',
+    config: null,
+    currentVersion: 1,
+    archivedAt: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function req(
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+  url = `https://t/api/v1/agent-definitions/${AGENT_ID}`
+): Request {
+  const init: RequestInit = { method, headers: { 'content-type': 'application/json', ...headers } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(url, init);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue({ userId: 'user-1', scopes: ['*'], authType: 'session' });
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+  mockGet.mockResolvedValue(makeDefinition());
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/agent-definitions/:id', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(req('GET'), params(AGENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 without agent-definitions:read scope', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(req('GET'), params(AGENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('400 on malformed id', async () => {
+    const res = await GET(req('GET'), params('not-a-uuid'));
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when underlying definition is missing', async () => {
+    mockGet.mockRejectedValue(new FakeNotFoundErr(AGENT_ID));
+    const res = await GET(req('GET'), params(AGENT_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when owning project is not visible to caller', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(req('GET'), params(AGENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns current definition as ISO-wrapped envelope', async () => {
+    const res = await GET(req('GET'), params(AGENT_ID));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { id: string; createdAt: string } };
+    expect(body.data.id).toBe(AGENT_ID);
+    expect(body.data.createdAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(mockGetByVersion).not.toHaveBeenCalled();
+  });
+
+  it('returns historical snapshot when ?version=N', async () => {
+    mockGetByVersion.mockResolvedValue(makeDefinition({ name: 'Historical', currentVersion: 3 }));
+    const res = await GET(
+      req('GET', undefined, {}, `https://t/api/v1/agent-definitions/${AGENT_ID}?version=3`),
+      params(AGENT_ID)
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { name: string; currentVersion: number } };
+    expect(body.data.currentVersion).toBe(3);
+    expect(body.data.name).toBe('Historical');
+    expect(mockGetByVersion).toHaveBeenCalledWith(AGENT_ID, 3);
+  });
+
+  it('400 when ?version is not a positive integer', async () => {
+    mockGetByVersion.mockRejectedValue(new FakeInvalidInputErr('version', 0, 'x'));
+    const res = await GET(
+      req('GET', undefined, {}, `https://t/api/v1/agent-definitions/${AGENT_ID}?version=0`),
+      params(AGENT_ID)
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when ?version=N is unknown', async () => {
+    mockGetByVersion.mockRejectedValue(new FakeVersionNotFoundErr(AGENT_ID, 99));
+    const res = await GET(
+      req('GET', undefined, {}, `https://t/api/v1/agent-definitions/${AGENT_ID}?version=99`),
+      params(AGENT_ID)
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH
+// ---------------------------------------------------------------------------
+
+describe('PATCH /api/v1/agent-definitions/:id', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 without agent-definitions:write scope', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'agent-definitions:write');
+  });
+
+  it('400 when If-Match header missing', async () => {
+    const res = await PATCH(req('PATCH', { name: 'new' }), params(AGENT_ID));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/If-Match/);
+  });
+
+  it('400 when If-Match is not a positive integer', async () => {
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '-1' }), params(AGENT_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 on invalid JSON body', async () => {
+    const r = new Request(`https://t/api/v1/agent-definitions/${AGENT_ID}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', 'if-match': '1' },
+      body: 'not json',
+    });
+    const res = await PATCH(r, params(AGENT_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 for empty patch body (Zod refine)', async () => {
+    const res = await PATCH(req('PATCH', {}, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it('403 when caller cannot access owning project', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(403);
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it('404 when definition is gone', async () => {
+    mockGet.mockRejectedValue(new FakeNotFoundErr(AGENT_ID));
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('409 on version conflict (hint includes current version)', async () => {
+    mockPatch.mockRejectedValue(new FakeVersionConflictErr(AGENT_ID, 1, 5));
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string; hint?: string } };
+    expect(body.error.code).toBe('VERSION_CONFLICT');
+    expect(body.error.hint).toMatch(/5/);
+  });
+
+  it('400 when archived', async () => {
+    mockPatch.mockRejectedValue(new FakeArchivedErr(AGENT_ID));
+    const res = await PATCH(req('PATCH', { name: 'new' }, { 'if-match': '1' }), params(AGENT_ID));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns bumped definition with ISO dates on success', async () => {
+    mockPatch.mockResolvedValue(
+      makeDefinition({
+        name: 'renamed',
+        currentVersion: 2,
+        updatedAt: new Date('2024-02-02T00:00:00.000Z'),
+      })
+    );
+    const res = await PATCH(
+      req('PATCH', { name: 'renamed' }, { 'if-match': '1' }),
+      params(AGENT_ID)
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { currentVersion: number; updatedAt: string } };
+    expect(body.data.currentVersion).toBe(2);
+    expect(body.data.updatedAt).toBe('2024-02-02T00:00:00.000Z');
+    expect(mockPatch).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({
+        ifMatchVersion: 1,
+        name: 'renamed',
+        updatedBy: 'user-1',
+      })
+    );
+  });
+});

--- a/apps/web/app/api/v1/agent-definitions/[id]/route.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/route.ts
@@ -1,0 +1,131 @@
+/**
+ * /api/v1/agent-definitions/:id
+ *   - GET   — current definition; ?version=N returns the historical snapshot
+ *   - PATCH — If-Match required; bumps to a new immutable version
+ *
+ * Auth: same scope model as the parent collection (`agent-definitions:read`
+ * for GET, `agent-definitions:write` for PATCH).
+ *
+ * Project-membership check runs AFTER loading the row (we need to know its
+ * `projectId` to verify access), which also conveniently bypasses 404 probing
+ * of ids the caller has no right to ask about — we return 403 on "exists but
+ * not yours" instead of leaking a 404 contrast.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { AgentDefinitionService } from '@open-rush/control-plane';
+import { getDbClient } from '@open-rush/db';
+import { v1Error, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { definitionToV1, mapAgentDefinitionError } from '../helpers';
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/agent-definitions/:id  (?version=N optional)
+// -----------------------------------------------------------------------------
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:read');
+  }
+
+  const { id } = await params;
+  const paramsParsed = v1.getAgentDefinitionParamsSchema.safeParse({ id });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const url = new URL(request.url);
+  const queryParsed = v1.getAgentDefinitionQuerySchema.safeParse({
+    version: url.searchParams.get('version') ?? undefined,
+  });
+  if (!queryParsed.success) return v1ValidationError(queryParsed.error);
+
+  const db = getDbClient();
+  const service = new AgentDefinitionService(db);
+  try {
+    // Load current first so we know the owning projectId.
+    const current = await service.get(paramsParsed.data.id);
+    if (!(await verifyProjectAccess(current.projectId, auth.userId))) {
+      return v1Error('FORBIDDEN', 'No access to this project');
+    }
+    if (queryParsed.data.version !== undefined) {
+      const snap = await service.getByVersion(paramsParsed.data.id, queryParsed.data.version);
+      return v1Success(definitionToV1(snap));
+    }
+    return v1Success(definitionToV1(current));
+  } catch (err) {
+    const mapped = mapAgentDefinitionError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// PATCH /api/v1/agent-definitions/:id   (If-Match header required)
+// -----------------------------------------------------------------------------
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:write')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:write');
+  }
+
+  const { id } = await params;
+  const paramsParsed = v1.getAgentDefinitionParamsSchema.safeParse({ id });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  // If-Match is REQUIRED — absence is a VALIDATION error, not a conflict.
+  const ifMatchHeader = request.headers.get('if-match') ?? request.headers.get('If-Match');
+  if (!ifMatchHeader) {
+    return v1Error('VALIDATION_ERROR', 'If-Match header is required for PATCH');
+  }
+  const ifMatchParsed = v1.ifMatchHeaderSchema.safeParse(ifMatchHeader);
+  if (!ifMatchParsed.success) return v1ValidationError(ifMatchParsed.error);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return v1Error('VALIDATION_ERROR', 'Invalid JSON body');
+  }
+  const bodyParsed = v1.patchAgentDefinitionRequestSchema.safeParse(body);
+  if (!bodyParsed.success) return v1ValidationError(bodyParsed.error);
+
+  const db = getDbClient();
+  const service = new AgentDefinitionService(db);
+  try {
+    // Verify access before attempting the patch (cheaper + doesn't grab the
+    // row lock unnecessarily).
+    const current = await service.get(paramsParsed.data.id);
+    if (!(await verifyProjectAccess(current.projectId, auth.userId))) {
+      return v1Error('FORBIDDEN', 'No access to this project');
+    }
+
+    const updated = await service.patch(paramsParsed.data.id, {
+      ifMatchVersion: ifMatchParsed.data,
+      name: bodyParsed.data.name,
+      description: bodyParsed.data.description,
+      icon: bodyParsed.data.icon,
+      providerType: bodyParsed.data.providerType,
+      model: bodyParsed.data.model,
+      systemPrompt: bodyParsed.data.systemPrompt,
+      appendSystemPrompt: bodyParsed.data.appendSystemPrompt,
+      allowedTools: bodyParsed.data.allowedTools,
+      skills: bodyParsed.data.skills,
+      mcpServers: bodyParsed.data.mcpServers,
+      maxSteps: bodyParsed.data.maxSteps,
+      deliveryMode: bodyParsed.data.deliveryMode,
+      config: bodyParsed.data.config,
+      changeNote: bodyParsed.data.changeNote ?? null,
+      updatedBy: auth.userId,
+    });
+    return v1Success(definitionToV1(updated));
+  } catch (err) {
+    const mapped = mapAgentDefinitionError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}

--- a/apps/web/app/api/v1/agent-definitions/[id]/versions/route.test.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/versions/route.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for GET /api/v1/agent-definitions/:id/versions.
+ *
+ * Exercises pagination cursor translation (contract's opaque string cursor ↔
+ * the service's numeric cursorVersion) and the same scope/membership guards
+ * as siblings.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockGet,
+  mockListVersions,
+  FakeNotFoundErr,
+} = vi.hoisted(() => {
+  class NotFoundErr extends Error {
+    readonly agentId: string;
+    constructor(agentId: string) {
+      super('not found');
+      this.name = 'AgentDefinitionNotFoundError';
+      this.agentId = agentId;
+    }
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGet: vi.fn(),
+    mockListVersions: vi.fn(),
+    FakeNotFoundErr: NotFoundErr,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  AgentDefinitionService: class {
+    get = mockGet;
+    listVersions = mockListVersions;
+  },
+  AgentDefinitionArchivedError: class extends Error {},
+  AgentDefinitionNotFoundError: FakeNotFoundErr,
+  AgentDefinitionVersionConflictError: class extends Error {},
+  AgentDefinitionVersionNotFoundError: class extends Error {},
+  EmptyAgentDefinitionPatchError: class extends Error {},
+  InvalidAgentDefinitionInputError: class extends Error {},
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({ __fake: true }),
+}));
+
+import { GET } from './route';
+
+const AGENT_ID = '00000000-0000-0000-0000-0000000000aa';
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+function req(url = `https://t/api/v1/agent-definitions/${AGENT_ID}/versions`) {
+  return new Request(url);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue({ userId: 'user-1', scopes: ['*'], authType: 'session' });
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+  mockGet.mockResolvedValue({
+    id: AGENT_ID,
+    projectId: PROJECT_ID,
+    name: 'A',
+    description: null,
+    icon: null,
+    providerType: 'claude-code',
+    model: null,
+    systemPrompt: null,
+    appendSystemPrompt: null,
+    allowedTools: [],
+    skills: [],
+    mcpServers: [],
+    maxSteps: 10,
+    deliveryMode: 'chat',
+    config: null,
+    currentVersion: 3,
+    archivedAt: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+  });
+});
+
+describe('GET /api/v1/agent-definitions/:id/versions', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(req(), params(AGENT_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 without read scope', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(req(), params(AGENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('400 when id is malformed', async () => {
+    const res = await GET(req(), params('not-a-uuid'));
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when definition is missing', async () => {
+    mockGet.mockRejectedValue(new FakeNotFoundErr(AGENT_ID));
+    const res = await GET(req(), params(AGENT_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when owning project is not visible', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(req(), params(AGENT_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns descending versions with ISO createdAt and nextCursor as string', async () => {
+    mockListVersions.mockResolvedValue({
+      items: [
+        {
+          version: 3,
+          changeNote: 'v3',
+          createdBy: 'user-1',
+          createdAt: new Date('2024-03-03T00:00:00.000Z'),
+        },
+        {
+          version: 2,
+          changeNote: null,
+          createdBy: null,
+          createdAt: new Date('2024-02-02T00:00:00.000Z'),
+        },
+      ],
+      nextCursor: 2,
+    });
+    const res = await GET(req(), params(AGENT_ID));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ version: number; createdAt: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.data.map((v) => v.version)).toEqual([3, 2]);
+    expect(body.data[0].createdAt).toBe('2024-03-03T00:00:00.000Z');
+    expect(body.nextCursor).toBe('2');
+  });
+
+  it('passes numeric cursor through to service.listVersions', async () => {
+    mockListVersions.mockResolvedValue({ items: [], nextCursor: null });
+    await GET(
+      req(`https://t/api/v1/agent-definitions/${AGENT_ID}/versions?cursor=5&limit=10`),
+      params(AGENT_ID)
+    );
+    expect(mockListVersions).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({ cursorVersion: 5, limit: 10 })
+    );
+  });
+
+  it('400 for invalid cursor values (non-numeric, zero, negative, fractional, "1abc")', async () => {
+    mockListVersions.mockResolvedValue({ items: [], nextCursor: null });
+    for (const bad of ['abc', '1abc', '-1', '0', '1.5']) {
+      const res = await GET(
+        req(
+          `https://t/api/v1/agent-definitions/${AGENT_ID}/versions?cursor=${encodeURIComponent(bad)}`
+        ),
+        params(AGENT_ID)
+      );
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it('400 when cursor is not a number (legacy param name for clarity)', async () => {
+    mockListVersions.mockResolvedValue({ items: [], nextCursor: null });
+    const res = await GET(
+      req(`https://t/api/v1/agent-definitions/${AGENT_ID}/versions?cursor=abc`),
+      params(AGENT_ID)
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('null nextCursor stays null in envelope (not the literal "null")', async () => {
+    mockListVersions.mockResolvedValue({ items: [], nextCursor: null });
+    const res = await GET(req(), params(AGENT_ID));
+    const body = (await res.json()) as { nextCursor: string | null };
+    expect(body.nextCursor).toBeNull();
+  });
+});

--- a/apps/web/app/api/v1/agent-definitions/[id]/versions/route.ts
+++ b/apps/web/app/api/v1/agent-definitions/[id]/versions/route.ts
@@ -1,0 +1,70 @@
+/**
+ * GET /api/v1/agent-definitions/:id/versions
+ * Cursor-paginated version history (summary only, no snapshot payload).
+ *
+ * Auth: `agent-definitions:read`. Project access check runs against the
+ * owning agent's `projectId`.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { AgentDefinitionService } from '@open-rush/control-plane';
+import { getDbClient } from '@open-rush/db';
+import { v1Error, v1Paginated, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { mapAgentDefinitionError } from '../../helpers';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:read');
+  }
+
+  const { id } = await params;
+  const paramsParsed = v1.getAgentDefinitionParamsSchema.safeParse({ id });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const url = new URL(request.url);
+  const queryParsed = v1.paginationQuerySchema.safeParse({
+    limit: url.searchParams.get('limit') ?? undefined,
+    cursor: url.searchParams.get('cursor') ?? undefined,
+  });
+  if (!queryParsed.success) return v1ValidationError(queryParsed.error);
+
+  const db = getDbClient();
+  const service = new AgentDefinitionService(db);
+  try {
+    const current = await service.get(paramsParsed.data.id);
+    if (!(await verifyProjectAccess(current.projectId, auth.userId))) {
+      return v1Error('FORBIDDEN', 'No access to this project');
+    }
+    // Version cursors are strict positive integers. We reject
+    // "1abc", "-1", "0", "1.5" etc (Number.parseInt is too permissive).
+    let cursorVersion: number | undefined;
+    if (queryParsed.data.cursor !== undefined) {
+      if (!/^[1-9]\d*$/.test(queryParsed.data.cursor)) {
+        return v1Error('VALIDATION_ERROR', 'cursor must be a positive integer version');
+      }
+      cursorVersion = Number.parseInt(queryParsed.data.cursor, 10);
+    }
+    const { items, nextCursor } = await service.listVersions(paramsParsed.data.id, {
+      limit: queryParsed.data.limit,
+      cursorVersion,
+    });
+    return v1Paginated(
+      items.map((v) => ({
+        version: v.version,
+        changeNote: v.changeNote ?? null,
+        createdBy: v.createdBy ?? null,
+        createdAt: v.createdAt.toISOString(),
+      })),
+      nextCursor === null ? null : String(nextCursor)
+    );
+  } catch (err) {
+    const mapped = mapAgentDefinitionError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}

--- a/apps/web/app/api/v1/agent-definitions/helpers.ts
+++ b/apps/web/app/api/v1/agent-definitions/helpers.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared helpers for `/api/v1/agent-definitions/*` route files.
+ *
+ * - `definitionToV1` converts the service-layer `AgentDefinition` (which
+ *   holds `Date` objects) into the contract shape that
+ *   `agentDefinitionSchema.parse` accepts (ISO strings on datetime fields).
+ * - `mapAgentDefinitionError` translates the service's domain error classes
+ *   into a v1 error Response. Route handlers call it from a `catch`:
+ *
+ *     catch (err) {
+ *       const mapped = mapAgentDefinitionError(err);
+ *       if (mapped) return mapped;
+ *       throw err;
+ *     }
+ */
+
+import type { v1 } from '@open-rush/contracts';
+import type { AgentDefinition as DomainAgentDefinition } from '@open-rush/control-plane';
+import {
+  AgentDefinitionArchivedError,
+  AgentDefinitionNotFoundError,
+  AgentDefinitionVersionConflictError,
+  AgentDefinitionVersionNotFoundError,
+  EmptyAgentDefinitionPatchError,
+  InvalidAgentDefinitionInputError,
+} from '@open-rush/control-plane';
+
+import { v1Error } from '@/lib/api/v1-responses';
+
+/**
+ * Convert the service-layer `AgentDefinition` (native Dates) to the v1 wire
+ * shape. Consumers should never push Date instances into the JSON response
+ * because the contract's `agentDefinitionSchema` expects strict ISO strings.
+ */
+export function definitionToV1(d: DomainAgentDefinition): v1.AgentDefinition {
+  return {
+    id: d.id,
+    projectId: d.projectId,
+    name: d.name,
+    description: d.description ?? null,
+    icon: d.icon ?? null,
+    providerType: d.providerType,
+    model: d.model ?? null,
+    systemPrompt: d.systemPrompt ?? null,
+    appendSystemPrompt: d.appendSystemPrompt ?? null,
+    allowedTools: d.allowedTools,
+    skills: d.skills,
+    mcpServers: d.mcpServers,
+    maxSteps: d.maxSteps,
+    deliveryMode: d.deliveryMode as v1.AgentDefinition['deliveryMode'],
+    config: d.config ?? null,
+    currentVersion: d.currentVersion,
+    archivedAt: d.archivedAt ? d.archivedAt.toISOString() : null,
+    createdAt: d.createdAt.toISOString(),
+    updatedAt: d.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Translate a service-layer error into a v1 error Response. Returns `null`
+ * when the error is NOT a known domain error — the caller should rethrow so
+ * the top-level runtime produces a 500.
+ */
+export function mapAgentDefinitionError(err: unknown): Response | null {
+  if (err instanceof AgentDefinitionNotFoundError) {
+    return v1Error('NOT_FOUND', `AgentDefinition ${err.agentId} not found`);
+  }
+  if (err instanceof AgentDefinitionVersionNotFoundError) {
+    return v1Error('NOT_FOUND', `AgentDefinition ${err.agentId} version ${err.version} not found`);
+  }
+  if (err instanceof AgentDefinitionVersionConflictError) {
+    return v1Error(
+      'VERSION_CONFLICT',
+      `If-Match=${err.expected} does not match current version ${err.actual}`,
+      { hint: `refetch the latest version and retry; current is ${err.actual}` }
+    );
+  }
+  if (err instanceof AgentDefinitionArchivedError) {
+    return v1Error(
+      'VALIDATION_ERROR',
+      `AgentDefinition ${err.agentId} is archived and cannot be modified`,
+      { hint: `archived_at=${err.archivedAt.toISOString()}` }
+    );
+  }
+  if (err instanceof EmptyAgentDefinitionPatchError) {
+    return v1Error('VALIDATION_ERROR', 'PATCH must modify at least one editable field');
+  }
+  if (err instanceof InvalidAgentDefinitionInputError) {
+    return v1Error('VALIDATION_ERROR', err.message);
+  }
+  return null;
+}

--- a/apps/web/app/api/v1/agent-definitions/patch-concurrency.integration.test.ts
+++ b/apps/web/app/api/v1/agent-definitions/patch-concurrency.integration.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Integration test — real AgentDefinitionService + PGlite through the route
+ * handler (only auth and membership are mocked). This satisfies the task-8
+ * acceptance criterion: "集成测试覆盖乐观并发 409" which the fully-mocked
+ * route unit tests can't fulfil on their own.
+ *
+ * Two PATCHers that both observed `current_version=1` race for the same agent.
+ * The service's FOR UPDATE + version check guarantees exactly one bump; the
+ * route maps the AgentDefinitionVersionConflictError raised on the loser side
+ * to a `VERSION_CONFLICT` 409 envelope.
+ */
+import { randomUUID } from 'node:crypto';
+import { PGlite } from '@electric-sql/pglite';
+import * as schema from '@open-rush/db';
+import { agents, projects, users } from '@open-rush/db';
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/pglite';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Shared PGlite instance + mocks bootstrapped BEFORE route import
+// ---------------------------------------------------------------------------
+
+type TestDb = ReturnType<typeof drizzle<typeof schema>>;
+let pglite: PGlite;
+let db: TestDb;
+
+const { mockAuthenticate, mockHasScope, mockVerifyProjectAccess, mockGetDbClient } = vi.hoisted(
+  () => ({
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGetDbClient: vi.fn(),
+  })
+);
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+// Real control-plane service, real Zod schemas, real helpers. Only the db
+// client factory is swapped out to return our PGlite-backed Drizzle instance.
+vi.mock('@open-rush/db', async () => {
+  const actual = await vi.importActual<typeof import('@open-rush/db')>('@open-rush/db');
+  return {
+    ...actual,
+    getDbClient: () => mockGetDbClient(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap schema + import route AFTER mocks
+// ---------------------------------------------------------------------------
+
+let PATCH: typeof import('./[id]/route')['PATCH'];
+let POST_CREATE: typeof import('./route')['POST'];
+
+beforeAll(async () => {
+  pglite = new PGlite();
+  db = drizzle(pglite, { schema });
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS users (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name TEXT,
+      email TEXT UNIQUE,
+      email_verified_at TIMESTAMPTZ,
+      image TEXT,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS projects (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      name VARCHAR(255) NOT NULL,
+      description TEXT,
+      sandbox_provider VARCHAR(50) NOT NULL DEFAULT 'opensandbox',
+      default_model VARCHAR(255),
+      default_connection_mode VARCHAR(50) DEFAULT 'anthropic',
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      deleted_at TIMESTAMPTZ
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS agents (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+      status VARCHAR(20) NOT NULL DEFAULT 'active',
+      name VARCHAR(120) NOT NULL DEFAULT 'New Agent',
+      description TEXT,
+      icon VARCHAR(50),
+      provider_type VARCHAR(50) NOT NULL DEFAULT 'claude-code',
+      model VARCHAR(255),
+      system_prompt TEXT,
+      append_system_prompt TEXT,
+      allowed_tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+      skills JSONB NOT NULL DEFAULT '[]'::jsonb,
+      mcp_servers JSONB NOT NULL DEFAULT '[]'::jsonb,
+      max_steps INTEGER NOT NULL DEFAULT 30,
+      delivery_mode VARCHAR(20) NOT NULL DEFAULT 'chat',
+      is_builtin BOOLEAN NOT NULL DEFAULT false,
+      custom_title VARCHAR(200),
+      config JSONB,
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      active_stream_id TEXT,
+      current_version INTEGER NOT NULL DEFAULT 1,
+      archived_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      last_active_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  await db.execute(sql`
+    CREATE TABLE IF NOT EXISTS agent_definition_versions (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      version INTEGER NOT NULL,
+      snapshot JSONB NOT NULL,
+      change_note TEXT,
+      created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      CONSTRAINT agent_definition_versions_agent_version_uniq UNIQUE(agent_id, version)
+    )
+  `);
+
+  mockGetDbClient.mockReturnValue(db);
+  const [idRoute, collRoute] = await Promise.all([import('./[id]/route'), import('./route')]);
+  PATCH = idRoute.PATCH;
+  POST_CREATE = collRoute.POST;
+});
+
+afterAll(async () => {
+  await pglite.close();
+});
+
+let USER_ID = '';
+
+beforeEach(async () => {
+  await db.execute(
+    sql`TRUNCATE TABLE agent_definition_versions, agents, projects, users RESTART IDENTITY CASCADE`
+  );
+  USER_ID = randomUUID();
+  mockAuthenticate.mockResolvedValue({ userId: USER_ID, scopes: ['*'], authType: 'session' });
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+});
+
+async function seedProject(): Promise<string> {
+  const [u] = await db
+    .insert(users)
+    .values({ id: USER_ID, name: 'Alice', email: `a-${USER_ID}@ex.com` })
+    .returning();
+  const [p] = await db.insert(projects).values({ name: 'P', createdBy: u.id }).returning();
+  return p.id;
+}
+
+async function createDefinition(projectId: string) {
+  const req = new Request('https://t/api/v1/agent-definitions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      projectId,
+      name: 'A',
+      providerType: 'claude-code',
+      allowedTools: [],
+      skills: [],
+      mcpServers: [],
+      maxSteps: 10,
+      deliveryMode: 'chat',
+    }),
+  });
+  const res = await POST_CREATE(req);
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { data: { id: string; currentVersion: number } };
+  return body.data;
+}
+
+function patchReq(id: string, name: string, ifMatch: number) {
+  return new Request(`https://t/api/v1/agent-definitions/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+      'if-match': String(ifMatch),
+    },
+    body: JSON.stringify({ name }),
+  });
+}
+
+describe('PATCH /api/v1/agent-definitions/:id — optimistic concurrency (integration)', () => {
+  it('two concurrent PATCHers with the same If-Match: one wins (200), the other loses (409)', async () => {
+    const projectId = await seedProject();
+    const def = await createDefinition(projectId);
+    expect(def.currentVersion).toBe(1);
+
+    // Issue both PATCHes without awaiting, then Promise.all.
+    const [resA, resB] = await Promise.all([
+      PATCH(patchReq(def.id, 'A-wins', 1), { params: Promise.resolve({ id: def.id }) }),
+      PATCH(patchReq(def.id, 'B-wins', 1), { params: Promise.resolve({ id: def.id }) }),
+    ]);
+
+    const statuses = [resA.status, resB.status].sort();
+    expect(statuses).toEqual([200, 409]);
+
+    const okRes = resA.status === 200 ? resA : resB;
+    const conflictRes = resA.status === 409 ? resA : resB;
+
+    const okBody = (await okRes.json()) as { data: { currentVersion: number; name: string } };
+    expect(okBody.data.currentVersion).toBe(2);
+    expect(['A-wins', 'B-wins']).toContain(okBody.data.name);
+
+    const errBody = (await conflictRes.json()) as { error: { code: string; hint?: string } };
+    expect(errBody.error.code).toBe('VERSION_CONFLICT');
+    expect(errBody.error.hint).toMatch(/current is 2/);
+  });
+
+  it('sequential PATCHes with fresh If-Match both succeed (sanity — no false conflict)', async () => {
+    const projectId = await seedProject();
+    const def = await createDefinition(projectId);
+    const res1 = await PATCH(patchReq(def.id, 'v2', 1), {
+      params: Promise.resolve({ id: def.id }),
+    });
+    expect(res1.status).toBe(200);
+    const res2 = await PATCH(patchReq(def.id, 'v3', 2), {
+      params: Promise.resolve({ id: def.id }),
+    });
+    expect(res2.status).toBe(200);
+    const body = (await res2.json()) as { data: { currentVersion: number } };
+    expect(body.data.currentVersion).toBe(3);
+  });
+
+  it('stale If-Match returns 409 even without concurrency', async () => {
+    const projectId = await seedProject();
+    const def = await createDefinition(projectId);
+    await PATCH(patchReq(def.id, 'v2', 1), { params: Promise.resolve({ id: def.id }) });
+    const res = await PATCH(patchReq(def.id, 'v2-retry', 1), {
+      params: Promise.resolve({ id: def.id }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('VERSION_CONFLICT');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression — GET without projectId filter must NOT leak soft-deleted projects
+// (Sparring MUST-FIX: listAccessibleProjectIds() previously didn't filter
+//  deletedAt on the membership branch, so members would still see definitions
+//  belonging to soft-deleted projects.)
+// ---------------------------------------------------------------------------
+
+import { projectMembers } from '@open-rush/db';
+
+import { GET as COLLECTION_GET } from './route';
+
+describe('GET /api/v1/agent-definitions — soft-deleted project exclusion', () => {
+  it('excludes definitions of soft-deleted projects even when caller is a member', async () => {
+    // Extra membership table for this test.
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS project_members (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        role VARCHAR(20) NOT NULL DEFAULT 'member',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        UNIQUE(project_id, user_id)
+      )
+    `);
+
+    const projectId = await seedProject();
+    // Second project, owned by a different user, with caller as member.
+    const [otherOwner] = await db
+      .insert(users)
+      .values({ name: 'Bob', email: `bob-${Math.random()}@ex.com` })
+      .returning();
+    const [otherProject] = await db
+      .insert(projects)
+      .values({ name: 'OP', createdBy: otherOwner.id })
+      .returning();
+    await db
+      .insert(projectMembers)
+      .values({ projectId: otherProject.id, userId: USER_ID, role: 'member' });
+
+    // Two definitions, one per project.
+    const _own = await createDefinition(projectId);
+    // For the "other" project, insert directly via DB (createDefinition uses
+    // POST which runs verifyProjectAccess, and we want the definition to
+    // pre-exist).
+    await db.insert(agents).values({ projectId: otherProject.id, name: 'OTHER' });
+
+    // Soft-delete the OTHER project. Caller is still a member row, but the
+    // verifyProjectAccess() guard treats deleted projects as no-access. The
+    // list endpoint must mirror that.
+    await db.execute(sql`UPDATE projects SET deleted_at = now() WHERE id = ${otherProject.id}`);
+
+    const res = await COLLECTION_GET(new Request('https://t/api/v1/agent-definitions'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ projectId: string }> };
+    // Only the live-project definition is visible. The soft-deleted project's
+    // definition MUST NOT be in the list.
+    expect(body.data.every((d) => d.projectId !== otherProject.id)).toBe(true);
+  });
+});

--- a/apps/web/app/api/v1/agent-definitions/route.test.ts
+++ b/apps/web/app/api/v1/agent-definitions/route.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for POST/GET /api/v1/agent-definitions.
+ *
+ * The route orchestrates auth + Zod validation + access control, then delegates
+ * persistence to `AgentDefinitionService`. We mock:
+ * - `@/lib/auth/unified-auth` — returns whatever AuthContext the test wants
+ * - `@/lib/api-utils` — `verifyProjectAccess` returns boolean
+ * - `@open-rush/control-plane` — the service class + domain errors
+ * - `@open-rush/db` — `getDbClient` sentinel + table stubs
+ *
+ * Each test asserts the exact v1 envelope (`{ data: ... }` or `{ error: ... }`)
+ * and the mapped HTTP status.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockCreate,
+  mockList,
+  FakeArchivedErr,
+  FakeNotFoundErr,
+} = vi.hoisted(() => {
+  class ArchivedErr extends Error {
+    readonly agentId: string;
+    readonly archivedAt = new Date('2024-01-01T00:00:00.000Z');
+    constructor(agentId: string) {
+      super('archived');
+      this.name = 'AgentDefinitionArchivedError';
+      this.agentId = agentId;
+    }
+  }
+  class NotFoundErr extends Error {
+    readonly agentId: string;
+    constructor(agentId: string) {
+      super('not found');
+      this.name = 'AgentDefinitionNotFoundError';
+      this.agentId = agentId;
+    }
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockCreate: vi.fn(),
+    mockList: vi.fn(),
+    FakeArchivedErr: ArchivedErr,
+    FakeNotFoundErr: NotFoundErr,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+// Mock api-utils WITHOUT importActual — the real module pulls in `@/auth` →
+// next-auth, which breaks under vitest's ESM resolver. We only need
+// verifyProjectAccess here; the rest is unused.
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  AgentDefinitionService: class {
+    create = mockCreate;
+    list = mockList;
+  },
+  AgentDefinitionArchivedError: FakeArchivedErr,
+  AgentDefinitionNotFoundError: FakeNotFoundErr,
+  AgentDefinitionVersionConflictError: class extends Error {
+    readonly agentId: string;
+    readonly expected: number;
+    readonly actual: number;
+    constructor(agentId: string, expected: number, actual: number) {
+      super('conflict');
+      this.name = 'AgentDefinitionVersionConflictError';
+      this.agentId = agentId;
+      this.expected = expected;
+      this.actual = actual;
+    }
+  },
+  AgentDefinitionVersionNotFoundError: class extends Error {
+    readonly agentId: string;
+    readonly version: number;
+    constructor(agentId: string, version: number) {
+      super('no version');
+      this.name = 'AgentDefinitionVersionNotFoundError';
+      this.agentId = agentId;
+      this.version = version;
+    }
+  },
+  EmptyAgentDefinitionPatchError: class extends Error {
+    constructor() {
+      super('empty');
+      this.name = 'EmptyAgentDefinitionPatchError';
+    }
+  },
+  InvalidAgentDefinitionInputError: class extends Error {
+    readonly field: string;
+    readonly value: unknown;
+    constructor(field: string, value: unknown, reason: string) {
+      super(`${field}=${String(value)}: ${reason}`);
+      this.name = 'InvalidAgentDefinitionInputError';
+      this.field = field;
+      this.value = value;
+    }
+  },
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve([]),
+      }),
+    }),
+  }),
+  projectMembers: { projectId: 'pm.pid', userId: 'pm.uid' },
+  projects: { id: 'p.id', createdBy: 'p.cb', deletedAt: 'p.deletedAt' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ type: 'and', parts }),
+  eq: (c: unknown, v: unknown) => ({ type: 'eq', c, v }),
+  isNull: (c: unknown) => ({ type: 'isNull', c }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { GET, POST } from './route';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: session user with wildcard scope.
+  mockAuthenticate.mockResolvedValue({
+    userId: 'user-1',
+    scopes: ['*'],
+    authType: 'session',
+  });
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+});
+
+function validCreateBody(overrides: Record<string, unknown> = {}) {
+  return {
+    projectId: '00000000-0000-0000-0000-000000000001',
+    name: 'A',
+    providerType: 'claude-code',
+    allowedTools: [],
+    skills: [],
+    mcpServers: [],
+    maxSteps: 10,
+    deliveryMode: 'chat',
+    ...overrides,
+  };
+}
+
+function jsonReq(
+  method: string,
+  body?: unknown,
+  url = 'https://t/api/v1/agent-definitions'
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: { 'content-type': 'application/json' },
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(url, init);
+}
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/agent-definitions', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await POST(jsonReq('POST', validCreateBody()));
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('403 when scope agent-definitions:write missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await POST(jsonReq('POST', validCreateBody()));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'agent-definitions:write');
+  });
+
+  it('400 for invalid JSON', async () => {
+    const req = new Request('https://t/api/v1/agent-definitions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('400 when schema validation fails', async () => {
+    const res = await POST(jsonReq('POST', { projectId: 'not-a-uuid' }));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; issues?: unknown[] } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(Array.isArray(body.error.issues)).toBe(true);
+  });
+
+  it('403 when caller has no access to the target project', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await POST(jsonReq('POST', validCreateBody()));
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('201 with data on success; ISO dates on the wire', async () => {
+    const created = {
+      id: '00000000-0000-0000-0000-000000000aaa',
+      projectId: '00000000-0000-0000-0000-000000000001',
+      name: 'A',
+      description: null,
+      icon: null,
+      providerType: 'claude-code',
+      model: null,
+      systemPrompt: null,
+      appendSystemPrompt: null,
+      allowedTools: [],
+      skills: [],
+      mcpServers: [],
+      maxSteps: 10,
+      deliveryMode: 'chat',
+      config: null,
+      currentVersion: 1,
+      archivedAt: null,
+      createdAt: new Date('2024-01-02T03:04:05.000Z'),
+      updatedAt: new Date('2024-01-02T03:04:05.000Z'),
+    };
+    mockCreate.mockResolvedValue(created);
+    const res = await POST(jsonReq('POST', validCreateBody()));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { createdAt: string; updatedAt: string } };
+    expect(body.data.createdAt).toBe('2024-01-02T03:04:05.000Z');
+    expect(body.data.updatedAt).toBe('2024-01-02T03:04:05.000Z');
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ createdBy: 'user-1', name: 'A' })
+    );
+  });
+
+  it('rethrows unknown errors (surfaces 500 in the Next.js runtime)', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'));
+    await expect(POST(jsonReq('POST', validCreateBody()))).rejects.toThrow('boom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/agent-definitions', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(jsonReq('GET'));
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope agent-definitions:read missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(jsonReq('GET'));
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'agent-definitions:read');
+  });
+
+  it('400 when query validation fails', async () => {
+    const res = await GET(
+      jsonReq('GET', undefined, 'https://t/api/v1/agent-definitions?limit=abc')
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('403 when projectId filter is set but caller has no access', async () => {
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(
+      jsonReq(
+        'GET',
+        undefined,
+        'https://t/api/v1/agent-definitions?projectId=00000000-0000-0000-0000-000000000001'
+      )
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns paginated envelope with ISO dates', async () => {
+    mockList.mockResolvedValue({
+      items: [
+        {
+          id: '00000000-0000-0000-0000-000000000aaa',
+          projectId: '00000000-0000-0000-0000-000000000001',
+          name: 'A',
+          description: null,
+          icon: null,
+          providerType: 'claude-code',
+          model: null,
+          systemPrompt: null,
+          appendSystemPrompt: null,
+          allowedTools: [],
+          skills: [],
+          mcpServers: [],
+          maxSteps: 10,
+          deliveryMode: 'chat',
+          config: null,
+          currentVersion: 1,
+          archivedAt: null,
+          createdAt: new Date('2024-03-04T05:06:07.000Z'),
+          updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+        },
+      ],
+      nextCursor: 'opaquecursor==',
+    });
+    const res = await GET(
+      jsonReq(
+        'GET',
+        undefined,
+        'https://t/api/v1/agent-definitions?projectId=00000000-0000-0000-0000-000000000001'
+      )
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ createdAt: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].createdAt).toBe('2024-03-04T05:06:07.000Z');
+    expect(body.nextCursor).toBe('opaquecursor==');
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: '00000000-0000-0000-0000-000000000001',
+        includeArchived: false,
+      })
+    );
+  });
+});

--- a/apps/web/app/api/v1/agent-definitions/route.ts
+++ b/apps/web/app/api/v1/agent-definitions/route.ts
@@ -1,0 +1,153 @@
+/**
+ * /api/v1/agent-definitions
+ *  - POST  — create a new AgentDefinition (v1 snapshot)
+ *  - GET   — cursor-paginated list, optionally filtered by projectId
+ *
+ * Auth: session OR service-token with scope `agent-definitions:read` (GET) /
+ *       `agent-definitions:write` (POST). See specs/service-token-auth.md.
+ *
+ * Project access: write paths require the caller to be a member of the target
+ * `projectId` (creator-fallback counts as membership). Read paths restrict to
+ * the caller's accessible projects (single projectId if filter is supplied,
+ * otherwise the union of project memberships + created-by fallback).
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { AgentDefinitionService } from '@open-rush/control-plane';
+import { getDbClient, projectMembers, projects } from '@open-rush/db';
+import { and, eq, isNull } from 'drizzle-orm';
+import { v1Error, v1Paginated, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { definitionToV1, mapAgentDefinitionError } from './helpers';
+
+// -----------------------------------------------------------------------------
+// POST /api/v1/agent-definitions
+// -----------------------------------------------------------------------------
+
+export async function POST(request: Request) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:write')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:write');
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return v1Error('VALIDATION_ERROR', 'Invalid JSON body');
+  }
+
+  const parsed = v1.createAgentDefinitionRequestSchema.safeParse(body);
+  if (!parsed.success) return v1ValidationError(parsed.error);
+
+  if (!(await verifyProjectAccess(parsed.data.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  const db = getDbClient();
+  const service = new AgentDefinitionService(db);
+  try {
+    const created = await service.create({
+      projectId: parsed.data.projectId,
+      name: parsed.data.name,
+      description: parsed.data.description ?? null,
+      icon: parsed.data.icon ?? null,
+      providerType: parsed.data.providerType,
+      model: parsed.data.model ?? null,
+      systemPrompt: parsed.data.systemPrompt ?? null,
+      appendSystemPrompt: parsed.data.appendSystemPrompt ?? null,
+      allowedTools: parsed.data.allowedTools,
+      skills: parsed.data.skills,
+      mcpServers: parsed.data.mcpServers,
+      maxSteps: parsed.data.maxSteps,
+      deliveryMode: parsed.data.deliveryMode,
+      config: parsed.data.config ?? null,
+      changeNote: parsed.data.changeNote ?? null,
+      createdBy: auth.userId,
+    });
+    return v1Success(definitionToV1(created), 201);
+  } catch (err) {
+    const mapped = mapAgentDefinitionError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/agent-definitions
+// -----------------------------------------------------------------------------
+
+export async function GET(request: Request) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'agent-definitions:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope agent-definitions:read');
+  }
+
+  const url = new URL(request.url);
+  const parsed = v1.listAgentDefinitionsQuerySchema.safeParse({
+    projectId: url.searchParams.get('projectId') ?? undefined,
+    includeArchived: url.searchParams.get('includeArchived') ?? undefined,
+    limit: url.searchParams.get('limit') ?? undefined,
+    cursor: url.searchParams.get('cursor') ?? undefined,
+  });
+  if (!parsed.success) return v1ValidationError(parsed.error);
+
+  const db = getDbClient();
+
+  let scope: { projectId?: string; projectIds?: string[] };
+  if (parsed.data.projectId) {
+    if (!(await verifyProjectAccess(parsed.data.projectId, auth.userId))) {
+      return v1Error('FORBIDDEN', 'No access to this project');
+    }
+    scope = { projectId: parsed.data.projectId };
+  } else {
+    scope = { projectIds: await listAccessibleProjectIds(db, auth.userId) };
+  }
+
+  const service = new AgentDefinitionService(db);
+  const { items, nextCursor } = await service.list({
+    ...scope,
+    includeArchived: parsed.data.includeArchived,
+    limit: parsed.data.limit,
+    cursor: parsed.data.cursor,
+  });
+  return v1Paginated(items.map(definitionToV1), nextCursor);
+}
+
+/**
+ * Resolve the set of `project_id` values the caller can read. Covers both
+ * membership rows and the creator fallback that `verifyProjectAccess` uses
+ * for historically-created projects without a `project_members` row.
+ *
+ * Soft-deleted projects (`projects.deleted_at IS NOT NULL`) are excluded from
+ * BOTH branches — this keeps the list endpoint aligned with the single-id
+ * `verifyProjectAccess()` which treats soft-deleted projects as "not yours".
+ * Without this filter, a caller remaining in `project_members` for a deleted
+ * project would still see that project's agent definitions.
+ */
+async function listAccessibleProjectIds(
+  db: ReturnType<typeof getDbClient>,
+  userId: string
+): Promise<string[]> {
+  const [memberships, created] = await Promise.all([
+    // Join `projects` so we can filter out soft-deleted ones. We pick the
+    // projectId column off the projects side to make the filter explicit.
+    db
+      .select({ projectId: projects.id })
+      .from(projectMembers)
+      .innerJoin(projects, eq(projectMembers.projectId, projects.id))
+      .where(and(eq(projectMembers.userId, userId), isNull(projects.deletedAt))),
+    db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(and(eq(projects.createdBy, userId), isNull(projects.deletedAt))),
+  ]);
+  const ids = new Set<string>();
+  for (const m of memberships) ids.add(m.projectId);
+  for (const p of created) ids.add(p.id);
+  return Array.from(ids);
+}

--- a/apps/web/lib/api/v1-responses.test.ts
+++ b/apps/web/lib/api/v1-responses.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the v1 response helpers. Small but essential:
+ * the helpers are used by every task-8/9 route, so any drift silently
+ * breaks every endpoint's contract.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { v1Error, v1Paginated, v1Success, v1ValidationError } from './v1-responses';
+
+describe('v1Success', () => {
+  it('returns 200 by default with { data } envelope', async () => {
+    const res = v1Success({ id: 'x' });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ data: { id: 'x' } });
+  });
+
+  it('honours explicit status (e.g. 201)', async () => {
+    const res = v1Success({ id: 'x' }, 201);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('v1Paginated', () => {
+  it('returns 200 with { data, nextCursor }', async () => {
+    const res = v1Paginated([1, 2, 3], 'cur');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ data: [1, 2, 3], nextCursor: 'cur' });
+  });
+
+  it('null nextCursor stays null (not omitted)', async () => {
+    const res = v1Paginated([], null);
+    await expect(res.json()).resolves.toEqual({ data: [], nextCursor: null });
+  });
+});
+
+describe('v1Error', () => {
+  it('maps error codes to the standard HTTP status', async () => {
+    const pairs: Array<[Parameters<typeof v1Error>[0], number]> = [
+      ['UNAUTHORIZED', 401],
+      ['FORBIDDEN', 403],
+      ['NOT_FOUND', 404],
+      ['VALIDATION_ERROR', 400],
+      ['VERSION_CONFLICT', 409],
+      ['IDEMPOTENCY_CONFLICT', 409],
+      ['RATE_LIMITED', 429],
+      ['INTERNAL', 500],
+    ];
+    for (const [code, status] of pairs) {
+      const res = v1Error(code, 'msg');
+      expect(res.status).toBe(status);
+    }
+  });
+
+  it('embeds hint + issues in the error envelope', async () => {
+    const res = v1Error('VALIDATION_ERROR', 'bad', {
+      hint: 'try again',
+      issues: [{ path: ['body', 'name'], message: 'required' }],
+    });
+    await expect(res.json()).resolves.toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'bad',
+        hint: 'try again',
+        issues: [{ path: ['body', 'name'], message: 'required' }],
+      },
+    });
+  });
+});
+
+describe('v1ValidationError', () => {
+  it('attaches all issues and uses first issue message as summary', async () => {
+    const fakeZodError = {
+      issues: [
+        { path: ['a'], message: 'first' },
+        { path: ['b', 1], message: 'second' },
+      ],
+    };
+    const res = v1ValidationError(fakeZodError, 'Input invalid');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { code: string; message: string; issues: Array<{ path: unknown[]; message: string }> };
+    };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.message).toBe('Input invalid: first');
+    expect(body.error.issues).toHaveLength(2);
+  });
+
+  it('works with empty issues array', async () => {
+    const res = v1ValidationError({ issues: [] }, 'Bad request');
+    const body = (await res.json()) as { error: { message: string; issues: unknown[] } };
+    expect(body.error.message).toBe('Bad request');
+    expect(body.error.issues).toEqual([]);
+  });
+});

--- a/apps/web/lib/api/v1-responses.ts
+++ b/apps/web/lib/api/v1-responses.ts
@@ -1,0 +1,88 @@
+/**
+ * `/api/v1/*` shared Response helpers.
+ *
+ * These wrap the v1 error envelope defined in `specs/managed-agents-api.md`
+ * §错误码 + `@open-rush/contracts` v1.common (`ERROR_CODE_HTTP_STATUS`,
+ * `errorBodySchema`). Kept deliberately small; the Zod schemas remain the
+ * source of truth for response shapes.
+ *
+ * Unlike the legacy `apiSuccess` / `apiError` in `apps/web/lib/api-utils.ts`
+ * (which wraps payloads as `{ success, data, code, error }`), v1 responses
+ * follow the stable external contract:
+ *
+ *   - success:  `{ data: <payload> }`                 (HTTP 2xx)
+ *   - failure:  `{ error: { code, message, hint?, issues? } }`  (HTTP 4xx/5xx)
+ *
+ * Consumers that need a *paginated* envelope emit `{ data: T[], nextCursor }`
+ * directly via {@link v1Paginated}.
+ */
+import { v1 } from '@open-rush/contracts';
+
+type ErrorCode = v1.ErrorCode;
+
+/**
+ * Minimal shape from Zod's `error.issues[number]`. Kept structural so we don't
+ * need a direct `zod` dependency in apps/web — the schemas live in
+ * `@open-rush/contracts` which re-exports Zod transitively.
+ */
+interface ZodIssueLike {
+  path: Array<string | number>;
+  message: string;
+}
+interface ZodErrorLike {
+  issues: ZodIssueLike[];
+}
+
+/** 200/201 success with a single resource. */
+export function v1Success<T>(data: T, status = 200): Response {
+  return Response.json({ data }, { status });
+}
+
+/** 200 paginated list. nextCursor is a string or null per contract. */
+export function v1Paginated<T>(data: T[], nextCursor: string | null): Response {
+  return Response.json({ data, nextCursor }, { status: 200 });
+}
+
+/**
+ * Plain error envelope. The HTTP status is derived from `code` via
+ * {@link ERROR_CODE_HTTP_STATUS}; callers generally should NOT override it
+ * (kept as escape hatch for rare cases where the same code maps to a
+ * different status — currently none, but reserved).
+ */
+export function v1Error(
+  code: ErrorCode,
+  message: string,
+  options: {
+    hint?: string;
+    issues?: Array<{ path: Array<string | number>; message: string }>;
+    status?: number;
+  } = {}
+): Response {
+  const { hint, issues, status } = options;
+  const body: {
+    error: {
+      code: ErrorCode;
+      message: string;
+      hint?: string;
+      issues?: Array<{ path: Array<string | number>; message: string }>;
+    };
+  } = { error: { code, message } };
+  if (hint !== undefined) body.error.hint = hint;
+  if (issues !== undefined) body.error.issues = issues;
+  return Response.json(body, { status: status ?? v1.ERROR_CODE_HTTP_STATUS[code] });
+}
+
+/**
+ * Convenience: translate a Zod failure into a VALIDATION_ERROR response with
+ * per-issue `path` + `message`. Reserves the first issue's message for the
+ * top-level `message` field so clients with naive error rendering still see
+ * a human-readable summary.
+ */
+export function v1ValidationError(error: ZodErrorLike, prefix = 'Validation failed'): Response {
+  const issues = error.issues.map((i) => ({
+    path: i.path,
+    message: i.message,
+  }));
+  const summary = issues[0]?.message ? `${prefix}: ${issues[0].message}` : prefix;
+  return v1Error('VALIDATION_ERROR', summary, { issues });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
     "use-stick-to-bottom": "^1.1.3"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.4.4",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^25.6.0",
     "@types/react": "^19.0.0",

--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -100,7 +100,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - 单测覆盖版本冲突 / 归档后 patch 被拒
       - verify: `./docs/execution/verify.sh task-7`
 
-- [ ] `task-8-api-v1-agent-definitions` — **Agent-A**
+- [x] `task-8-api-v1-agent-definitions` — **Agent-A**
       域: `apps/web/app/api/v1/agent-definitions/*`
       依赖: task-5, task-7
       验收:

--- a/docs/execution/progress/agent-a.md
+++ b/docs/execution/progress/agent-a.md
@@ -55,15 +55,69 @@
   - `pnpm --filter @open-rush/control-plane test` 35 files / 476 tests(含我的 1 file / 30 tests)全绿
   - `./docs/execution/verify.sh task-7` PASS
 
-## task-8: API /api/v1/agent-definitions/*(待 task-7 merge 后)
-- 依赖 task-5(已 merged,可直接 `authenticate()` / `hasScope()`)+ task-7(本分支)
-- 计划消费 contracts v1 的 6 个 schema,由 route handler 层把 `Date` → ISO + 错误类 → 401/403/404/409/400
+## task-8: API /api/v1/agent-definitions/* (6 endpoints)
+- **状态**: ✅ 本地验证全绿,等 Sparring + PR
+- **分支**: `feat/task-8` 在 `/tmp/agent-wt/a` 专属 worktree(基于 origin/main 5ffc60b — 包含 task-5/6/7/10 merged commits)
+- **文件域**:
+  - `apps/web/app/api/v1/agent-definitions/route.ts`(POST + GET list,新)
+  - `apps/web/app/api/v1/agent-definitions/[id]/route.ts`(GET + PATCH,新)
+  - `apps/web/app/api/v1/agent-definitions/[id]/versions/route.ts`(GET versions,新)
+  - `apps/web/app/api/v1/agent-definitions/[id]/archive/route.ts`(POST archive,新)
+  - `apps/web/app/api/v1/agent-definitions/helpers.ts`(definitionToV1 + mapAgentDefinitionError,新)
+  - `apps/web/app/api/v1/agent-definitions/*.test.ts`(4 route 测试文件,新,共 48 tests)
+  - `apps/web/lib/api/v1-responses.ts`(v1Success / v1Error / v1Paginated / v1ValidationError,新)
+  - `apps/web/lib/api/v1-responses.test.ts`(helper 单测,新,10 tests)
+  - `packages/control-plane/src/agent-definition-service.ts`(+ `list(opts)` 方法 + `ListAgentDefinitionsOptions/Result` types + cursor encode/decode helpers,+ 8 tests)
+  - `packages/control-plane/src/index.ts`(+ 2 types re-export)
+  - `docs/execution/TASKS.md`(勾选 task-8 checkbox)
+- **关键决策**:
+  - **v1 响应契约独立于 legacy**:`api-utils.apiSuccess/apiError` 用 `{success, data, error, code}`(legacy)。v1 契约要求 `{data}` / `{error: {code, message, hint?, issues?}}`。新建 `lib/api/v1-responses.ts` 做干净分离,单测覆盖 8 个 ErrorCode → HTTP status 映射。
+  - **错误分类 1:1 映射**:`helpers.ts.mapAgentDefinitionError` 把 service 6 个错误类映射到 v1 ErrorCode(NotFound/VersionNotFound → 404,VersionConflict → 409 + hint,Archived/EmptyPatch/InvalidInput → 400,未知 → rethrow → 500)。
+  - **project-membership 前/后置**:
+    - POST / GET?projectId=X:**前置**校验(快速失败、不泄露存在性)
+    - GET/PATCH/archive 按 id:**后置**校验(`service.get` 拿 projectId 再 verifyProjectAccess)。存在但无权 → 403;不存在 → 404
+    - GET 无 projectId:扫 caller 可见的 projectIds(memberships + createdBy fallback),`service.list({ projectIds })` 批量过滤;`projectIds=[]` 早短路
+  - **list() 服务扩展**:task-7 只有 listVersions。task-8 在 AgentDefinitionService 加 `list(opts)` 支持 `{ projectId | projectIds, includeArchived, limit, cursor }`。keyset 分页 `(created_at DESC, id DESC)`,opaque base64url cursor 编码 `createdAt.ISO|id`,非法 cursor 静默回落到首页。
+  - **If-Match 必填**:Route 显式检查 header 缺失 → 400 VALIDATION,再用 `ifMatchHeaderSchema`(coerce positive int)校验内容。
+  - **Next.js 16 params**:`params: Promise<{ id: string }>` + `await params`。id 用 `getAgentDefinitionParamsSchema.safeParse` 做 uuid 校验。
+  - **日期序列化集中在 helpers**:service 返回 `Date`,route 通过 `definitionToV1(d)` 一次性 toISOString 再输出。契约 schema 期望 `z.string().datetime({offset:true})`,route test 断言字面字符串。
+  - **mock 策略防止 next-auth 塌房**:`@/lib/api-utils` 依赖 `@/auth` → next-auth 在 vitest ESM 下会 `Cannot find module 'next/server'`。测试直接 `vi.mock('@/lib/api-utils', () => ({ verifyProjectAccess: ... }))` 不 importActual,绕过整个 adapter 链。
+  - **ZodError 结构化类型**:apps/web 无直接 zod 依赖,inline `ZodIssueLike / ZodErrorLike` 避免 import zod。
+- **测试覆盖** (总 66 new tests):
+  - `route.test.ts` (12):POST 401/403/400 invalid-JSON/400 schema/403 project/201 ISO/rethrow + GET 401/403/400 limit/403 project/paginated ISO
+  - `[id]/route.test.ts` (20):GET 401/403/400 id/404/403 project/200 current/200 ?version=N/400 invalid version/404 unknown version;PATCH 401/403/400 no-If-Match/400 bad-If-Match/400 invalid-JSON/400 empty body/403 project/404/409 conflict+hint/400 archived/200 bumped
+  - `[id]/versions/route.test.ts` (9):401/403/400 id/404/403 project/desc+ISO+nextCursor/cursor pass-through/400 non-numeric cursor/null nextCursor
+  - `[id]/archive/route.test.ts` (7):401/403/400 id/404/403 project/200 ISO/幂等第二次同 archivedAt
+  - `lib/api/v1-responses.test.ts` (10):v1Success/v1Paginated 格式 + v1Error 8 code→status 映射 + v1ValidationError 多 issue 合并 + 空 issues
+  - control-plane `list()` (8):DESC 排序 / projectId / projectIds / `projectIds=[]` 短路 / includeArchived / cursor 3 页 round-trip / 非法 cursor 宽松 / limit 夹紧
+- **坑 / 经验**:
+  - **Worktree 隔离必须严格**:第一次启动 task-8 时仍在 `/Users/kris/develop/open-rush` 主 worktree 工作,team-lead 提醒后切到 `/tmp/agent-wt/a`。中间尝试 `git stash -u` 再 `git checkout origin/main -- .` 引入了 task-6 的未追踪改动 — 最终 `git reset --hard origin/main` 干净恢复。教训:worktree 内的 git 写操作保持最小,冲突用 reset + 让 untracked 文件自然保留。
+  - **task-6/10 中途 merge 到 main**:起步时 main 在 961716d,期间 coordinator merge 了 task-6(auth/tokens)+ task-10(agent-worker)。rebase 到新 main(5ffc60b)后域不冲突。
+  - **DATABASE_URL for build**:`pnpm build` 经 turbo 不透传 env。解决:`echo 'DATABASE_URL=postgresql://dummy:...' > apps/web/.env`(gitignored),复刻 CI 做法。pre-existing 问题。
+  - **Next-auth ESM 解析塌房**:`@/lib/api-utils` → `@/auth` → next-auth → Cannot find module 'next/server'。用 `vi.mock('@/lib/api-utils', () => ({ verifyProjectAccess: ... }))` 直接替换,不 importActual。
+- **验证结果**:
+  - `pnpm build` PASS(需 DATABASE_URL,同 CI)
+  - `pnpm check` / `pnpm lint` PASS(2 pre-existing warnings)
+  - `pnpm test` PASS:web 17 files / 249 tests,control-plane 35 / 505
+  - `./docs/execution/verify.sh task-8` **PASS**
+- **Sparring 轮 1**(Codex gpt-5.3-codex-xhigh):CONCERNS
+  - MUST-FIX 1: `listAccessibleProjectIds()` 在 `project_members` 分支没 filter `projects.deletedAt` → 软删项目的 definition 仍能被 member 列出。
+    → 修:改成 innerJoin projects + `isNull(projects.deletedAt)`;加回归 integration 测试(soft-deleted project exclusion)。
+  - MUST-FIX 2: "集成测试覆盖乐观并发 409" 仅用 mock service 不算集成。
+    → 修:新建 `patch-concurrency.integration.test.ts`,用真实 AgentDefinitionService + PGlite + 真实 route 链路(只 mock auth / verifyProjectAccess / getDbClient)。4 测试:并发 200/409、顺序无 false-conflict、stale If-Match 409、软删项目排除。加 `@electric-sql/pglite` 为 apps/web devDep。
+  - SHOULD-FIX 1: `/versions?cursor=1abc` 被 Number.parseInt 接受为 1 — 宽松。
+    → 修:严格正则 `/^[1-9]\d*$/`,5 个非法值(abc, 1abc, -1, 0, 1.5)全 400 测试覆盖。
+  - SHOULD-FIX 2: list cursor Date.toISOString 是 ms 精度但 PG timestamptz 是 μs → 同 ms 内 μs-不同的行可能被跳过。
+    → 修:`WHERE` + `ORDER BY` 两侧都用 `date_trunc('milliseconds', created_at)` 统一到 ms 精度;现在比较一致、不丢行。
+- **Sparring 轮 2**: **APPROVE**(逐项确认 4 项修复成立 + 其他 Round 1 项不退化;NIT 仅建议补 Docker PG 多连接用例,非阻塞)
 
-## task-9: API /api/v1/vaults/entries/*(待 task-5 & task-4 — 都已 ready)
-- 等 task-7/8 合并后启动
+## task-9: API /api/v1/vaults/entries/*(待 task-8 merge 后)
+- 依赖 task-5(已 merged)+ task-4(已 merged)
+- 复用 task-8 的 `v1-responses.ts` helpers + 前/后置 membership check 模式
 
 ## 纪律 / 流程
 
 - 每 task 单独 branch、单独 PR、Sparring APPROVE 才 commit
 - context > 50% 通知 team-lead,> 70% 必换
 - 受保护文件不改;只勾 TASKS.md checkbox
+- 每 Bash 调用前缀 `cd /tmp/agent-wt/a && ...`(worktree 隔离)

--- a/packages/control-plane/src/__tests__/agent-definition-service.test.ts
+++ b/packages/control-plane/src/__tests__/agent-definition-service.test.ts
@@ -598,3 +598,110 @@ describe('AgentDefinitionService invariants', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// list()
+// ---------------------------------------------------------------------------
+
+describe('AgentDefinitionService.list', () => {
+  it('returns definitions in created_at DESC (newest first)', async () => {
+    const a = await service.create(makeCreateInput({ name: 'A' }));
+    // Force a later timestamp so the DESC sort is deterministic.
+    await db.execute(
+      sql`UPDATE agents SET created_at = now() + interval '1 second' WHERE id = ${a.id}`
+    );
+    const b = await service.create(makeCreateInput({ name: 'B' }));
+    await db.execute(
+      sql`UPDATE agents SET created_at = now() + interval '2 second' WHERE id = ${b.id}`
+    );
+    const res = await service.list({});
+    expect(res.items.map((d) => d.name)).toEqual(['B', 'A']);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('filters by projectId', async () => {
+    await service.create(makeCreateInput({ name: 'A' }));
+    const [u] = await db
+      .insert(users)
+      .values({ name: 'Bob', email: `bob-${Math.random()}@ex.com` })
+      .returning();
+    const [otherProject] = await db
+      .insert(projects)
+      .values({ name: 'OP', createdBy: u.id })
+      .returning();
+    const other = await service.create(makeCreateInput({ name: 'B', projectId: otherProject.id }));
+
+    const onlyMine = await service.list({ projectId });
+    expect(onlyMine.items.map((d) => d.name)).toEqual(['A']);
+    const onlyOther = await service.list({ projectId: otherProject.id });
+    expect(onlyOther.items.map((d) => d.id)).toEqual([other.id]);
+  });
+
+  it('filters by projectIds (IN clause)', async () => {
+    const [u] = await db
+      .insert(users)
+      .values({ name: 'Carol', email: `carol-${Math.random()}@ex.com` })
+      .returning();
+    const [p2] = await db.insert(projects).values({ name: 'P2', createdBy: u.id }).returning();
+    await service.create(makeCreateInput({ name: 'X' }));
+    await service.create(makeCreateInput({ name: 'Y', projectId: p2.id }));
+    const res = await service.list({ projectIds: [projectId, p2.id] });
+    expect(res.items.map((d) => d.name).sort()).toEqual(['X', 'Y']);
+  });
+
+  it('projectIds=[] short-circuits to no rows (without hitting DB)', async () => {
+    await service.create(makeCreateInput());
+    const res = await service.list({ projectIds: [] });
+    expect(res.items).toHaveLength(0);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('excludes archived rows by default; includeArchived=true includes them', async () => {
+    const a = await service.create(makeCreateInput({ name: 'A' }));
+    const b = await service.create(makeCreateInput({ name: 'B' }));
+    await service.archive(b.id);
+
+    const defaultList = await service.list({});
+    expect(defaultList.items.map((d) => d.id)).toEqual([a.id]);
+
+    const withArchived = await service.list({ includeArchived: true });
+    expect(withArchived.items.map((d) => d.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('paginates with opaque cursor (round-trip verbatim)', async () => {
+    for (let i = 0; i < 5; i++) {
+      const d = await service.create(makeCreateInput({ name: `A${i}` }));
+      await db.execute(
+        sql`UPDATE agents SET created_at = now() + interval '${sql.raw(String(i))} seconds' WHERE id = ${d.id}`
+      );
+    }
+    const first = await service.list({ limit: 2 });
+    expect(first.items).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await service.list({ limit: 2, cursor: first.nextCursor ?? undefined });
+    expect(second.items).toHaveLength(2);
+    const firstIds = new Set(first.items.map((d) => d.id));
+    for (const it of second.items) expect(firstIds.has(it.id)).toBe(false);
+
+    const third = await service.list({ limit: 2, cursor: second.nextCursor ?? undefined });
+    expect(third.items).toHaveLength(1);
+    expect(third.nextCursor).toBeNull();
+  });
+
+  it('ignores malformed cursors (returns first page instead of erroring)', async () => {
+    await service.create(makeCreateInput());
+    for (const bad of ['not-base64', '!!!not valid!!!', '', ' ']) {
+      const res = await service.list({ cursor: bad });
+      expect(res.items).toHaveLength(1);
+    }
+  });
+
+  it('clamps limit to 1..200', async () => {
+    await service.create(makeCreateInput());
+    const res = await service.list({ limit: 9999 });
+    expect(res.items.length).toBeLessThanOrEqual(200);
+    const res2 = await service.list({ limit: 0 });
+    expect(res2.items).toHaveLength(1);
+  });
+});

--- a/packages/control-plane/src/agent-definition-service.ts
+++ b/packages/control-plane/src/agent-definition-service.ts
@@ -20,7 +20,7 @@
  *   the pglite driver with the shared pglite-helpers schema.
  */
 import { agentDefinitionVersions, agents, type DbClient } from '@open-rush/db';
-import { and, desc, eq, lt, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm';
 
 type AgentRow = typeof agents.$inferSelect;
 type AgentVersionRow = typeof agentDefinitionVersions.$inferSelect;
@@ -101,6 +101,37 @@ export interface ListVersionsResult {
    * if no more rows. Smaller than the smallest `version` in `items`.
    */
   nextCursor: number | null;
+}
+
+/** Options for GET /api/v1/agent-definitions (top-level list). */
+export interface ListAgentDefinitionsOptions {
+  /** Filter to a single project. Takes precedence over `projectIds`. */
+  projectId?: string;
+  /**
+   * Filter to a set of projects (`project_id IN (...)`). Useful when the
+   * caller is scoped to "any project I can access" rather than a single
+   * project. An empty array returns no rows.
+   */
+  projectIds?: string[];
+  /** Include archived rows (default false). */
+  includeArchived?: boolean;
+  /** Max rows (1..200), default 50. */
+  limit?: number;
+  /**
+   * Opaque cursor produced by a previous page's `nextCursor`. Internally
+   * encodes the last row's `(created_at, id)` so pagination is deterministic
+   * even across rows with identical `created_at`.
+   */
+  cursor?: string;
+}
+
+export interface ListAgentDefinitionsResult {
+  items: AgentDefinition[];
+  /**
+   * Opaque cursor for the next page, or `null` if no more rows. Round-trip it
+   * verbatim to the next {@link ListAgentDefinitionsOptions.cursor}.
+   */
+  nextCursor: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +446,79 @@ export class AgentDefinitionService {
   }
 
   /**
+   * GET /api/v1/agent-definitions — cursor-paginated list, newest first.
+   *
+   * Ordering: `(created_at DESC, id DESC)` — the `id` tiebreaker lets the
+   * cursor be deterministic across rows that share a `created_at` (e.g. from
+   * bulk fixture imports). The cursor is an opaque base64url string that the
+   * client must round-trip verbatim.
+   *
+   * Filters:
+   * - `projectId`: restrict to a single project.
+   * - `includeArchived`: default `false` → excludes rows with `archived_at IS NOT NULL`.
+   *
+   * NOTE: this method does NOT enforce project membership. The route layer is
+   * responsible for scoping callers to projects they can see (by passing
+   * `projectId` only after checking access, or by post-filtering).
+   */
+  async list(opts: ListAgentDefinitionsOptions = {}): Promise<ListAgentDefinitionsResult> {
+    // Empty projectIds = caller can't see anything → short-circuit to no rows.
+    if (opts.projectIds !== undefined && opts.projectIds.length === 0) {
+      return { items: [], nextCursor: null };
+    }
+
+    const limit = clampLimit(opts.limit);
+    const includeArchived = opts.includeArchived === true;
+    const cursor = decodeListCursor(opts.cursor);
+
+    const filters = [];
+    if (opts.projectId) {
+      filters.push(eq(agents.projectId, opts.projectId));
+    } else if (opts.projectIds) {
+      filters.push(inArray(agents.projectId, opts.projectIds));
+    }
+    if (!includeArchived) filters.push(isNull(agents.archivedAt));
+    // Pagination: keyset over (date_trunc('ms', created_at), id).
+    //
+    // PostgreSQL `timestamptz` stores microseconds but `Date.toISOString()`
+    // renders only milliseconds. If we compared raw `created_at` to a
+    // ms-precision cursor, microsecond-different rows in the same ms bucket
+    // could be lost (cursor `< .123Z` excludes a row at `.123456`, and `=`
+    // never matches because microseconds differ).
+    //
+    // We reconcile by truncating BOTH sides to millisecond precision with
+    // `date_trunc('milliseconds', created_at)`. That matches the cursor
+    // exactly and preserves the `id`-tiebreaker semantics.
+    if (cursor) {
+      filters.push(
+        or(
+          sql`date_trunc('milliseconds', ${agents.createdAt}) < ${cursor.createdAt}`,
+          and(
+            sql`date_trunc('milliseconds', ${agents.createdAt}) = ${cursor.createdAt}`,
+            lt(agents.id, cursor.id)
+          )
+        ) as never
+      );
+    }
+
+    const where = filters.length === 0 ? undefined : and(...filters);
+    const rows = await this.db
+      .select()
+      .from(agents)
+      .where(where as never)
+      // Order BY date_trunc match filter precision; id tiebreaker stays strict.
+      .orderBy(sql`date_trunc('milliseconds', ${agents.createdAt}) DESC`, desc(agents.id))
+      .limit(limit + 1);
+
+    const hasMore = rows.length > limit;
+    const page = rows.slice(0, limit);
+    const items = page.map(rowToDefinition);
+    const last = page[page.length - 1];
+    const nextCursor = hasMore && last ? encodeListCursor(last.createdAt, last.id) : null;
+    return { items, nextCursor };
+  }
+
+  /**
    * GET /api/v1/agent-definitions/:id?version=N — returns the historical
    * snapshot merged with the owning agent row's immutable metadata.
    */
@@ -589,4 +693,34 @@ export class AgentDefinitionService {
 function clampLimit(raw: number | undefined): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 1) return 50;
   return Math.min(Math.floor(raw), 200);
+}
+
+/**
+ * List cursor = base64url("<createdAtISO>|<id>"). Opaque to clients; decoded
+ * back into `(createdAt: Date, id: string)` for keyset pagination.
+ *
+ * Malformed / unparseable cursors are silently dropped (return `null` from
+ * {@link decodeListCursor}); the caller falls back to "no cursor = first page"
+ * semantics, which is friendlier than erroring on a cosmetic issue.
+ */
+function encodeListCursor(createdAt: Date, id: string): string {
+  const raw = `${createdAt.toISOString()}|${id}`;
+  return Buffer.from(raw, 'utf8').toString('base64url');
+}
+
+function decodeListCursor(cursor: string | undefined): { createdAt: Date; id: string } | null {
+  if (!cursor) return null;
+  try {
+    const raw = Buffer.from(cursor, 'base64url').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep < 0) return null;
+    const iso = raw.slice(0, sep);
+    const id = raw.slice(sep + 1);
+    if (!iso || !id) return null;
+    const createdAt = new Date(iso);
+    if (Number.isNaN(createdAt.getTime())) return null;
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
 }

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -12,6 +12,8 @@ export {
   type CreateAgentDefinitionInput,
   EmptyAgentDefinitionPatchError,
   InvalidAgentDefinitionInputError,
+  type ListAgentDefinitionsOptions,
+  type ListAgentDefinitionsResult,
   type ListVersionsOptions,
   type ListVersionsResult,
   type PatchAgentDefinitionInput,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3(react@19.2.5)
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2


### PR DESCRIPTION
## Summary
- Full AgentDefinition REST surface on `/api/v1/agent-definitions/*` (6 endpoints) per `specs/managed-agents-api.md` + `specs/agent-definition-versioning.md`
- Consumes task-5 unified auth + task-7 AgentDefinitionService; adds v1 response helpers (`v1Success/v1Error/v1Paginated/v1ValidationError` + 8-ErrorCode→HTTP map)
- Extends AgentDefinitionService with `list(opts)` supporting projectId / projectIds filters + millisecond-precision keyset cursor `(date_trunc('ms', created_at), id)` DESC

## Test plan
- [x] `pnpm build` (with `DATABASE_URL` .env) — PASS
- [x] `pnpm check` — PASS
- [x] `pnpm lint` — 2 pre-existing warnings, no new errors
- [x] `pnpm test` — web 18 files / 254 tests; control-plane 35 / 505 (total 74 new: 58 route/helper + 8 service list + 4 integration + 4 versions extra)
- [x] `./docs/execution/verify.sh task-8` — **PASS**
- [x] Sparring round 1 CONCERNS (soft-deleted project leak MUST-FIX, 409 integration MUST-FIX, /versions cursor permissive SHOULD-FIX, list cursor ms/μs precision SHOULD-FIX) → round 2 **APPROVE**
- [x] Integration test exercises real service + routes + PGlite (only auth/membership mocked): concurrent PATCH 200/409 + stale If-Match + sequential no-false-conflict + soft-deleted regression

## Auth / access model
- 401 unauthenticated / 403 scope gate (agent-definitions:read/write)
- POST / GET?projectId=X: pre-check membership (fast fail)
- GET/PATCH/archive by id: post-check membership (avoid existence probing)
- GET without projectId: caller's accessible projects = memberships ∪ createdBy (both filter deletedAt)

## Notes
- Branch created from `/tmp/agent-wt/a` (Agent-A dedicated worktree per coordinator isolation plan)
- `@electric-sql/pglite` added as apps/web devDep (for integration test only)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)