### PR TITLE
chore(vitest): set global hookTimeout=30s in PGlite-using packages

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -9,5 +9,7 @@ export default defineConfig({
   },
   test: {
     passWithNoTests: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
   },
 });

--- a/packages/control-plane/vitest.config.ts
+++ b/packages/control-plane/vitest.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    testTimeout: 30000,
+    hookTimeout: 30000,
   },
 });

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts'],
     testTimeout: 30000,
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Background

Per-hook timeout overrides (PR #146, PR #149 fixup) have been playing whack-a-mole. PR #149 CI re-failed on a **third** surface:

- PR #146 → fixed 4 packages/db tests
- PR #149 fixup → fixed 2 apps/web integration tests
- PR #149 rerun → **still failed** on \`packages/control-plane/src/__tests__/drizzle-vault-db.test.ts\` (added in task-9, never got a per-hook override)

Every new PGlite-using test is a latent timebomb until it ships.

## Root-cause insight

Vitest has **two separate** timeout knobs:

| Option | Controls |
|---|---|
| \`testTimeout\` | \`it(…)\` body execution |
| \`hookTimeout\` | \`beforeAll / beforeEach / afterEach / afterAll\` |

\`packages/db/vitest.config.ts\` already had \`testTimeout: 30000\` but **no \`hookTimeout\`**, so hooks defaulted to 10s. That's why crud.test.ts had a passing \`testTimeout\` config and still hit hookTimeout in CI.

## Fix

Set \`hookTimeout: 30000\` globally in the 3 vitest.config.ts files where PGlite tests live:

- \`apps/web/vitest.config.ts\`
- \`packages/control-plane/vitest.config.ts\`
- \`packages/db/vitest.config.ts\`

Also add \`testTimeout: 30000\` to control-plane and web for consistency.

**Scope**: 3 files, 5 added lines. No business logic, no contracts, no schema.

**Not touched**: pure unit-test packages (contracts, stream, memory, skills, mcp, sandbox, integrations, observability, agent-runtime) don't do DB init in hooks. YAGNI.

## Legacy per-hook overrides

Per-hook \`, 30000\` overrides from PR #146 / PR #149 fixup remain in place:
- 4 files in packages/db (PR #146)
- 2 files in apps/web (PR #149 fixup, currently on feat/task-9 branch)

They're now redundant but harmless (both hook-level and config-level are 30s). Cleanup = later chore.

## Sparring Review

**APPROVE** (gpt-5.3-codex-xhigh):
- Root cause captured correctly (hookTimeout vs testTimeout distinction)
- Scope minimal and accurate (only 3 packages with PGlite tests)
- No business logic, no contracts, no schema
- Risk: very low — pure test framework config

## Unblocks

- PR #149 (task-9) will pass CI on next rebase (the drizzle-vault-db.test.ts hook fault will be covered by the global hookTimeout now)
- Future PGlite test additions won't need to remember per-hook timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)