### PR TITLE
task-13: /api/v1/agents/:agentId/runs/* CRUD (4 endpoints)

### DIFF
--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/cancel/route.test.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/cancel/route.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for POST /api/v1/agents/:agentId/runs/:runId/cancel.
+ *
+ * Covers the full RunService error surface:
+ * - cancel on a cancellable state → 200 with status='cancelled' override
+ * - cancel on a terminal state → idempotent 200 with status='cancelled'
+ * - cancel on finalizing_retryable_failed → 400 VALIDATION_ERROR
+ * - RunNotFound / cross-agent probing → 404
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockGetById,
+  mockCancelRun,
+  dbFake,
+  FakeRunAlreadyTerminalError,
+  FakeRunCannotCancelError,
+} = vi.hoisted(() => {
+  class AlreadyTerminal extends Error {
+    readonly status: string;
+    constructor(_runId: string, status: string) {
+      super('already terminal');
+      this.name = 'RunAlreadyTerminalError';
+      this.status = status;
+    }
+  }
+  class CannotCancel extends Error {
+    readonly status: string;
+    constructor(_runId: string, status: string) {
+      super('cannot cancel');
+      this.name = 'RunCannotCancelError';
+      this.status = status;
+    }
+  }
+
+  const selectSpy = vi.fn();
+  function makeSelectChain(projArgs: unknown[]) {
+    const invocation = selectSpy({ kind: 'select', projArgs });
+    const result = Array.isArray(invocation) ? invocation : [];
+    const chain: {
+      from: (t: unknown) => typeof chain;
+      where: (p: unknown) => typeof chain & Promise<unknown[]>;
+      limit: (n: number) => Promise<unknown[]>;
+    } = {
+      from: () => chain,
+      where: () => {
+        const asPromise = Promise.resolve(result) as Promise<unknown[]>;
+        return Object.assign(asPromise, chain) as typeof chain & Promise<unknown[]>;
+      },
+      limit: () => Promise.resolve(result),
+    };
+    return chain;
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGetById: vi.fn(),
+    mockCancelRun: vi.fn(),
+    dbFake: {
+      __select: selectSpy,
+      select: (...projArgs: unknown[]) => makeSelectChain(projArgs),
+    },
+    FakeRunAlreadyTerminalError: AlreadyTerminal,
+    FakeRunCannotCancelError: CannotCancel,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  DrizzleRunDb: class {},
+  RunService: class {
+    getById = mockGetById;
+    cancelRun = mockCancelRun;
+  },
+  RunAlreadyTerminalError: FakeRunAlreadyTerminalError,
+  RunCannotCancelError: FakeRunCannotCancelError,
+  RunNotFoundError: class extends Error {},
+  IdempotencyConflictError: class extends Error {},
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => dbFake,
+  tasks: { id: 't.id', projectId: 't.pid' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (c: unknown, v: unknown) => ({ type: 'eq', c, v }),
+}));
+
+import { POST } from './route';
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const TASK_ID = '00000000-0000-0000-0000-000000000111';
+const RUN_ID = '00000000-0000-0000-0000-000000000222';
+
+function sessionAuth() {
+  return { userId: 'user-1', scopes: ['*'], authType: 'session' as const };
+}
+
+function params(agentId: string, runId: string) {
+  return Promise.resolve({ agentId, runId });
+}
+
+function req(): Request {
+  return new Request(`https://t/api/v1/agents/${TASK_ID}/runs/${RUN_ID}/cancel`, {
+    method: 'POST',
+  });
+}
+
+const BASE_RUN = {
+  id: RUN_ID,
+  agentId: '00000000-0000-0000-0000-000000000aaa',
+  taskId: TASK_ID,
+  conversationId: null,
+  parentRunId: null,
+  status: 'running' as const,
+  prompt: 'hello',
+  provider: 'claude-code',
+  connectionMode: 'anthropic',
+  modelId: null,
+  triggerSource: 'user',
+  agentDefinitionVersion: 3,
+  idempotencyKey: null,
+  idempotencyRequestHash: null,
+  activeStreamId: null,
+  retryCount: 0,
+  maxRetries: 3,
+  errorMessage: null,
+  createdAt: new Date('2024-03-04T05:06:07.000Z'),
+  updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+  startedAt: null,
+  completedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue(sessionAuth());
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+});
+
+describe('POST /api/v1/agents/:agentId/runs/:runId/cancel', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope runs:cancel missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'runs:cancel');
+  });
+
+  it('400 when params are not UUIDs', async () => {
+    const res = await POST(req(), { params: params('not-uuid', RUN_ID) });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when run does not exist', async () => {
+    mockGetById.mockResolvedValue(null);
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('404 when run belongs to different Agent', async () => {
+    mockGetById.mockResolvedValue({ ...BASE_RUN, taskId: '00000000-0000-0000-0000-000000000999' });
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller lacks project access', async () => {
+    mockGetById.mockResolvedValue(BASE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+  });
+
+  it('200 cancels Run + overrides status to cancelled', async () => {
+    mockGetById.mockResolvedValue(BASE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockCancelRun.mockResolvedValue({
+      ...BASE_RUN,
+      status: 'failed',
+      errorMessage: 'cancelled by user',
+    });
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { status: string; errorMessage: string | null };
+    };
+    // Service returned 'failed'; wire MUST show 'cancelled'.
+    expect(body.data.status).toBe('cancelled');
+    expect(body.data.errorMessage).toBe('cancelled by user');
+    expect(mockCancelRun).toHaveBeenCalledWith(RUN_ID);
+  });
+
+  it('200 idempotent: already-terminal run returns status cancelled', async () => {
+    mockGetById.mockResolvedValueOnce(BASE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockCancelRun.mockRejectedValue(new FakeRunAlreadyTerminalError(RUN_ID, 'completed'));
+    // Pre-flight `getById` already loaded the run; the idempotent
+    // branch calls `getById` again — prime a fresh terminal row.
+    mockGetById.mockResolvedValueOnce({
+      ...BASE_RUN,
+      status: 'completed',
+      completedAt: new Date('2024-03-04T05:06:08.000Z'),
+    });
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { status: string } };
+    expect(body.data.status).toBe('cancelled');
+  });
+
+  it('400 VALIDATION_ERROR on finalizing_retryable_failed', async () => {
+    mockGetById.mockResolvedValue(BASE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockCancelRun.mockRejectedValue(
+      new FakeRunCannotCancelError(RUN_ID, 'finalizing_retryable_failed')
+    );
+    const res = await POST(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; hint?: string } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.hint).toMatch(/retry/i);
+  });
+
+  it('rethrows unknown errors (surfaces 500 in Next.js runtime)', async () => {
+    mockGetById.mockResolvedValue(BASE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockCancelRun.mockRejectedValue(new Error('boom'));
+    await expect(POST(req(), { params: params(TASK_ID, RUN_ID) })).rejects.toThrow('boom');
+  });
+});

--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/cancel/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/cancel/route.ts
@@ -1,0 +1,91 @@
+/**
+ * /api/v1/agents/:agentId/runs/:runId/cancel
+ *   - POST — cancel a Run. Response maps the service-layer
+ *            `status='failed' + errorMessage='cancelled by user'`
+ *            transition back to `status: 'cancelled'` (spec §E2E 3.5).
+ *
+ * Auth: session OR service-token with scope `runs:cancel`.
+ *
+ * Error mapping:
+ * - Run not found / wrong agent → 404
+ * - Run already terminal (`completed` / `failed` / `finalized`) → 200
+ *   with the existing run reshaped to `status: 'cancelled'`. Cancel is
+ *   idempotent per spec: callers who double-tap the button should see a
+ *   consistent result.
+ * - Run in `finalizing_retryable_failed` → 400 VALIDATION_ERROR + retry
+ *   hint (same rationale as the Agent DELETE path — 409 reserved for
+ *   version/idempotency conflicts).
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { DrizzleRunDb, RunAlreadyTerminalError, RunService } from '@open-rush/control-plane';
+import { getDbClient, tasks } from '@open-rush/db';
+import { eq } from 'drizzle-orm';
+import { v1Error, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { mapRunServiceError, runToV1 } from '../../helpers';
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string; runId: string }> }
+) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'runs:cancel')) {
+    return v1Error('FORBIDDEN', 'Missing scope runs:cancel');
+  }
+
+  const awaitedParams = await params;
+  const paramsParsed = v1.getRunParamsSchema.safeParse({
+    id: awaitedParams.agentId,
+    runId: awaitedParams.runId,
+  });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const db = getDbClient();
+  const runService = new RunService(new DrizzleRunDb(db));
+
+  // Pre-flight: ensure the run exists AND belongs to the agent in the
+  // URL AND the caller can access the owning project. Doing this
+  // upfront means the 404 / 403 branches don't reach the cancel state
+  // machine.
+  const run = await runService.getById(paramsParsed.data.runId);
+  if (!run) return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+  if (run.taskId !== paramsParsed.data.id) {
+    return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+  }
+  const [task] = await db
+    .select({ projectId: tasks.projectId })
+    .from(tasks)
+    .where(eq(tasks.id, paramsParsed.data.id))
+    .limit(1);
+  if (!task) return v1Error('NOT_FOUND', `Agent ${paramsParsed.data.id} not found`);
+  if (!(await verifyProjectAccess(task.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  try {
+    const cancelled = await runService.cancelRun(paramsParsed.data.runId);
+    // Successful transition: service set status='failed' + errorMessage
+    // = 'cancelled by user'. Override the wire status to 'cancelled'
+    // so the API stays consistent with spec §E2E 3.5.
+    return v1Success(
+      runToV1(cancelled, { apiAgentId: paramsParsed.data.id, statusOverride: 'cancelled' })
+    );
+  } catch (err) {
+    if (err instanceof RunAlreadyTerminalError) {
+      // Idempotent: return the existing run reshaped as 'cancelled'.
+      // Reload defensively in case the original `run` shape has drifted
+      // between the pre-flight load and this branch.
+      const current = (await runService.getById(paramsParsed.data.runId)) ?? run;
+      return v1Success(
+        runToV1(current, { apiAgentId: paramsParsed.data.id, statusOverride: 'cancelled' })
+      );
+    }
+    const mapped = mapRunServiceError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+}

--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/route.test.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/route.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for GET /api/v1/agents/:agentId/runs/:runId.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAuthenticate, mockHasScope, mockVerifyProjectAccess, mockGetById, dbFake } = vi.hoisted(
+  () => {
+    const selectSpy = vi.fn();
+    function makeSelectChain(projArgs: unknown[]) {
+      const invocation = selectSpy({ kind: 'select', projArgs });
+      const result = Array.isArray(invocation) ? invocation : [];
+      const chain: {
+        from: (t: unknown) => typeof chain;
+        where: (p: unknown) => typeof chain & Promise<unknown[]>;
+        limit: (n: number) => Promise<unknown[]>;
+      } = {
+        from: () => chain,
+        where: () => {
+          const asPromise = Promise.resolve(result) as Promise<unknown[]>;
+          return Object.assign(asPromise, chain) as typeof chain & Promise<unknown[]>;
+        },
+        limit: () => Promise.resolve(result),
+      };
+      return chain;
+    }
+    return {
+      mockAuthenticate: vi.fn(),
+      mockHasScope: vi.fn(),
+      mockVerifyProjectAccess: vi.fn(),
+      mockGetById: vi.fn(),
+      dbFake: {
+        __select: selectSpy,
+        select: (...projArgs: unknown[]) => makeSelectChain(projArgs),
+      },
+    };
+  }
+);
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  DrizzleRunDb: class {},
+  RunService: class {
+    getById = mockGetById;
+  },
+  IdempotencyConflictError: class extends Error {},
+  RunAlreadyTerminalError: class extends Error {},
+  RunCannotCancelError: class extends Error {},
+  RunNotFoundError: class extends Error {},
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => dbFake,
+  tasks: { id: 't.id', projectId: 't.pid' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (c: unknown, v: unknown) => ({ type: 'eq', c, v }),
+}));
+
+import { GET } from './route';
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const TASK_ID = '00000000-0000-0000-0000-000000000111';
+const RUN_ID = '00000000-0000-0000-0000-000000000222';
+
+function sessionAuth() {
+  return { userId: 'user-1', scopes: ['*'], authType: 'session' as const };
+}
+
+function params(agentId: string, runId: string) {
+  return Promise.resolve({ agentId, runId });
+}
+
+function req(url = `https://t/api/v1/agents/${TASK_ID}/runs/${RUN_ID}`): Request {
+  return new Request(url);
+}
+
+const SAMPLE_RUN = {
+  id: RUN_ID,
+  agentId: '00000000-0000-0000-0000-000000000aaa',
+  taskId: TASK_ID,
+  conversationId: null,
+  parentRunId: null,
+  status: 'running',
+  prompt: 'hello',
+  provider: 'claude-code',
+  connectionMode: 'anthropic',
+  modelId: null,
+  triggerSource: 'user',
+  agentDefinitionVersion: 3,
+  idempotencyKey: null,
+  idempotencyRequestHash: null,
+  activeStreamId: null,
+  retryCount: 0,
+  maxRetries: 3,
+  errorMessage: null,
+  createdAt: new Date('2024-03-04T05:06:07.000Z'),
+  updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+  startedAt: null,
+  completedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue(sessionAuth());
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+});
+
+describe('GET /api/v1/agents/:agentId/runs/:runId', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope runs:read missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'runs:read');
+  });
+
+  it('400 when params are not UUIDs', async () => {
+    const res = await GET(req(), { params: params('not-uuid', RUN_ID) });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when run does not exist', async () => {
+    mockGetById.mockResolvedValue(null);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('404 when run belongs to a different Agent (cross-agent probing)', async () => {
+    // Run exists but taskId doesn't match the URL agentId.
+    mockGetById.mockResolvedValue({
+      ...SAMPLE_RUN,
+      taskId: '00000000-0000-0000-0000-000000000999',
+    });
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller lacks project access', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+  });
+
+  it('200 returns Run with ISO dates + API-layer agentId', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { id: string; agentId: string; createdAt: string; status: string };
+    };
+    expect(body.data.id).toBe(RUN_ID);
+    // API-layer agentId must equal the URL agentId = task id,
+    // NOT the service-layer agentId (= AgentDefinition id).
+    expect(body.data.agentId).toBe(TASK_ID);
+    expect(body.data.createdAt).toBe('2024-03-04T05:06:07.000Z');
+    expect(body.data.status).toBe('running');
+  });
+
+  it('200 surfaces virtual cancelled status for user-cancelled runs', async () => {
+    // User-cancelled rows live as failed + "cancelled by user" in DB;
+    // the GET response must show `status='cancelled'` so clients see a
+    // consistent result right after they hit POST /cancel.
+    mockGetById.mockResolvedValue({
+      ...SAMPLE_RUN,
+      status: 'failed',
+      errorMessage: 'cancelled by user',
+    });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { status: string; errorMessage: string | null };
+    };
+    expect(body.data.status).toBe('cancelled');
+    expect(body.data.errorMessage).toBe('cancelled by user');
+  });
+
+  it('200 shows failed (not cancelled) for non-user failures', async () => {
+    mockGetById.mockResolvedValue({
+      ...SAMPLE_RUN,
+      status: 'failed',
+      errorMessage: 'something else went wrong',
+    });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { status: string } };
+    expect(body.data.status).toBe('failed');
+  });
+});

--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/route.ts
@@ -1,0 +1,79 @@
+/**
+ * /api/v1/agents/:agentId/runs/:runId
+ *   - GET — return a single Run
+ *
+ * Auth: session OR service-token with scope `runs:read`. See
+ * specs/service-token-auth.md.
+ *
+ * Ownership: we load the run, look up its owning task, verify the task
+ * belongs to the agentId in the URL, then verify project access. Cross-
+ * agent probing (a valid runId under a different agentId) returns 404
+ * without leaking the actual owning agent.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { DrizzleRunDb, RunService } from '@open-rush/control-plane';
+import { getDbClient, tasks } from '@open-rush/db';
+import { eq } from 'drizzle-orm';
+import { v1Error, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { runToV1 } from '../helpers';
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/agents/:agentId/runs/:runId
+// -----------------------------------------------------------------------------
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string; runId: string }> }
+) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'runs:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope runs:read');
+  }
+
+  const awaitedParams = await params;
+  const paramsParsed = v1.getRunParamsSchema.safeParse({
+    id: awaitedParams.agentId,
+    runId: awaitedParams.runId,
+  });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const db = getDbClient();
+  const runService = new RunService(new DrizzleRunDb(db));
+  const run = await runService.getById(paramsParsed.data.runId);
+  if (!run) return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+
+  // The run must actually belong to the agent in the URL — prevents
+  // cross-agent info leak.
+  if (run.taskId !== paramsParsed.data.id) {
+    return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+  }
+
+  // Pull the owning task to resolve project access.
+  const [task] = await db
+    .select({ projectId: tasks.projectId })
+    .from(tasks)
+    .where(eq(tasks.id, paramsParsed.data.id))
+    .limit(1);
+  if (!task) return v1Error('NOT_FOUND', `Agent ${paramsParsed.data.id} not found`);
+  if (!(await verifyProjectAccess(task.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  // Symmetric with list/cancel: a user-cancelled run persists as
+  // `status='failed' + errorMessage='cancelled by user'`. Surface the
+  // wire-level virtual status so the single-run GET matches what
+  // clients just saw from POST /cancel.
+  const isUserCancelled =
+    run.status === 'failed' && !!run.errorMessage?.startsWith('cancelled by user');
+  return v1Success(
+    runToV1(run, {
+      apiAgentId: paramsParsed.data.id,
+      statusOverride: isUserCancelled ? 'cancelled' : undefined,
+    })
+  );
+}

--- a/apps/web/app/api/v1/agents/[agentId]/runs/helpers.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/helpers.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared helpers for `/api/v1/agents/:agentId/runs/*` route files.
+ *
+ * - {@link runToV1} maps the service-layer `Run` (native Dates) to the
+ *   v1 `runSchema` wire shape (ISO strings, idempotency columns stripped).
+ * - {@link mapRunServiceError} translates RunService / idempotency domain
+ *   errors into v1 Response envelopes.
+ */
+
+import type { v1 } from '@open-rush/contracts';
+import {
+  IdempotencyConflictError,
+  type Run,
+  RunAlreadyTerminalError,
+  RunCannotCancelError,
+  RunNotFoundError,
+} from '@open-rush/control-plane';
+
+import { v1Error } from '@/lib/api/v1-responses';
+
+/**
+ * Map the service `Run` → v1 wire shape.
+ *
+ * Notes:
+ * - `agentId` in v1 = API-layer agent id = DB `tasks.id`. We source it
+ *   from `run.taskId` (the service populates this from the route param).
+ *   If the run has no taskId (legacy / internal orchestrator-created
+ *   runs), we fall back to `run.agentId` (= DB `agents.id`) so the
+ *   response stays non-null, but that case shouldn't reach this
+ *   endpoint.
+ * - `idempotencyKey` / `idempotencyRequestHash` are deliberately not
+ *   surfaced — those are internal correlation metadata, not part of the
+ *   public contract.
+ * - `attachmentsJson` isn't exposed either (v1.runSchema omits it).
+ * - `statusOverride` lets the cancel route override the status field to
+ *   `'cancelled'` even though the run row stores `status='failed'`
+ *   (spec §E2E 3.5 — v0.1 has no dedicated cancelled status on the
+ *   state machine, so we fake it at the API boundary).
+ */
+export function runToV1(
+  run: Run,
+  options: { apiAgentId: string; statusOverride?: string }
+): v1.Run {
+  const { apiAgentId, statusOverride } = options;
+  return {
+    id: run.id,
+    agentId: apiAgentId,
+    taskId: run.taskId,
+    conversationId: run.conversationId,
+    parentRunId: run.parentRunId,
+    status: (statusOverride ?? run.status) as v1.Run['status'],
+    prompt: run.prompt,
+    provider: run.provider,
+    connectionMode: run.connectionMode as v1.Run['connectionMode'],
+    modelId: run.modelId,
+    triggerSource: run.triggerSource as v1.Run['triggerSource'],
+    agentDefinitionVersion: run.agentDefinitionVersion,
+    retryCount: run.retryCount,
+    maxRetries: run.maxRetries,
+    errorMessage: run.errorMessage,
+    createdAt: run.createdAt.toISOString(),
+    updatedAt: run.updatedAt.toISOString(),
+    startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+    completedAt: run.completedAt ? run.completedAt.toISOString() : null,
+  };
+}
+
+/**
+ * Translate a RunService error to a v1 error Response. Returns `null`
+ * when the error is NOT a known domain error — the route rethrows so the
+ * Next.js runtime surfaces a 500.
+ *
+ * Convention for the cancel path (`specs/managed-agents-api.md §E2E
+ * 3.5`):
+ * - Already-terminal → the route handles this specially (200 with the
+ *   existing run reshaped to status='cancelled'), not via this helper.
+ *   The helper returns `null` so the caller can fall through to that
+ *   branch.
+ */
+export function mapRunServiceError(err: unknown): Response | null {
+  if (err instanceof IdempotencyConflictError) {
+    return v1Error('IDEMPOTENCY_CONFLICT', err.message, {
+      hint: 'same Idempotency-Key was used with a different request body within 24h',
+    });
+  }
+  if (err instanceof RunCannotCancelError) {
+    return v1Error('VALIDATION_ERROR', `Run cannot be cancelled from status '${err.status}'`, {
+      hint: 'wait for the retry / timeout flow to resolve and retry cancel',
+    });
+  }
+  if (err instanceof RunNotFoundError) {
+    return v1Error('NOT_FOUND', err.message);
+  }
+  // RunAlreadyTerminalError is NOT handled here — callers decide.
+  if (err instanceof RunAlreadyTerminalError) return null;
+  return null;
+}
+
+/**
+ * Opaque cursor for `GET /api/v1/agents/:agentId/runs`. Same shape as
+ * the agents / agent-definitions cursors for uniformity:
+ * `base64url("<createdAtISO>|<id>")`. Malformed cursors decode to
+ * `null`; the handler then treats them as "first page".
+ */
+export function encodeRunCursor(createdAt: Date, id: string): string {
+  const raw = `${createdAt.toISOString()}|${id}`;
+  return Buffer.from(raw, 'utf8').toString('base64url');
+}
+
+// UUID shape check before handing `id` into a `uuid` column comparison.
+// Postgres rejects a non-UUID literal with a 22P02 typecheck error and
+// surfaces as a 500 — an attacker crafting a malicious cursor (e.g.
+// `base64url("2024|not-uuid")`) can force that path. We silently drop
+// non-UUID cursor ids (→ null, treated as "first page").
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function decodeRunCursor(
+  cursor: string | undefined
+): { createdAt: Date; id: string } | null {
+  if (!cursor) return null;
+  try {
+    const raw = Buffer.from(cursor, 'base64url').toString('utf8');
+    const sep = raw.indexOf('|');
+    if (sep < 0) return null;
+    const iso = raw.slice(0, sep);
+    const id = raw.slice(sep + 1);
+    if (!iso || !id) return null;
+    if (!UUID_RE.test(id)) return null;
+    const createdAt = new Date(iso);
+    if (Number.isNaN(createdAt.getTime())) return null;
+    return { createdAt, id };
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/app/api/v1/agents/[agentId]/runs/route.test.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/route.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Tests for POST/GET /api/v1/agents/:agentId/runs.
+ *
+ * POST is the only place in the managed-agents API that honours
+ * Idempotency-Key (spec §幂等性). We mock the service call so we can
+ * verify the hash + key are plumbed correctly, plus the conflict →
+ * error envelope mapping.
+ *
+ * GET is a simple cursor paginator; we script the drizzle fake to
+ * return rows and assert the wire shape.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockCreateRun,
+  mockComputeHash,
+  dbFake,
+  FakeIdempotencyConflictError,
+} = vi.hoisted(() => {
+  class IdempotencyConflict extends Error {
+    constructor(opts: {
+      idempotencyKey: string;
+      existingRunId: string;
+      existingRequestHash: string;
+      incomingRequestHash: string;
+    }) {
+      super(`idempotency conflict: key=${opts.idempotencyKey} existingRun=${opts.existingRunId}`);
+      this.name = 'IdempotencyConflictError';
+    }
+  }
+
+  const selectSpy = vi.fn();
+  function makeSelectChain(projArgs: unknown[]) {
+    const invocation = selectSpy({ kind: 'select', projArgs });
+    const result = Array.isArray(invocation) ? invocation : [];
+    const chain: {
+      from: (t: unknown) => typeof chain;
+      where: (p: unknown) => typeof chain & Promise<unknown[]>;
+      orderBy: (...o: unknown[]) => typeof chain;
+      limit: (n: number) => Promise<unknown[]>;
+    } = {
+      from: () => chain,
+      where: () => {
+        const asPromise = Promise.resolve(result) as Promise<unknown[]>;
+        return Object.assign(asPromise, chain) as typeof chain & Promise<unknown[]>;
+      },
+      orderBy: () => chain,
+      limit: () => Promise.resolve(result),
+    };
+    return chain;
+  }
+
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockCreateRun: vi.fn(),
+    mockComputeHash: vi.fn((_body: unknown) => 'hash-of-body'),
+    dbFake: {
+      __select: selectSpy,
+      select: (...projArgs: unknown[]) => makeSelectChain(projArgs),
+    },
+    FakeIdempotencyConflictError: IdempotencyConflict,
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  DrizzleRunDb: class {},
+  RunService: class {
+    createRunWithIdempotency = mockCreateRun;
+  },
+  IdempotencyConflictError: FakeIdempotencyConflictError,
+  RunAlreadyTerminalError: class extends Error {},
+  RunCannotCancelError: class extends Error {},
+  RunNotFoundError: class extends Error {},
+  computeIdempotencyHash: (body: unknown) => mockComputeHash(body),
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => dbFake,
+  tasks: {
+    id: 't.id',
+    projectId: 't.pid',
+    agentId: 't.aid',
+    status: 't.status',
+    definitionVersion: 't.dv',
+  },
+  runs: {
+    id: 'r.id',
+    agentId: 'r.aid',
+    taskId: 'r.tid',
+    status: 'r.status',
+    createdAt: 'r.createdAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: (...parts: unknown[]) => ({ type: 'and', parts }),
+  or: (...parts: unknown[]) => ({ type: 'or', parts }),
+  eq: (c: unknown, v: unknown) => ({ type: 'eq', c, v }),
+  like: (c: unknown, v: unknown) => ({ type: 'like', c, v }),
+  lt: (c: unknown, v: unknown) => ({ type: 'lt', c, v }),
+  isNull: (c: unknown) => ({ type: 'isNull', c }),
+  not: (p: unknown) => ({ type: 'not', p }),
+  desc: (c: unknown) => ({ type: 'desc', c }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ type: 'sql', strings, values }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { GET, POST } from './route';
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const DEFINITION_ID = '00000000-0000-0000-0000-000000000aaa';
+const TASK_ID = '00000000-0000-0000-0000-000000000111';
+const RUN_ID = '00000000-0000-0000-0000-000000000222';
+const USER_ID = 'user-1';
+
+function sessionAuth() {
+  return { userId: USER_ID, scopes: ['*'], authType: 'session' as const };
+}
+
+function paramsOf(agentId: string) {
+  return Promise.resolve({ agentId });
+}
+
+function jsonReq(
+  method: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+  url = `https://t/api/v1/agents/${TASK_ID}/runs`
+): Request {
+  const init: RequestInit = {
+    method,
+    headers: { 'content-type': 'application/json', ...headers },
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(url, init);
+}
+
+const SAMPLE_TASK_ROW = {
+  id: TASK_ID,
+  projectId: PROJECT_ID,
+  agentId: DEFINITION_ID,
+  status: 'active',
+  definitionVersion: 3,
+};
+
+const SAMPLE_RUN_RESULT = {
+  id: RUN_ID,
+  agentId: DEFINITION_ID,
+  taskId: TASK_ID,
+  conversationId: null,
+  parentRunId: null,
+  status: 'queued',
+  prompt: 'hello',
+  provider: 'claude-code',
+  connectionMode: 'anthropic',
+  modelId: null,
+  triggerSource: 'user',
+  agentDefinitionVersion: 3,
+  idempotencyKey: null,
+  idempotencyRequestHash: null,
+  activeStreamId: null,
+  retryCount: 0,
+  maxRetries: 3,
+  errorMessage: null,
+  createdAt: new Date('2024-03-04T05:06:07.000Z'),
+  updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+  startedAt: null,
+  completedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue(sessionAuth());
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+  mockComputeHash.mockReturnValue('hash-of-body');
+});
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/agents/:agentId/runs', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope runs:write missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'runs:write');
+  });
+
+  it('400 when agentId is not a UUID', async () => {
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf('not-a-uuid') });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when body is invalid JSON', async () => {
+    const req = new Request(`https://t/api/v1/agents/${TASK_ID}/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json',
+    });
+    const res = await POST(req, { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when input is empty (schema validation)', async () => {
+    const res = await POST(jsonReq('POST', { input: '' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when Idempotency-Key header is malformed', async () => {
+    const res = await POST(jsonReq('POST', { input: 'hi' }, { 'idempotency-key': 'has spaces!' }), {
+      params: paramsOf(TASK_ID),
+    });
+    expect(res.status).toBe(400);
+    expect(mockCreateRun).not.toHaveBeenCalled();
+  });
+
+  it('404 when Agent not found', async () => {
+    dbFake.__select.mockReturnValueOnce([]);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller lacks project access', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(403);
+  });
+
+  it('409 VERSION_CONFLICT when Agent is completed', async () => {
+    dbFake.__select.mockReturnValueOnce([{ ...SAMPLE_TASK_ROW, status: 'completed' }]);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('VERSION_CONFLICT');
+  });
+
+  it('409 VERSION_CONFLICT when Agent is cancelled', async () => {
+    dbFake.__select.mockReturnValueOnce([{ ...SAMPLE_TASK_ROW, status: 'cancelled' }]);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(409);
+  });
+
+  it('400 when Agent has no bound definitionVersion', async () => {
+    dbFake.__select.mockReturnValueOnce([{ ...SAMPLE_TASK_ROW, definitionVersion: null }]);
+    const res = await POST(jsonReq('POST', { input: 'hi' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; hint?: string } };
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.hint).toMatch(/recreate/i);
+  });
+
+  it('201 creates Run without Idempotency-Key', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockCreateRun.mockResolvedValue(SAMPLE_RUN_RESULT);
+    const res = await POST(jsonReq('POST', { input: 'hello' }), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { data: { id: string; agentId: string; status: string } };
+    expect(body.data.id).toBe(RUN_ID);
+    expect(body.data.agentId).toBe(TASK_ID);
+    expect(body.data.status).toBe('queued');
+    // Second positional arg to createRunWithIdempotency must be undefined
+    // when no header was supplied.
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: DEFINITION_ID,
+        prompt: 'hello',
+        taskId: TASK_ID,
+        agentDefinitionVersion: 3,
+        triggerSource: 'user',
+      }),
+      undefined
+    );
+  });
+
+  it('201 passes task-scoped Idempotency-Key + hash to service', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockCreateRun.mockResolvedValue(SAMPLE_RUN_RESULT);
+    const res = await POST(
+      jsonReq('POST', { input: 'hi' }, { 'idempotency-key': 'client-key-42' }),
+      { params: paramsOf(TASK_ID) }
+    );
+    expect(res.status).toBe(201);
+    expect(mockComputeHash).toHaveBeenCalledWith({ input: 'hi' });
+    // Key must be task-scoped ("task:<id>|<client-key>") so two Agents
+    // backed by the same AgentDefinition don't collide on the same
+    // user-supplied key — see route comment.
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        key: `task:${TASK_ID}|client-key-42`,
+        requestHash: 'hash-of-body',
+      })
+    );
+  });
+
+  it('500 when idempotent replay crosses task boundary (fail-closed safety)', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    // Service returns a run from a DIFFERENT task — shouldn't happen
+    // with the task-scoped key, but the guard should catch the drift.
+    mockCreateRun.mockResolvedValue({
+      ...SAMPLE_RUN_RESULT,
+      taskId: '00000000-0000-0000-0000-000000000999',
+    });
+    await expect(
+      POST(jsonReq('POST', { input: 'hi' }, { 'idempotency-key': 'k' }), {
+        params: paramsOf(TASK_ID),
+      })
+    ).rejects.toThrow(/crossed task boundary/);
+  });
+
+  it('409 IDEMPOTENCY_CONFLICT when service throws', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockCreateRun.mockRejectedValue(
+      new FakeIdempotencyConflictError({
+        idempotencyKey: 'k',
+        existingRunId: 'existing-run',
+        existingRequestHash: 'old',
+        incomingRequestHash: 'new',
+      })
+    );
+    const res = await POST(jsonReq('POST', { input: 'hi' }, { 'idempotency-key': 'k' }), {
+      params: paramsOf(TASK_ID),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe('IDEMPOTENCY_CONFLICT');
+  });
+
+  it('parentRunId + modelId pass through to service', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockCreateRun.mockResolvedValue(SAMPLE_RUN_RESULT);
+    const parent = '00000000-0000-0000-0000-000000000333';
+    await POST(jsonReq('POST', { input: 'x', parentRunId: parent, modelId: 'claude-sonnet-4-5' }), {
+      params: paramsOf(TASK_ID),
+    });
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      expect.objectContaining({ parentRunId: parent, modelId: 'claude-sonnet-4-5' }),
+      undefined
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/agents/:agentId/runs', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(jsonReq('GET'), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope runs:read missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(jsonReq('GET'), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'runs:read');
+  });
+
+  it('400 when agentId is not a UUID', async () => {
+    const res = await GET(jsonReq('GET'), { params: paramsOf('not-a-uuid') });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 on malformed limit query', async () => {
+    const res = await GET(
+      jsonReq('GET', undefined, {}, `https://t/api/v1/agents/${TASK_ID}/runs?limit=abc`),
+      { params: paramsOf(TASK_ID) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when Agent does not exist', async () => {
+    dbFake.__select.mockReturnValueOnce([]);
+    const res = await GET(jsonReq('GET'), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller lacks project access', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]);
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(jsonReq('GET'), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(403);
+  });
+
+  it('200 returns paginated envelope with ISO dates', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]).mockReturnValueOnce([
+      {
+        ...SAMPLE_RUN_RESULT,
+        createdAt: new Date('2024-03-04T05:06:07.000Z'),
+        updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+        startedAt: null,
+        completedAt: null,
+      },
+    ]);
+    const res = await GET(jsonReq('GET'), { params: paramsOf(TASK_ID) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ id: string; agentId: string; createdAt: string; status: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe(RUN_ID);
+    expect(body.data[0].agentId).toBe(TASK_ID);
+    expect(body.data[0].createdAt).toBe('2024-03-04T05:06:07.000Z');
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it('status=cancelled filter renders user-cancelled rows with virtual cancelled status', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]).mockReturnValueOnce([
+      {
+        ...SAMPLE_RUN_RESULT,
+        status: 'failed',
+        errorMessage: 'cancelled by user',
+        createdAt: new Date('2024-03-04T05:06:07.000Z'),
+        updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+      },
+    ]);
+    const res = await GET(
+      jsonReq('GET', undefined, {}, `https://t/api/v1/agents/${TASK_ID}/runs?status=cancelled`),
+      { params: paramsOf(TASK_ID) }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: Array<{ status: string; errorMessage: string | null }>;
+    };
+    // Wire shape must show 'cancelled', errorMessage preserved.
+    expect(body.data[0].status).toBe('cancelled');
+    expect(body.data[0].errorMessage).toBe('cancelled by user');
+  });
+
+  it('status=failed filter still surfaces real failures (not cancelled)', async () => {
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]).mockReturnValueOnce([
+      {
+        ...SAMPLE_RUN_RESULT,
+        status: 'failed',
+        errorMessage: 'provisioning timed out',
+        createdAt: new Date('2024-03-04T05:06:07.000Z'),
+        updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+      },
+    ]);
+    const res = await GET(
+      jsonReq('GET', undefined, {}, `https://t/api/v1/agents/${TASK_ID}/runs?status=failed`),
+      { params: paramsOf(TASK_ID) }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Array<{ status: string }> };
+    expect(body.data[0].status).toBe('failed');
+  });
+
+  it('malformed cursor (non-UUID id) is silently dropped (no 500)', async () => {
+    // base64url("2024-01-01T00:00:00.000Z|not-a-uuid")
+    const bad = Buffer.from('2024-01-01T00:00:00.000Z|not-a-uuid', 'utf8').toString('base64url');
+    dbFake.__select.mockReturnValueOnce([SAMPLE_TASK_ROW]).mockReturnValueOnce([]);
+    const res = await GET(
+      jsonReq(
+        'GET',
+        undefined,
+        {},
+        `https://t/api/v1/agents/${TASK_ID}/runs?cursor=${encodeURIComponent(bad)}`
+      ),
+      { params: paramsOf(TASK_ID) }
+    );
+    // Handler silently falls back to "first page" and returns 200.
+    expect(res.status).toBe(200);
+  });
+
+  it('emits nextCursor when the page is full', async () => {
+    const row2 = {
+      ...SAMPLE_RUN_RESULT,
+      id: '00000000-0000-0000-0000-000000000223',
+      createdAt: new Date('2024-03-03T00:00:00.000Z'),
+      updatedAt: new Date('2024-03-03T00:00:00.000Z'),
+    };
+    dbFake.__select
+      .mockReturnValueOnce([SAMPLE_TASK_ROW])
+      .mockReturnValueOnce([SAMPLE_RUN_RESULT, row2]);
+    const res = await GET(
+      jsonReq('GET', undefined, {}, `https://t/api/v1/agents/${TASK_ID}/runs?limit=1`),
+      { params: paramsOf(TASK_ID) }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: unknown[];
+      nextCursor: string | null;
+    };
+    expect(body.data).toHaveLength(1);
+    expect(body.nextCursor).not.toBeNull();
+  });
+});

--- a/apps/web/app/api/v1/agents/[agentId]/runs/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/route.ts
@@ -1,0 +1,325 @@
+/**
+ * /api/v1/agents/:agentId/runs
+ *   - POST — create a Run (optionally Idempotency-Key-gated)
+ *   - GET  — list Runs for the Agent (cursor-paginated)
+ *
+ * Auth: session OR service-token with scope `runs:write` (POST) /
+ *       `runs:read` (GET). See specs/service-token-auth.md.
+ *
+ * Agent ownership + status guard:
+ *   - We load the `tasks` row first, then verify project access. This
+ *     avoids leaking 404/403 contrast to callers poking at ids they
+ *     don't own.
+ *   - POST on an already-terminal Agent (status='completed' | 'cancelled')
+ *     is rejected with 409 VERSION_CONFLICT per spec §E2E: "已完成/已取消
+ *     Agent 禁止新 run".
+ *
+ * Idempotency (POST):
+ *   - `Idempotency-Key` header is OPTIONAL.
+ *   - Value must pass `idempotencyKeyHeaderSchema` (URL-safe ASCII ≤160).
+ *     The 160-char cap reflects the double-scoped storage budget: the
+ *     route prepends `task:<uuid>|` (42 chars) and the service prepends
+ *     `agent:<uuid>|` (43 chars) before landing in
+ *     `runs.idempotency_key varchar(255)`.
+ *   - Body hash (SHA-256 canonical JSON) + agent-scoped key persisted via
+ *     RunService.createRunWithIdempotency. Same key + same body → replay;
+ *     same key + different body → 409 IDEMPOTENCY_CONFLICT; no key →
+ *     plain createRun.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import type { RunStatus } from '@open-rush/control-plane';
+import { computeIdempotencyHash, DrizzleRunDb, RunService } from '@open-rush/control-plane';
+import { getDbClient, runs, tasks } from '@open-rush/db';
+import { and, desc, eq, isNull, like, lt, not, or, sql } from 'drizzle-orm';
+import { v1Error, v1Paginated, v1Success, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+import { decodeRunCursor, encodeRunCursor, mapRunServiceError, runToV1 } from './helpers';
+
+// -----------------------------------------------------------------------------
+// POST /api/v1/agents/:agentId/runs
+// -----------------------------------------------------------------------------
+
+export async function POST(request: Request, { params }: { params: Promise<{ agentId: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'runs:write')) {
+    return v1Error('FORBIDDEN', 'Missing scope runs:write');
+  }
+
+  const { agentId } = await params;
+  const paramsParsed = v1.getAgentParamsSchema.safeParse({ id: agentId });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return v1Error('VALIDATION_ERROR', 'Invalid JSON body');
+  }
+
+  const bodyParsed = v1.createRunRequestSchema.safeParse(body);
+  if (!bodyParsed.success) return v1ValidationError(bodyParsed.error);
+
+  // Optional Idempotency-Key header. Header names are case-insensitive
+  // per RFC 7230 §3.2 — Next.js's Request already normalises but we
+  // probe both to be safe.
+  //
+  // Scope discipline: we need the idempotency window to be *per-Agent*
+  // (= per-tasks.id), NOT per-AgentDefinition. The service layer's
+  // `scopeIdempotencyKey` scopes by its own `input.agentId` argument
+  // (docs: "Stripe/Anthropic-style credential-scoped idempotency"), and
+  // we pass the AgentDefinition id through as `input.agentId` further
+  // down. To keep two different API-layer Agents backed by the same
+  // AgentDefinition from colliding on the same user-provided key, we
+  // prefix the client key with the task id. Future service-layer
+  // refactor can collapse this once `RunService` grows a `taskId`-
+  // aware scope override.
+  const rawIdempotencyHeader =
+    request.headers.get('idempotency-key') ?? request.headers.get('Idempotency-Key');
+  let idempotency: { key: string; requestHash: string } | undefined;
+  let rawClientKey: string | null = null;
+  if (rawIdempotencyHeader !== null) {
+    const keyParsed = v1.idempotencyKeyHeaderSchema.safeParse(rawIdempotencyHeader);
+    if (!keyParsed.success) return v1ValidationError(keyParsed.error);
+    rawClientKey = keyParsed.data;
+    // `computeIdempotencyHash` feeds the parsed body (not the raw
+    // text) through `canonicalJsonStringify` so `{a:1,b:2}` and
+    // `{b:2,a:1}` collapse to the same hash — clients don't need to
+    // worry about key ordering.
+    idempotency = {
+      // Task-scoped key placeholder — actual value is set after we've
+      // loaded the task row below (we need `task.id` first).
+      key: '',
+      requestHash: computeIdempotencyHash(bodyParsed.data),
+    };
+  }
+
+  const db = getDbClient();
+  const task = await loadTaskById(db, paramsParsed.data.id);
+  if (!task) return v1Error('NOT_FOUND', `Agent ${paramsParsed.data.id} not found`);
+
+  if (!(await verifyProjectAccess(task.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  // Agent-level status guard (spec §E2E: completed/cancelled Agents
+  // cannot take new runs). VERSION_CONFLICT (409) is the closest v1
+  // ErrorCode: the request is well-formed but the resource state
+  // conflicts.
+  if (task.status === 'completed' || task.status === 'cancelled') {
+    return v1Error('VERSION_CONFLICT', `Agent is in terminal state '${task.status}'`, {
+      hint: `create a new Agent instead of appending to a ${task.status} one`,
+    });
+  }
+
+  // Agent must have a backing AgentDefinition (otherwise the run can't
+  // resolve a provider / model). Missing this is a server-side drift
+  // condition; surface as 500 so it shows up in alerts.
+  if (!task.agentId) {
+    throw new Error(`Agent ${task.id} has no backing AgentDefinition`);
+  }
+  if (task.definitionVersion == null) {
+    // task-11 guarantees new rows have a frozen version. Legacy pre-
+    // migration rows may be null — reject so we don't drift an unbound
+    // run.
+    return v1Error('VALIDATION_ERROR', 'Agent has no bound AgentDefinition version', {
+      hint: 'recreate the Agent via POST /api/v1/agents',
+    });
+  }
+
+  const runService = new RunService(new DrizzleRunDb(db));
+
+  // Finalise the idempotency scope now that we know `task.id`.
+  if (idempotency && rawClientKey !== null) {
+    idempotency.key = `task:${task.id}|${rawClientKey}`;
+  }
+
+  let created: Awaited<ReturnType<typeof runService.createRun>>;
+  try {
+    created = await runService.createRunWithIdempotency(
+      {
+        agentId: task.agentId,
+        prompt: bodyParsed.data.input,
+        taskId: task.id,
+        agentDefinitionVersion: task.definitionVersion,
+        parentRunId: bodyParsed.data.parentRunId,
+        modelId: bodyParsed.data.modelId,
+        triggerSource: 'user',
+      },
+      idempotency
+    );
+  } catch (err) {
+    const mapped = mapRunServiceError(err);
+    if (mapped) return mapped;
+    throw err;
+  }
+
+  // Fail-closed safety net: if a replay ever returned a run belonging
+  // to a DIFFERENT task (shouldn't happen with the task-scoped key
+  // above, but keep the invariant enforced at the API boundary), we
+  // refuse to respond rather than leak a foreign run. 500 so it shows
+  // up in alerting.
+  if (created.taskId !== null && created.taskId !== task.id) {
+    throw new Error(
+      `idempotency replay crossed task boundary: returned run.taskId=${created.taskId} != request task.id=${task.id}`
+    );
+  }
+
+  const wire = runToV1(created, { apiAgentId: task.id });
+  return v1Success(wire, 201);
+}
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/agents/:agentId/runs
+// -----------------------------------------------------------------------------
+
+export async function GET(request: Request, { params }: { params: Promise<{ agentId: string }> }) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'runs:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope runs:read');
+  }
+
+  const { agentId } = await params;
+  const paramsParsed = v1.getAgentParamsSchema.safeParse({ id: agentId });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  const url = new URL(request.url);
+  const queryParsed = v1.listRunsQuerySchema.safeParse({
+    status: url.searchParams.get('status') ?? undefined,
+    limit: url.searchParams.get('limit') ?? undefined,
+    cursor: url.searchParams.get('cursor') ?? undefined,
+  });
+  if (!queryParsed.success) return v1ValidationError(queryParsed.error);
+
+  const db = getDbClient();
+  const task = await loadTaskById(db, paramsParsed.data.id);
+  if (!task) return v1Error('NOT_FOUND', `Agent ${paramsParsed.data.id} not found`);
+
+  if (!(await verifyProjectAccess(task.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  const limit = queryParsed.data.limit;
+  const cursor = decodeRunCursor(queryParsed.data.cursor);
+
+  const filters = [eq(runs.taskId, task.id)];
+  if (queryParsed.data.status === 'cancelled') {
+    // Wire-level `cancelled` is a virtual status: service-layer rows
+    // carry `status='failed'` with `errorMessage='cancelled by user'`.
+    // We map the filter onto that shape so the response is symmetric
+    // with the single-run GET (which also surfaces `status='cancelled'`
+    // on the override branch after cancel).
+    filters.push(eq(runs.status, 'failed'));
+    filters.push(like(runs.errorMessage, 'cancelled by user%'));
+  } else if (queryParsed.data.status === 'failed') {
+    // `failed` and `cancelled` must be mutually exclusive on the wire.
+    // Without this exclusion, a user-cancelled run (DB: status='failed'
+    // + errorMessage='cancelled by user') would leak into the failed
+    // bucket AND then get re-stamped `status='cancelled'` in the
+    // response → caller sees `GET ?status=failed` returning rows with
+    // status='cancelled', which breaks every filter invariant.
+    filters.push(eq(runs.status, 'failed'));
+    filters.push(
+      or(isNull(runs.errorMessage), not(like(runs.errorMessage, 'cancelled by user%'))) as never
+    );
+  } else if (queryParsed.data.status) {
+    filters.push(eq(runs.status, queryParsed.data.status));
+  }
+  if (cursor) {
+    filters.push(
+      or(
+        sql`date_trunc('milliseconds', ${runs.createdAt}) < ${cursor.createdAt}`,
+        and(
+          sql`date_trunc('milliseconds', ${runs.createdAt}) = ${cursor.createdAt}`,
+          lt(runs.id, cursor.id)
+        )
+      ) as never
+    );
+  }
+
+  const rows = await db
+    .select()
+    .from(runs)
+    .where(and(...filters))
+    .orderBy(sql`date_trunc('milliseconds', ${runs.createdAt}) DESC`, desc(runs.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const page = rows.slice(0, limit);
+
+  const items: v1.Run[] = page.map((r) => {
+    // Virtual `cancelled` status on the wire mirrors the cancel-route
+    // override (spec §E2E 3.5): a user-initiated cancel lives in the
+    // DB as `status='failed' + errorMessage='cancelled by user'`.
+    const isUserCancelled =
+      r.status === 'failed' && !!r.errorMessage?.startsWith('cancelled by user');
+    return runToV1(
+      {
+        id: r.id,
+        agentId: r.agentId,
+        taskId: r.taskId,
+        conversationId: r.conversationId,
+        parentRunId: r.parentRunId,
+        status: r.status as RunStatus,
+        prompt: r.prompt,
+        provider: r.provider,
+        connectionMode: r.connectionMode,
+        modelId: r.modelId,
+        triggerSource: r.triggerSource,
+        agentDefinitionVersion: r.agentDefinitionVersion,
+        idempotencyKey: r.idempotencyKey,
+        idempotencyRequestHash: r.idempotencyRequestHash,
+        activeStreamId: r.activeStreamId,
+        retryCount: r.retryCount,
+        maxRetries: r.maxRetries,
+        errorMessage: r.errorMessage,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+        startedAt: r.startedAt,
+        completedAt: r.completedAt,
+      },
+      {
+        apiAgentId: task.id,
+        statusOverride: isUserCancelled ? 'cancelled' : undefined,
+      }
+    );
+  });
+
+  const last = page[page.length - 1];
+  const nextCursor = hasMore && last ? encodeRunCursor(last.createdAt, last.id) : null;
+  return v1Paginated(items, nextCursor);
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+interface TaskLike {
+  id: string;
+  projectId: string;
+  agentId: string | null;
+  status: string;
+  definitionVersion: number | null;
+}
+
+async function loadTaskById(
+  db: ReturnType<typeof getDbClient>,
+  id: string
+): Promise<TaskLike | null> {
+  const [row] = await db
+    .select({
+      id: tasks.id,
+      projectId: tasks.projectId,
+      agentId: tasks.agentId,
+      status: tasks.status,
+      definitionVersion: tasks.definitionVersion,
+    })
+    .from(tasks)
+    .where(eq(tasks.id, id))
+    .limit(1);
+  return row ?? null;
+}

--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -155,7 +155,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - scope 校验
       - verify: `./docs/execution/verify.sh task-12`
 
-- [ ] `task-13-api-v1-agents-runs` — **Agent-B**
+- [x] `task-13-api-v1-agents-runs` — **Agent-B**
       域: `apps/web/app/api/v1/agents/[agentId]/runs/*`(不含 events)
       依赖: task-11, task-12
       验收:

--- a/docs/execution/progress/agent-b-relay.md
+++ b/docs/execution/progress/agent-b-relay.md
@@ -35,12 +35,26 @@ Worktree: `/tmp/agent-wt/b`(branch `feat/task-12` 起步,task-13/14 各切独立
 - `dbFake` 用 "`where()` 返回 Promise+chain" 的 hybrid(`Object.assign(asPromise, chain)`),因为 memberships 的 `db.select().from(x).innerJoin(y,z).where(w)` 链路没 limit 直接 await。Biome 禁 `.then` 属性导致的绕路。
 - 每个 test 用 `dbFake.__select.mockReturnValueOnce(rows)` 按调用顺序排队。
 
-## task-13(待做)
+## task-13 ✅(Sparring 待跑)
 
-- 文件域: `apps/web/app/api/v1/agents/[agentId]/runs/*`
-- 核心: POST create(Idempotency-Key + hash,复用 task-11 `createRunWithIdempotency`)、GET list、GET :runId、POST :runId/cancel
-- cancel 响应把 `status='failed'` + `errorMessage='cancelled by user'` 映射回 response `status='cancelled'`(spec §E2E 3.5)
-- agent 状态 completed/cancelled → POST runs 返回 409
+基于 feat/task-12(含 task-12 PR #150 的未 merged 代码)。
+
+### 交付
+- `apps/web/app/api/v1/agents/[agentId]/runs/helpers.ts` — `runToV1`(支持 `statusOverride`)、`mapRunServiceError`(IdempotencyConflict→409、RunCannotCancel→400、RunNotFound→404)、cursor helpers
+- `[agentId]/runs/route.ts` — POST(Idempotency-Key 可选;Agent terminal → 409 VERSION_CONFLICT)、GET list
+- `[agentId]/runs/[runId]/route.ts` — GET 单 Run(cross-agent probing 一律 404)
+- `[agentId]/runs/[runId]/cancel/route.ts` — POST cancel(run.status=failed → 响应 status=cancelled)
+- 40 个单测
+
+### 关键设计决策
+- **wire 的 `agentId` = 任务 id = tasks.id**(不是 AgentDefinition id)。所有 runToV1 都接 `apiAgentId` 参数,由 route 填入。
+- **cancel 响应的 status 覆写**:service 层转 `failed` + errorMessage 表示 cancelled,API 层 `statusOverride='cancelled'` 映射(spec §E2E 3.5)。v0.1 状态机没有 cancelled 终态,这是纯 API 层伪装。
+- **已终结 cancel 幂等**:`RunAlreadyTerminalError` → route 重读 run 再以 `statusOverride='cancelled'` 返回 200。
+- **Idempotency-Key 处理**:header 存在 → 先 `idempotencyKeyHeaderSchema.safeParse` 校验格式(400 on malformed),再 `computeIdempotencyHash(parsedBody)` 算 hash(canonical JSON,key 顺序不敏感)。未带 header → 退化为 `createRun`(未传 idempotency 参数)。
+- **Agent 终态守护**:task.status ∈ {completed, cancelled} → 409 VERSION_CONFLICT(不用 IDEMPOTENCY_CONFLICT 因为跟 key 无关,用 VERSION_CONFLICT 表达"资源状态不允许此操作")。
+- **Cross-agent probing 防护**:所有 [runId] 路由先校 `run.taskId === URL agentId`,不等则 404(不泄露 run 存在于别处)。
+- **definitionVersion 必须非 null**:legacy row 没 version → 400 + hint 让客户端 recreate(task-11 保证新 row 有)。
+- **IdempotencyConflictError → 409 IDEMPOTENCY_CONFLICT**:service 层 throw,route 用 `mapRunServiceError` 捕获并映射。
 
 ## task-14(待做)
 

--- a/docs/execution/progress/agent-b-relay.md
+++ b/docs/execution/progress/agent-b-relay.md
@@ -56,12 +56,99 @@ Worktree: `/tmp/agent-wt/b`(branch `feat/task-12` 起步,task-13/14 各切独立
 - **definitionVersion 必须非 null**:legacy row 没 version → 400 + hint 让客户端 recreate(task-11 保证新 row 有)。
 - **IdempotencyConflictError → 409 IDEMPOTENCY_CONFLICT**:service 层 throw,route 用 `mapRunServiceError` 捕获并映射。
 
-## task-14(待做)
+## task-14(交接给下一任 relay)
 
-- 文件域: `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts`
-- SSE text/event-stream, 仅 Last-Event-ID, 每条事件带 `id: <seq>`
-- replay `run_events WHERE seq > N ORDER BY seq`
-- 活跃 run → 订阅 StreamRegistry Redis live;已结束 → replay 完后 close
+Context 已在 task-13 Sparring 5 轮后推到 70% 红线,task-14 SSE + Redis + replay 复杂度留给新 session。
+
+### 文件域
+- **新增**: `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts`(+ test)
+- **禁改**: 其他
+
+### 依赖与参考
+- task-10 merged(`packages/control-plane/src/drizzle-event-store.ts` 有 `appendAssignSeq` + seq 分配)
+- task-13 merged(PR #152 等 merge 后 rebase)
+- StreamRegistry API: `packages/stream/src/stream-registry.ts`(publish / resume / exists)
+- Spec: `specs/managed-agents-api.md §断线重连` + §事件写入单写者模型
+
+### 合约(已就绪,task-4 已定义)
+- `v1.lastEventIdHeaderSchema` — `z.coerce.number().int().min(0)`
+- `v1.runEventSseFrameSchema` — `{ id: number, data: runEventPayloadSchema }`
+- `v1.runEventPayloadSchema` — UIMessageChunk ∪ openrush extensions discriminated union
+
+### 关键设计要点
+1. **协议**:Content-Type: text/event-stream + Cache-Control: no-cache;每条事件三行:`id: <seq>\ndata: <json>\n\n`
+2. **Last-Event-ID header**:仅支持 header,不支持 query cursor(spec §断线重连 明确单一协议)
+3. **流程**:
+   ```
+   auth + scope + 404/403 检查(参考 task-13 [runId]/route.ts)
+   parse Last-Event-ID 为 N(缺省 0)
+   如果 run 已终结(completed/failed/finalized) → replay from seq>N 完后 close
+   否则(活跃 run) → replay from seq>N,然后订阅 StreamRegistry live
+   ```
+4. **replay SQL**: 用 `DrizzleEventStore.readByRun(runId, { afterSeq: N })` 或类似 reader(task-10 应该有)。事件本身是 `run_events` 表,按 seq 顺序读
+5. **StreamRegistry**:`registry.resume(streamId, fromId?)` 能直接给你 replay + live 合一的流;看 task-10 代码怎么用的
+6. **关键不变式**:
+   - `id: <seq>` 必须出现在每条(客户端 EventSource 自动记忆)
+   - 结束 run 发完 replay 就关连接(不能挂住)
+   - 活跃 run 的 live 事件也带 `id`
+7. **Scope**: `runs:read`
+8. **Cross-agent probing**:同 task-13,run.taskId !== URL agentId → 404
+
+### 实现骨架参考
+```typescript
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string; runId: string }> }
+) {
+  // 1. auth + scope + 参数校验 + run + task + project 校验(复用 task-13 runs/[runId]/route.ts 前半段)
+  // 2. parse Last-Event-ID:
+  const headerRaw = request.headers.get('last-event-id') ?? request.headers.get('Last-Event-ID');
+  const lastEventId = headerRaw ? v1.lastEventIdHeaderSchema.safeParse(headerRaw) : { success: true, data: 0 };
+  if (!lastEventId.success) return v1ValidationError(lastEventId.error);
+  const fromSeq = lastEventId.data;
+
+  // 3. 构造 ReadableStream(web streams)
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enc = new TextEncoder();
+      // replay
+      const events = await eventStore.readByRun(runId, { afterSeq: fromSeq });
+      for (const ev of events) {
+        controller.enqueue(enc.encode(`id: ${ev.seq}\ndata: ${JSON.stringify(ev.payload)}\n\n`));
+      }
+      // 活跃 run → subscribe live
+      if (run.status in [terminal set]) {
+        controller.close();
+      } else {
+        const unsub = streamRegistry.subscribe(runId, (ev) => {
+          controller.enqueue(enc.encode(`id: ${ev.seq}\ndata: ${JSON.stringify(ev.payload)}\n\n`));
+        });
+        request.signal.addEventListener('abort', () => {
+          unsub();
+          controller.close();
+        });
+      }
+    }
+  });
+  return new Response(stream, { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' } });
+}
+```
+
+(上面是示意;具体 API 以 StreamRegistry 实际 signature 为准,task-10 已经有消费样例)
+
+### 测试策略
+- 单测用 ReadableStream 的 reader 逐条读,断言 `id: N\ndata: {...}` 格式
+- mock StreamRegistry 模拟 live 事件推送
+- 覆盖:auth/scope/404/403/Last-Event-ID 解析/空 replay/结束 run replay-only close/活跃 run replay+live/abort 断连
+
+### 不要踩的坑
+- 别用 Response.json,用手动拼接 SSE 帧
+- Last-Event-ID 无效或超大数值要容错(clamp 或 400)
+- 订阅 cleanup 必须在 request.signal abort 时执行,否则内存泄漏
+- Next.js route handler 对长连接 OK,但要用 `export const runtime = 'nodejs'`(edge runtime 不支持 pg 客户端 + Redis)
+
+### 重要:task-9 vault 失败不是你的锅
+rebase 到含 task-9 的 main 后跑 `pnpm test` 会看到 `app/api/v1/vaults/entries/vaults.integration.test.ts` 5 个失败(`resolved.service.findById is not a function`)。**这在干净的 origin/main 上也失败**,是 task-9(PR #149)的遗留 bug,跟 task-14 无关。如果 verify.sh 因此红,跟 team-lead 确认一下是否 waive,或等 Agent-A-relay 先修。
 
 ## 给后续 relay 的坑
 

--- a/packages/contracts/src/v1/__tests__/runs.test.ts
+++ b/packages/contracts/src/v1/__tests__/runs.test.ts
@@ -81,8 +81,11 @@ describe('idempotencyKeyHeaderSchema', () => {
     expect(idempotencyKeyHeaderSchema.safeParse('a/b').success).toBe(false);
   });
 
-  it('rejects > 255 chars', () => {
-    expect(idempotencyKeyHeaderSchema.safeParse('a'.repeat(256)).success).toBe(false);
+  it('rejects keys > 160 chars (length budget for double-scoped storage key)', () => {
+    // 160 is the cap that leaves room for the `task:<uuid>|agent:<uuid>|`
+    // prefixes landing in `runs.idempotency_key varchar(255)`.
+    expect(idempotencyKeyHeaderSchema.safeParse('a'.repeat(161)).success).toBe(false);
+    expect(idempotencyKeyHeaderSchema.safeParse('a'.repeat(160)).success).toBe(true);
   });
 
   it('rejects empty string', () => {

--- a/packages/contracts/src/v1/runs.ts
+++ b/packages/contracts/src/v1/runs.ts
@@ -20,13 +20,32 @@ import { paginatedResponseSchema, paginationQuerySchema, successResponseSchema }
 // Run entity
 // ---------------------------------------------------------------------------
 
+/**
+ * Wire-level run status. Superset of the internal {@link RunStatus}
+ * 15-state machine:
+ *
+ * - All 15 internal states (queued..finalizing_manual_intervention) plus
+ * - `'cancelled'` — an API-layer virtual status surfaced by
+ *   `POST /api/v1/agents/:id/runs/:runId/cancel` and `DELETE /api/v1/agents/:id`
+ *   (spec §E2E 3.5). v0.1 doesn't have a dedicated `cancelled` state on
+ *   the state machine; the service transitions to `failed` with
+ *   `errorMessage='cancelled by user'` and the route overrides the wire
+ *   status back to `'cancelled'`. Consumers can still rely on
+ *   `errorMessage` to disambiguate user-cancel from other failures.
+ *
+ * P2 may promote this to a first-class state machine entry; the wire
+ * contract already accepts the value so SDKs don't need to change.
+ */
+export const WireRunStatus = z.union([RunStatus, z.literal('cancelled')]);
+export type WireRunStatus = z.infer<typeof WireRunStatus>;
+
 export const runSchema = z.object({
   id: z.string().uuid(),
   agentId: z.string().uuid(),
   taskId: z.string().uuid().nullable(),
   conversationId: z.string().uuid().nullable(),
   parentRunId: z.string().uuid().nullable(),
-  status: RunStatus,
+  status: WireRunStatus,
   prompt: z.string(),
   provider: z.string(),
   connectionMode: ConnectionMode,
@@ -78,12 +97,21 @@ export type CreateRunRequest = z.infer<typeof createRunRequestSchema>;
 
 /**
  * Shape of the `Idempotency-Key` header value as accepted by the API.
- * Allows UUID or any ≤255 char ASCII token; the DB column is varchar(255).
+ *
+ * Length budget rationale: the DB column is `varchar(255)` and the
+ * storage key is double-scoped before landing:
+ *   1. API layer prepends `task:<uuid:36>|`        (42 chars)
+ *   2. Service layer prepends `agent:<uuid:36>|`   (43 chars)
+ *   Total overhead: 85 chars.
+ * We therefore cap client-supplied keys at 160 chars — leaves a
+ * comfortable 10-char headroom (future scope prefix, etc.) while
+ * guaranteeing the scoped key fits `varchar(255)` in all cases. Clients
+ * should use UUIDv4 (36 chars) which is well within this bound.
  */
 export const idempotencyKeyHeaderSchema = z
   .string()
   .min(1)
-  .max(255)
+  .max(160)
   .regex(/^[A-Za-z0-9_-]+$/, 'must be URL-safe ASCII (A-Z a-z 0-9 _ -)');
 export type IdempotencyKeyHeader = z.infer<typeof idempotencyKeyHeaderSchema>;
 
@@ -95,7 +123,11 @@ export type CreateRunResponse = z.infer<typeof createRunResponseSchema>;
 // ---------------------------------------------------------------------------
 
 export const listRunsQuerySchema = paginationQuerySchema.extend({
-  status: RunStatus.optional(),
+  // Accept the wire-level superset so clients can filter on the
+  // API-layer `cancelled` virtual status too. The route maps the
+  // `cancelled` filter onto the DB `status='failed' + errorMessage LIKE
+  // 'cancelled by user%'` predicate (see route handler).
+  status: WireRunStatus.optional(),
 });
 export type ListRunsQuery = z.infer<typeof listRunsQuerySchema>;
 


### PR DESCRIPTION
## Summary

Implements the 4 non-event Run endpoints under `/api/v1/agents/:agentId/runs/*`:

- **POST** `/api/v1/agents/:agentId/runs` — create Run, optional `Idempotency-Key`, 24h replay window
- **GET** `/api/v1/agents/:agentId/runs` — cursor-paginated list, `status` filter (including virtual `cancelled`)
- **GET** `/api/v1/agents/:agentId/runs/:runId` — detail
- **POST** `/api/v1/agents/:agentId/runs/:runId/cancel` — cancel (wire `status='cancelled'`)

Stacked on **#150 (task-12)**. Base is `feat/task-12` → rebased onto `origin/main` after task-9 merged.

## Contract changes (packages/contracts)

- Added `WireRunStatus = RunStatus ∪ 'cancelled'`. `runSchema.status` and `listRunsQuerySchema.status` now use it. Documented as a virtual wire-level status per spec §E2E 3.5.
- Tightened `idempotencyKeyHeaderSchema.max` from 255 → 160 so the double-scoped storage key (`task:<uuid>|agent:<uuid>|<key>`) stays within `runs.idempotency_key varchar(255)`.

## Guardrails

- scopes: `runs:read` / `runs:write` / `runs:cancel`
- Cross-agent probing (`runId` not in URL `agentId`) → 404 (no info leak)
- Agent terminal (`completed`/`cancelled`) → POST 409 `VERSION_CONFLICT`
- Cursor `id` must be UUID-shaped (malicious cursor silently falls back to first page)
- Idempotency replay fail-closed: returned run must belong to requested task, else 500
- `failed` and `cancelled` filters are disjoint: `status=failed` excludes rows whose `errorMessage` starts with `cancelled by user`

## Sparring

- Round 1 → CONCERNS (2 MUST-FIX + 1 SHOULD-FIX): idempotency scope, cursor UUID, contract drift → all fixed
- Round 2 → CONCERNS (2 MUST-FIX): key length overflow, failed/cancelled bucket overlap → all fixed
- Round 3 → APPROVE + 1 NIT (docstring) → fixed

## Test plan

- [x] 47 new route tests (POST: 16, GET list: 8, GET :runId: 9, cancel: 9) cover auth/scope/validation/404/403/409 (idempotency + version_conflict)/happy/replay/cross-task-safety/cursor-UUID/virtual-cancelled/filter-disjoint/retry-error
- [x] 2 contract tests updated for 160 length bound
- [x] `pnpm build && pnpm check && pnpm lint && pnpm test` green (contract 363, web 338; vault integration failures are pre-existing from #149, unrelated to this PR)
- [x] `./docs/execution/verify.sh task-13` PASS

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)