### PR TITLE
task-14: /api/v1/agents/:agentId/runs/:runId/events SSE + Last-Event-ID

### DIFF
--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.test.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.test.ts
@@ -1,0 +1,583 @@
+/**
+ * Tests for GET /api/v1/agents/:agentId/runs/:runId/events (SSE).
+ *
+ * We mock `DrizzleEventStore` and `RunService` so tests can simulate
+ * `run_events` reads and terminal transitions without Postgres. The
+ * live polling branch uses `vi.useFakeTimers()` to advance time deterministically.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAuthenticate,
+  mockHasScope,
+  mockVerifyProjectAccess,
+  mockGetById,
+  mockGetEvents,
+  mockIsTerminal,
+  dbFake,
+} = vi.hoisted(() => {
+  const selectSpy = vi.fn();
+  function makeSelectChain(projArgs: unknown[]) {
+    const invocation = selectSpy({ kind: 'select', projArgs });
+    const result = Array.isArray(invocation) ? invocation : [];
+    const chain: {
+      from: (t: unknown) => typeof chain;
+      where: (p: unknown) => typeof chain & Promise<unknown[]>;
+      limit: (n: number) => Promise<unknown[]>;
+    } = {
+      from: () => chain,
+      where: () => {
+        const asPromise = Promise.resolve(result) as Promise<unknown[]>;
+        return Object.assign(asPromise, chain) as typeof chain & Promise<unknown[]>;
+      },
+      limit: () => Promise.resolve(result),
+    };
+    return chain;
+  }
+  return {
+    mockAuthenticate: vi.fn(),
+    mockHasScope: vi.fn(),
+    mockVerifyProjectAccess: vi.fn(),
+    mockGetById: vi.fn(),
+    mockGetEvents: vi.fn(),
+    mockIsTerminal: vi.fn(),
+    dbFake: {
+      __select: selectSpy,
+      select: (...projArgs: unknown[]) => makeSelectChain(projArgs),
+    },
+  };
+});
+
+vi.mock('@/lib/auth/unified-auth', () => ({
+  authenticate: (req: Request) => mockAuthenticate(req),
+  hasScope: (ctx: unknown, scope: string) => mockHasScope(ctx, scope),
+}));
+
+vi.mock('@/lib/api-utils', () => ({
+  verifyProjectAccess: (projectId: string, userId: string) =>
+    mockVerifyProjectAccess(projectId, userId),
+}));
+
+vi.mock('@open-rush/control-plane', () => ({
+  DrizzleRunDb: class {},
+  RunService: class {
+    getById = mockGetById;
+  },
+  DrizzleEventStore: class {
+    getEvents = mockGetEvents;
+  },
+  isTerminal: (status: string) => mockIsTerminal(status),
+}));
+
+vi.mock('@open-rush/db', () => ({
+  getDbClient: () => dbFake,
+  tasks: { id: 't.id', projectId: 't.pid' },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: (c: unknown, v: unknown) => ({ type: 'eq', c, v }),
+}));
+
+import { GET } from './route';
+
+const PROJECT_ID = '00000000-0000-0000-0000-000000000001';
+const TASK_ID = '00000000-0000-0000-0000-000000000111';
+const RUN_ID = '00000000-0000-0000-0000-000000000222';
+
+function sessionAuth() {
+  return { userId: 'user-1', scopes: ['*'], authType: 'session' as const };
+}
+
+function params(agentId: string, runId: string) {
+  return Promise.resolve({ agentId, runId });
+}
+
+function req(init?: { headers?: Record<string, string>; signal?: AbortSignal }): Request {
+  return new Request(`https://t/api/v1/agents/${TASK_ID}/runs/${RUN_ID}/events`, {
+    headers: init?.headers,
+    signal: init?.signal,
+  });
+}
+
+const SAMPLE_RUN = {
+  id: RUN_ID,
+  agentId: '00000000-0000-0000-0000-000000000aaa',
+  taskId: TASK_ID,
+  conversationId: null,
+  parentRunId: null,
+  status: 'running',
+  prompt: 'hello',
+  provider: 'claude-code',
+  connectionMode: 'anthropic',
+  modelId: null,
+  triggerSource: 'user',
+  agentDefinitionVersion: 3,
+  idempotencyKey: null,
+  idempotencyRequestHash: null,
+  activeStreamId: null,
+  retryCount: 0,
+  maxRetries: 3,
+  errorMessage: null,
+  createdAt: new Date('2024-03-04T05:06:07.000Z'),
+  updatedAt: new Date('2024-03-04T05:06:07.000Z'),
+  startedAt: null,
+  completedAt: null,
+};
+
+// Helper: drain a ReadableStream<Uint8Array> body into a list of SSE
+// frames (splits on the blank-line terminator `\n\n`). Returns all
+// frames accumulated until the stream closes.
+async function readAllFrames(res: Response): Promise<string[]> {
+  if (!res.body) throw new Error('Response has no body');
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const frames: string[] = [];
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx = buffer.indexOf('\n\n');
+    while (idx !== -1) {
+      frames.push(buffer.slice(0, idx));
+      buffer = buffer.slice(idx + 2);
+      idx = buffer.indexOf('\n\n');
+    }
+  }
+  if (buffer.length > 0) frames.push(buffer);
+  return frames;
+}
+
+// Helper: read frames up to `until` but break if reader fails (used for
+// live-stream tests where the stream may stay open).
+async function readFramesUntil(
+  res: Response,
+  until: (frame: string) => boolean
+): Promise<string[]> {
+  if (!res.body) throw new Error('Response has no body');
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const frames: string[] = [];
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx = buffer.indexOf('\n\n');
+    while (idx !== -1) {
+      const frame = buffer.slice(0, idx);
+      frames.push(frame);
+      buffer = buffer.slice(idx + 2);
+      if (until(frame)) {
+        reader.cancel().catch(() => undefined);
+        return frames;
+      }
+      idx = buffer.indexOf('\n\n');
+    }
+  }
+  return frames;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue(sessionAuth());
+  mockHasScope.mockReturnValue(true);
+  mockVerifyProjectAccess.mockResolvedValue(true);
+  mockGetEvents.mockResolvedValue([]);
+  mockIsTerminal.mockImplementation(
+    (status: string) => status === 'completed' || status === 'failed'
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('GET /api/v1/agents/:agentId/runs/:runId/events (auth + scope + ownership)', () => {
+  it('401 when unauthenticated', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when scope runs:read missing', async () => {
+    mockHasScope.mockReturnValue(false);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+    expect(mockHasScope).toHaveBeenCalledWith(expect.anything(), 'runs:read');
+  });
+
+  it('400 when agentId is not a UUID', async () => {
+    const res = await GET(req(), { params: params('not-uuid', RUN_ID) });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when runId is not a UUID', async () => {
+    const res = await GET(req(), { params: params(TASK_ID, 'bad') });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when Last-Event-ID is non-numeric', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    const res = await GET(req({ headers: { 'Last-Event-ID': 'not-a-number' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when Last-Event-ID is negative', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    const res = await GET(req({ headers: { 'Last-Event-ID': '-1' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when Last-Event-ID is empty string', async () => {
+    // `z.coerce.number()` would happily turn '' into 0 and silently
+    // replay from the beginning. Rejecting at the route layer forces
+    // callers to be explicit (omit header = full replay; send integer
+    // = replay after N).
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    const res = await GET(req({ headers: { 'Last-Event-ID': '' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when Last-Event-ID is whitespace-only', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    const res = await GET(req({ headers: { 'Last-Event-ID': '   ' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when run does not exist', async () => {
+    mockGetById.mockResolvedValue(null);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('404 when run belongs to a different Agent (cross-agent probing)', async () => {
+    mockGetById.mockResolvedValue({
+      ...SAMPLE_RUN,
+      taskId: '00000000-0000-0000-0000-000000000999',
+    });
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(404);
+  });
+
+  it('403 when caller lacks project access', async () => {
+    mockGetById.mockResolvedValue(SAMPLE_RUN);
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockVerifyProjectAccess.mockResolvedValue(false);
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /events — terminal run replay', () => {
+  it('200 with text/event-stream + replays events then closes', async () => {
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'completed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([
+      { seq: 1, payload: { type: 'text-delta', delta: 'Hello' } },
+      { seq: 2, payload: { type: 'text-delta', delta: ' world' } },
+      { seq: 3, payload: { type: 'finish', reason: 'end_turn' } },
+    ]);
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache, no-transform');
+    expect(res.headers.get('X-Accel-Buffering')).toBe('no');
+
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(3);
+    expect(frames[0]).toBe(
+      `id: 1\ndata: ${JSON.stringify({ type: 'text-delta', delta: 'Hello' })}`
+    );
+    expect(frames[1]).toBe(
+      `id: 2\ndata: ${JSON.stringify({ type: 'text-delta', delta: ' world' })}`
+    );
+    expect(frames[2]).toBe(
+      `id: 3\ndata: ${JSON.stringify({ type: 'finish', reason: 'end_turn' })}`
+    );
+
+    // getEvents called with currentSeq=0 (no Last-Event-ID). The store
+    // filters seq > 0 → events 1,2,3. The initial replay is the only
+    // call for a terminal run (no polling loop).
+    expect(mockGetEvents).toHaveBeenCalledWith(RUN_ID, 0);
+  });
+
+  it('honours Last-Event-ID by starting replay after that seq', async () => {
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'completed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([
+      { seq: 5, payload: { type: 'text-delta', delta: 'resume' } },
+      { seq: 6, payload: { type: 'finish' } },
+    ]);
+
+    const res = await GET(req({ headers: { 'Last-Event-ID': '4' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(200);
+
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(2);
+    expect(frames[0].startsWith('id: 5\n')).toBe(true);
+    expect(frames[1].startsWith('id: 6\n')).toBe(true);
+
+    expect(mockGetEvents).toHaveBeenCalledWith(RUN_ID, 4);
+  });
+
+  it('terminal run with zero unseen events closes without frames', async () => {
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'completed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([]);
+
+    const res = await GET(req({ headers: { 'Last-Event-ID': '99' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(200);
+
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(0);
+  });
+
+  it('failed run replays fully and closes (no polling loop)', async () => {
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'failed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([
+      { seq: 1, payload: { type: 'error', errorText: 'boom' } },
+      {
+        seq: 2,
+        payload: { type: 'data-openrush-run-done', data: { status: 'failed', error: 'boom' } },
+      },
+    ]);
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(2);
+    expect(frames[1]).toContain('data-openrush-run-done');
+
+    // Only the initial drain; no live-stream polling for terminal runs.
+    expect(mockGetEvents).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /events — active run (polling)', () => {
+  it('replays initial events then delivers live ones via polling', async () => {
+    vi.useFakeTimers();
+
+    mockGetById.mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+
+    // Poll sequence:
+    // 1. Initial drain (afterSeq=0) → returns seq 1
+    // 2. Next tick → seq 2 appears
+    // 3. Next tick → seq 3 appears + run transitions to completed
+    mockGetEvents
+      .mockResolvedValueOnce([{ seq: 1, payload: { type: 'text-delta', delta: 'a' } }]) // initial
+      .mockResolvedValueOnce([{ seq: 2, payload: { type: 'text-delta', delta: 'b' } }]) // tick 1
+      .mockResolvedValueOnce([{ seq: 3, payload: { type: 'finish' } }]) // tick 2 (pre-terminal)
+      .mockResolvedValueOnce([]); // tick 2 (second drain after terminal detect)
+
+    // status checks during polling
+    mockGetById
+      .mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' }) // tick 1
+      .mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'completed' }); // tick 2
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+
+    // Kick off reader before advancing timers so the poll loop has a
+    // consumer to enqueue into.
+    const framesPromise = readAllFrames(res);
+
+    // Let initial replay microtasks resolve.
+    await vi.advanceTimersByTimeAsync(0);
+    // Fire the first interval tick.
+    await vi.advanceTimersByTimeAsync(500);
+    // Fire the second interval tick (should detect terminal + close).
+    await vi.advanceTimersByTimeAsync(500);
+
+    const frames = await framesPromise;
+    expect(frames.map((f) => f.split('\n')[0])).toEqual(['id: 1', 'id: 2', 'id: 3']);
+  });
+
+  it('tolerates empty poll responses between live events', async () => {
+    vi.useFakeTimers();
+
+    mockGetById.mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+
+    mockGetEvents
+      .mockResolvedValueOnce([]) // initial — no events yet
+      .mockResolvedValueOnce([]) // tick 1
+      .mockResolvedValueOnce([{ seq: 1, payload: { type: 'start' } }]) // tick 2 pre-check
+      .mockResolvedValueOnce([]); // tick 2 post-check drain
+
+    mockGetById
+      .mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' }) // tick 1
+      .mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'completed' }); // tick 2
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    const framesPromise = readAllFrames(res);
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(500); // tick 1 (no new events)
+    await vi.advanceTimersByTimeAsync(500); // tick 2 (seq 1 + terminal)
+
+    const frames = await framesPromise;
+    expect(frames).toHaveLength(1);
+    expect(frames[0].startsWith('id: 1\n')).toBe(true);
+  });
+
+  it('closes the stream when client aborts (AbortSignal)', async () => {
+    vi.useFakeTimers();
+
+    mockGetById.mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValue([]);
+
+    const controller = new AbortController();
+    const res = await GET(req({ signal: controller.signal }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(200);
+
+    const readAll = readFramesUntil(res, () => false);
+
+    // Let start() run through to installing handlers.
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort();
+
+    // Reader should terminate once the stream closes.
+    const frames = await readAll;
+    expect(frames).toHaveLength(0);
+  });
+
+  it('does NOT start polling if client aborts before `start()` runs', async () => {
+    // Regression test for sparring round-3 race: the abort listener
+    // must be registered before any DB work so aborting in the window
+    // between `GET()` returning and `start()` executing still cleans
+    // up. With the fix, `closed` is pre-set and `start()` bails out
+    // before installing the poll interval.
+    vi.useFakeTimers();
+
+    mockGetById.mockResolvedValueOnce({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValue([]);
+
+    const controller = new AbortController();
+    // Abort BEFORE GET is awaited — the signal is already aborted
+    // when the route handler observes it, exercising the
+    // `request.signal.aborted` short-circuit branch.
+    controller.abort();
+
+    const res = await GET(req({ signal: controller.signal }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    expect(res.status).toBe(200);
+
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(0);
+
+    // Advance past several poll intervals — if the bug regressed,
+    // `tick()` would call getEvents repeatedly.
+    const getEventsCallsBefore = mockGetEvents.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockGetEvents.mock.calls.length).toBe(getEventsCallsBefore);
+  });
+
+  it('stops polling when reader cancels the stream', async () => {
+    // Regression test: `cancel()` on the ReadableStream (invoked e.g.
+    // when a caller calls `body.cancel()`) must run `cleanup()` so the
+    // setInterval is cleared. Without the fix the timer keeps running
+    // indefinitely against an orphaned controller.
+    vi.useFakeTimers();
+
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValue([]);
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    expect(res.status).toBe(200);
+
+    // Let start() install the poll interval.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Cancel the reader (simulates `body.cancel()` or the consumer
+    // going away without touching the request signal).
+    await res.body?.cancel();
+
+    const callsAfterCancel = mockGetEvents.mock.calls.length;
+    // Fire several tick intervals — cancelled stream should not
+    // trigger more DB reads.
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockGetEvents.mock.calls.length).toBe(callsAfterCancel);
+  });
+
+  it('closes the stream without a body frame when initial replay throws', async () => {
+    // Error path: we DO NOT emit a synthetic `data:` frame because
+    // every SSE frame must carry `id: <seq>` per spec §事件协议, and
+    // the DB failure means we have no seq to attach. Instead we close
+    // the stream; the client's reconnect path resumes from its last
+    // known `Last-Event-ID`.
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'running' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockRejectedValueOnce(new Error('db down'));
+
+    const res = await GET(req(), { params: params(TASK_ID, RUN_ID) });
+    const frames = await readAllFrames(res);
+    expect(frames).toHaveLength(0);
+  });
+});
+
+describe('GET /events — Last-Event-ID monotonicity', () => {
+  it('does not re-emit events already delivered (reconnect with last id)', async () => {
+    // Client previously received up to seq=2. On reconnect with
+    // Last-Event-ID: 2 the server must replay seq > 2 only.
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'completed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([
+      { seq: 3, payload: { type: 'text-delta', delta: 'c' } },
+      { seq: 4, payload: { type: 'finish' } },
+    ]);
+
+    const res = await GET(req({ headers: { 'Last-Event-ID': '2' } }), {
+      params: params(TASK_ID, RUN_ID),
+    });
+    const frames = await readAllFrames(res);
+    expect(frames.map((f) => f.split('\n')[0])).toEqual(['id: 3', 'id: 4']);
+    expect(mockGetEvents).toHaveBeenCalledWith(RUN_ID, 2);
+  });
+});
+
+describe('GET /events — query cursor is NOT a reconnection vector', () => {
+  it('ignores ?cursor / ?after / ?seq query params (header-only protocol)', async () => {
+    // Spec §断线重连 pins the protocol to Last-Event-ID header ONLY.
+    // This regression test locks that behaviour: query params masquerading
+    // as cursors must NOT affect replay position. Without this guard,
+    // future changes could silently introduce a dual-source protocol.
+    mockGetById.mockResolvedValue({ ...SAMPLE_RUN, status: 'completed' });
+    dbFake.__select.mockReturnValueOnce([{ projectId: PROJECT_ID }]);
+    mockGetEvents.mockResolvedValueOnce([
+      { seq: 1, payload: { type: 'text-delta', delta: 'a' } },
+      { seq: 2, payload: { type: 'finish' } },
+    ]);
+
+    const url = `https://t/api/v1/agents/${TASK_ID}/runs/${RUN_ID}/events?cursor=99&after=50&seq=42`;
+    const res = await GET(new Request(url), { params: params(TASK_ID, RUN_ID) });
+    const frames = await readAllFrames(res);
+
+    // Replay starts at seq=0 (no Last-Event-ID header), NOT at 99/50/42.
+    expect(frames.map((f) => f.split('\n')[0])).toEqual(['id: 1', 'id: 2']);
+    expect(mockGetEvents).toHaveBeenCalledWith(RUN_ID, 0);
+  });
+});

--- a/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts
+++ b/apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts
@@ -1,0 +1,313 @@
+/**
+ * /api/v1/agents/:agentId/runs/:runId/events
+ *   - GET — Server-Sent Events stream of run events.
+ *
+ * Protocol (spec §事件协议 + §断线重连, locked in task-4 contracts):
+ *   - Content-Type: text/event-stream
+ *   - Cache-Control: no-cache, no-transform
+ *   - Connection: keep-alive (Next.js adds this on Response bodies that
+ *     are ReadableStreams, but we set it explicitly for upstream proxies)
+ *   - X-Accel-Buffering: no (disable nginx buffering)
+ *
+ * Each frame:
+ *   id: <seq>\n
+ *   data: <json-payload>\n
+ *   \n
+ *
+ * **Every frame carries `id: <seq>`** — the monotonic per-run
+ * `run_events.seq` assigned by the single writer (control-worker via
+ * `DrizzleEventStore.appendAssignSeq`). When the browser's EventSource
+ * disconnects it automatically resends the last received `id` as a
+ * `Last-Event-ID` header — we honour that to replay from
+ * `seq > Last-Event-ID`. We never emit a bare `data:` frame (no
+ * synthetic error / heartbeat events that would break the "always has
+ * id" invariant). On fatal errors we simply close the stream — the
+ * client's reconnect path resumes from its last seen id.
+ *
+ * We deliberately do NOT support a query-string cursor: the spec pins
+ * the protocol to a single reconnection path (header-only) to avoid
+ * two sources of truth.
+ *
+ * Liveness: for runs still in-flight we poll `run_events` at a fixed
+ * interval for new rows. Rationale over subscribing to Redis pub/sub
+ * via StreamRegistry: the `run_events` table is already the
+ * authoritative single-writer destination (control-worker writes, all
+ * readers read), and the existing legacy `/api/runs/[id]/stream` route
+ * uses the same polling strategy. This keeps the v1 endpoint
+ * transport-free (no Redis dependency for SSE②) and matches the
+ * terminal-detection semantics used elsewhere. The polling loop stays
+ * open until the run transitions to a terminal status; we drain once
+ * more post-terminal to catch events written in the same tick as the
+ * status flip, then close the stream.
+ *
+ * Auth + ownership (mirrors task-13):
+ *   - session OR service-token with scope `runs:read`
+ *   - Run must exist AND `run.taskId === URL agentId` (cross-agent
+ *     probing returns 404 without revealing the real owner)
+ *   - Owning project must be accessible via `verifyProjectAccess`
+ *
+ * Runtime: Next.js defaults to Edge for some stream routes, but we need
+ * Node.js for the `pg`-backed Drizzle client — declared via
+ * `export const runtime = 'nodejs'`.
+ */
+
+import { v1 } from '@open-rush/contracts';
+import { DrizzleEventStore, DrizzleRunDb, isTerminal, RunService } from '@open-rush/control-plane';
+import { getDbClient, tasks } from '@open-rush/db';
+import { eq } from 'drizzle-orm';
+import { v1Error, v1ValidationError } from '@/lib/api/v1-responses';
+import { verifyProjectAccess } from '@/lib/api-utils';
+import { authenticate, hasScope } from '@/lib/auth/unified-auth';
+
+// Force Node.js runtime: pg + DrizzleEventStore are not Edge-safe.
+export const runtime = 'nodejs';
+
+/** Poll interval for live run_events delivery. */
+const POLL_INTERVAL_MS = 500;
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/agents/:agentId/runs/:runId/events
+// -----------------------------------------------------------------------------
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ agentId: string; runId: string }> }
+) {
+  const auth = await authenticate(request);
+  if (!auth) return v1Error('UNAUTHORIZED', 'Authentication required');
+  if (!hasScope(auth, 'runs:read')) {
+    return v1Error('FORBIDDEN', 'Missing scope runs:read');
+  }
+
+  const awaitedParams = await params;
+  const paramsParsed = v1.getRunParamsSchema.safeParse({
+    id: awaitedParams.agentId,
+    runId: awaitedParams.runId,
+  });
+  if (!paramsParsed.success) return v1ValidationError(paramsParsed.error);
+
+  // Last-Event-ID — header-only per spec §断线重连. Malformed values
+  // (non-numeric, negative, empty/whitespace) → 400 rather than
+  // silently clobbering to 0. This keeps clients from accidentally
+  // re-replaying a whole stream when a buggy proxy strips digits from
+  // the header. A missing header means "start from the beginning"
+  // (`afterSeq = 0` → `seq > 0`, which includes seq=1 onwards since
+  // `appendAssignSeq` numbers from 1).
+  //
+  // Note: `lastEventIdHeaderSchema` uses `z.coerce.number()` which
+  // happily turns '' / '   ' into 0. We reject those at the route
+  // layer so an empty header can't masquerade as "replay all" — the
+  // client should either omit the header or send a concrete integer.
+  const rawLastEventId =
+    request.headers.get('last-event-id') ?? request.headers.get('Last-Event-ID');
+  let afterSeq = 0;
+  if (rawLastEventId !== null) {
+    if (rawLastEventId.trim() === '') {
+      return v1Error('VALIDATION_ERROR', 'Last-Event-ID must not be empty', {
+        hint: 'omit the header to start from the beginning, or send a non-negative integer',
+      });
+    }
+    const parsed = v1.lastEventIdHeaderSchema.safeParse(rawLastEventId);
+    if (!parsed.success) return v1ValidationError(parsed.error);
+    afterSeq = parsed.data;
+  }
+
+  const db = getDbClient();
+  const runService = new RunService(new DrizzleRunDb(db));
+  const run = await runService.getById(paramsParsed.data.runId);
+  if (!run) return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+
+  // Cross-agent probing guard: a valid runId under a foreign agentId
+  // returns 404 without leaking the true owner (mirrors task-13).
+  if (run.taskId !== paramsParsed.data.id) {
+    return v1Error('NOT_FOUND', `Run ${paramsParsed.data.runId} not found`);
+  }
+
+  const [task] = await db
+    .select({ projectId: tasks.projectId })
+    .from(tasks)
+    .where(eq(tasks.id, paramsParsed.data.id))
+    .limit(1);
+  if (!task) return v1Error('NOT_FOUND', `Agent ${paramsParsed.data.id} not found`);
+  if (!(await verifyProjectAccess(task.projectId, auth.userId))) {
+    return v1Error('FORBIDDEN', 'No access to this project');
+  }
+
+  const eventStore = new DrizzleEventStore(db);
+  const runId = paramsParsed.data.runId;
+  const initialIsTerminal = isTerminal(run.status);
+
+  // Shared lifecycle state. Declared in enclosing scope so both the
+  // stream's `start` and `cancel` hooks (and the request.signal abort
+  // listener wired below) can converge on the same `cleanup()`.
+  let closed = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
+    }
+    try {
+      streamController?.close();
+    } catch {
+      // already closed
+    }
+  };
+
+  // Register the abort listener BEFORE we spin up any DB calls so a
+  // client that disconnects during `drain()` still triggers cleanup.
+  // `{ once: true }` means this listener fires at most once even if
+  // the signal re-dispatches. If the signal has already aborted (e.g.
+  // the caller cancelled before the handler ran), we short-circuit
+  // via `closed = true` so `start()` skips all work.
+  if (request.signal.aborted) {
+    closed = true;
+  } else {
+    request.signal.addEventListener(
+      'abort',
+      () => {
+        cleanup();
+      },
+      { once: true }
+    );
+  }
+
+  // Web ReadableStream (required by Next.js Response). We emit strings;
+  // Next.js wraps with the correct body encoding.
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      streamController = controller;
+      // If the client aborted before we even got here, close
+      // immediately without touching the DB.
+      if (closed) {
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+        return;
+      }
+
+      const encoder = new TextEncoder();
+      let currentSeq = afterSeq;
+
+      const emit = (text: string) => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(text));
+        } catch {
+          // stream already closed (e.g. client aborted between the
+          // `closed` check and enqueue). Swallow — cleanup handles it.
+        }
+      };
+
+      /**
+       * Load events strictly after `currentSeq` and emit each as an
+       * SSE frame. Updates `currentSeq` to the last emitted `seq` so
+       * the next drain continues monotonically.
+       *
+       * `DrizzleEventStore.getEvents(runId, afterSeq)` filters
+       * `seq > afterSeq` and orders by seq ASC. Using it here keeps
+       * the route decoupled from raw schema details.
+       */
+      const drain = async (): Promise<void> => {
+        const events = await eventStore.getEvents(runId, currentSeq);
+        for (const ev of events) {
+          // Preserve spec frame shape: `id: <seq>\ndata: <json>\n\n`.
+          // Every frame MUST have an `id` — spec §事件协议 + §断线重连.
+          // Payload is emitted verbatim (control-worker already stored
+          // the canonical UIMessageChunk JSON via appendAssignSeq).
+          const payload = JSON.stringify(ev.payload);
+          emit(`id: ${ev.seq}\ndata: ${payload}\n\n`);
+          currentSeq = ev.seq;
+        }
+      };
+
+      // Initial replay (always runs, even for terminal runs — the spec
+      // requires "结束 run 全量 replay 后关闭").
+      //
+      // On failure we close without a body frame: emitting a synthetic
+      // `data:` event would violate the "every frame has id" invariant
+      // (we have no seq to attach). The client sees EOF and can
+      // reconnect with its last-known `Last-Event-ID`; if the underlying
+      // failure persists the reconnect will also EOF, which is the
+      // correct failure mode for a transport that's cursor-based.
+      try {
+        await drain();
+      } catch {
+        cleanup();
+        return;
+      }
+
+      if (initialIsTerminal) {
+        // Terminal run — replay once, then close. No polling loop.
+        // Matches spec §断线重连:
+        // "对已结束 run(status=success/failed/cancelled),全量 replay
+        //  后关连接".
+        cleanup();
+        return;
+      }
+
+      // Live stream: poll run_events on interval. Stay open until the
+      // run transitions to terminal (then drain once more + close).
+      // No fixed lifetime cap — the connection lives exactly as long as
+      // the run does. The run's state machine + the caller's own
+      // abort signal are the two termination sources.
+      let polling = false;
+      const tick = async () => {
+        if (closed || polling) return;
+        polling = true;
+        try {
+          await drain();
+          const latest = await runService.getById(runId);
+          if (latest && isTerminal(latest.status)) {
+            // Drain once more to catch any events written in the
+            // window between `drain()` above and the status
+            // transition. Safe because drain skips events with
+            // `seq <= currentSeq`.
+            await drain();
+            cleanup();
+          }
+        } catch {
+          // Transient polling errors: close without a synthetic frame
+          // (see initial-replay comment above). The client will
+          // reconnect on EOF.
+          cleanup();
+        } finally {
+          polling = false;
+        }
+      };
+
+      // Guard: the abort signal may have fired during `await drain()`.
+      // If so, `cleanup()` already closed the stream — skip installing
+      // the polling interval.
+      if (closed) return;
+
+      pollTimer = setInterval(() => {
+        void tick();
+      }, POLL_INTERVAL_MS);
+    },
+
+    cancel() {
+      // Reader cancelled (e.g. route caller discarded the stream).
+      // Invoke `cleanup()` so any in-flight polling interval is
+      // cleared — otherwise we'd keep hitting the DB for an orphaned
+      // consumer.
+      cleanup();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      // Disable nginx buffering so frames reach the client immediately.
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -164,7 +164,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - 已完成/已取消 Agent 禁止新 run → 409
       - verify: `./docs/execution/verify.sh task-13`
 
-- [ ] `task-14-api-v1-events-sse` — **Agent-B**
+- [x] `task-14-api-v1-events-sse` — **Agent-B**
       域: `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/*`
       依赖: task-10, task-13
       验收:

--- a/docs/execution/progress/agent-b-relay2-task18-notes.md
+++ b/docs/execution/progress/agent-b-relay2-task18-notes.md
@@ -1,0 +1,181 @@
+# task-18 E2E 专项 handoff — SSE `/events` 协议 & 测试地形
+
+来自 agent-b-relay2(task-14 交付者)。task-18 要写
+`apps/web/e2e/v1-api.spec.ts` 覆盖 `specs/managed-agents-api.md §E2E 测试`
+的 6 场景,其中 **场景 3 "Agent + Run + Event 闭环"** 需要测
+"断线 → 带 Last-Event-ID 重连 → 无重复无丢"。本文档是给 task-18
+agent 的 SSE 专项提示,避免重踩 task-14 Sparring 4 轮的坑。
+
+## 1. SSE 协议铁律(task-14 锁定)
+
+这些是 `/api/v1/agents/:agentId/runs/:runId/events` 的协议不变式,E2E
+断言必须贴着它们写。实现在 `apps/web/app/api/v1/agents/[agentId]/runs/
+[runId]/events/route.ts`。
+
+### 1.1 每条 frame 必带 `id: <seq>`
+格式:`id: <seq>\ndata: <json>\n\n`。EventSource 自动把最新 `id` 记住,
+断线重连时浏览器会把它塞进 `Last-Event-ID` header。**没有 `id` 的
+frame 会导致客户端丢失游标**。实现里**不存在 bare `data:` frame**
+(包括错误路径);错误就 close 连接,靠客户端重连。
+
+### 1.2 Last-Event-ID 仅支持 header,query 参数被忽略
+- `Last-Event-ID: N`(integer ≥ 0)→ 服务端 replay `seq > N`
+- `?cursor=X` / `?after=X` / `?seq=X` **完全无效**(spec §断线重连 明确
+  "单一协议,不引 query cursor")。task-14 有一条回归测试锁死这点
+
+### 1.3 Last-Event-ID 边界值
+- missing → `afterSeq = 0` → replay 全部(`seq > 0`;
+  `appendAssignSeq` 从 1 起始,所以 seq=1 也会命中)
+- 非数字 / 负数 / **空串 / 全空白** → 400 VALIDATION_ERROR
+  - 注意:`z.coerce.number()` 会把 `''` / `'   '` 默默 coerce 成 0,
+    route 层特判拒绝。不要以为 empty header 等同于 missing
+
+### 1.4 Terminal run → 全量 replay 后关连接
+- `isTerminal(run.status)` 命中(completed / failed)→ 单次 drain,
+  然后 `controller.close()`。不装 poll interval,不挂 live subscriber
+- 客户端重连同样路径,再 replay 一次,依然关连接(幂等)
+
+### 1.5 活跃 run → 500ms 轮询 run_events,终结后再 drain 一次
+- `setInterval(tick, 500)`,tick 里先 `drain()`、再
+  `runService.getById` 检查终态
+- **关键 race 保护**:检测到终态后再 `drain()` 一次,捕获"tick
+  开始到 status transition 之间写入的事件"(典型:控制面写完
+  `data-openrush-run-done` 后立刻把状态改 completed)
+- 然后才 `cleanup()` 关连接
+- **无 fixed lifetime cap**。连接寿命 = run 的寿命 + 客户端连接寿命。
+  Sparring 轮 1 曾 catch 5 分钟 cap 违反"live 到 terminal 才关"验收
+
+### 1.6 Abort / cancel 的单一 cleanup 口
+- `cleanup()` = 清 interval + `controller.close()`,幂等
+- 三个触发源共享一个 `cleanup()`:
+  1. `request.signal.abort` listener(在 `new ReadableStream` 外注册,
+     `{ once: true }`;handler 开头先 check `signal.aborted` 预置
+     `closed = true`)
+  2. ReadableStream 的 `cancel()` hook(reader 被消费方取消时)
+  3. `tick()` 里检测到终态 / 异常
+
+## 2. SSE 测试地形(vitest unit vs playwright E2E)
+
+task-14 的单测在 `events/route.test.ts`,23 条覆盖了上面全部分支。
+E2E 不能复用这些 mock,但测试思路和断言可以搬。
+
+### 2.1 读 SSE body 的三步
+```typescript
+const res = await fetch('/api/v1/agents/A/runs/R/events', {
+  headers: { 'Last-Event-ID': '2' },
+});
+const reader = res.body!.getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+const frames: string[] = [];
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+  let idx = buffer.indexOf('\n\n');
+  while (idx !== -1) {
+    frames.push(buffer.slice(0, idx));
+    buffer = buffer.slice(idx + 2);
+    idx = buffer.indexOf('\n\n');
+  }
+}
+// 每条 frame 断言:
+//   frame.startsWith('id: <n>\n')  ← 解 id
+//   frame.split('\n')[1].startsWith('data: ')  ← 解 payload
+```
+
+### 2.2 测"断线重连无重复无丢"(场景 3.3-3.5)
+1. 发 POST `/agents` 创建 agent + 第一个 run(拿到 runId)
+2. 开 SSE 连接不带 `Last-Event-ID`,读若干 frame,记录最新 `id: N`
+3. **主动 abort**(e.g. `reader.cancel()` 或 `fetch(…, { signal })`)
+4. 再开 SSE 连接,带 `Last-Event-ID: N`
+5. 断言:第二次连接**只收到 seq > N** 的 frames(用 id 提取列)
+6. 断言:没有 seq ≤ N 的重复 frame
+7. 断言:最终 `data-openrush-run-done` 出现,然后连接 close
+   (`reader.read()` 返回 `{ done: true }`)
+
+**坑**:活跃 run 期间 abort + 立刻重连,轮询节拍可能让你收到 0 条
+frame(run 还没写新事件)。不要 assert 必须有 frame;要 assert
+"收到的 frame 的 seq 都 > N"。
+
+### 2.3 测 terminal run 重连幂等
+run 已完成,发 SSE 带 `Last-Event-ID: <last seq of run>`。期望:
+0 frames,连接立即 close。用这个断言验证"没有因为 seq > N 为空
+而挂住"。
+
+### 2.4 Abort signal 断言(不依赖真实客户端)
+`AbortController` + `fetch({ signal })`:
+```typescript
+const ctrl = new AbortController();
+const fetchPromise = fetch(url, { signal: ctrl.signal });
+// 等 response 进来
+const res = await fetchPromise;
+// 开始读
+const reader = res.body!.getReader();
+// ... 读若干 chunk
+ctrl.abort();
+// await reader.read() 会 reject(AbortError)或返回 done
+```
+E2E 不需要断言服务端 cleanup 细节(单测已覆盖),断言"再次重连没
+错乱"即可。
+
+## 3. 参考文件清单
+
+- **实现**
+  - `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts`
+    — 协议全貌,注释密度高,读完再写 E2E
+  - `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.test.ts`
+    — 23 条单测,断言模板可以搬进 E2E
+- **协议 & 合约**
+  - `specs/managed-agents-api.md §事件协议 §断线重连 §E2E 测试`
+  - `packages/contracts/src/v1/runs.ts` — `runEventPayloadSchema`
+    (UIMessageChunk ∪ openrush extensions),`lastEventIdHeaderSchema`
+- **单写者**
+  - `packages/control-plane/src/event-store.ts` — `appendAssignSeq` /
+    `getEvents(runId, afterSeq)` 契约(seq > afterSeq,ASC)
+  - `packages/control-plane/src/run/run-state-machine.ts` —
+    `isTerminal` = completed | failed(注意 E2E 里 user-cancelled run
+    的 DB 状态是 `failed + errorMessage='cancelled by user'`,wire 层
+    看起来是 cancelled,但 isTerminal 仍命中 → SSE 关连接的逻辑不受影响)
+
+## 4. E2E 场景 3 建议分解
+
+对应 `specs/managed-agents-api.md §E2E 测试` 场景 3:
+
+1. **3.1** POST `/agents` → 自动创建 Agent + 第一个 Run + 返回 runId
+2. **3.2** GET `/events`(不带 Last-Event-ID)→ 收到 `text-delta` / `tool-*` /
+   `data-openrush-run-done`,断言至少包含这三类 type;断言每条 frame 都有
+   `id: <n>`,seq 单调递增从 1 开始
+3. **3.3** POST `/runs`(追加消息)→ 新 run 创建,runId2 != runId1
+4. **3.4** 打开 SSE 连 runId2,读若干 frame(`id: N`),abort,再开 SSE
+   带 `Last-Event-ID: N`,断言只收到 seq > N
+5. **3.5** POST `/cancel` runId2 → 响应 status=cancelled;之后 GET `/events`
+   应 replay + 关连接,最后一条事件带 `data-openrush-run-done
+   status=cancelled`
+
+## 5. 非 SSE E2E 场景(6 场景里的其他 5 个)
+
+不是本文重点,但 task-18 agent 应该知道:
+
+- **场景 1** Service Token 鉴权 — 4 个 case(无 / 错 / 对+够 / 对+不够)
+- **场景 2** AgentDefinition CRUD + 版本化 — 6 个 case(create v1 /
+  PATCH v2 / If-Match 冲突 / GET ?version=1 / GET /versions / POST
+  /archive)
+- **场景 4** 幂等性 — 3 个 case(POST 带 Idempotency-Key / 相同 key+body
+  replay / 相同 key 不同 body 409)
+- **场景 5** 未列出(看 spec)
+- **场景 6** 未列出(看 spec)
+
+`verify.sh task-18` 跑 `apps/web/e2e/v1-api.spec.ts`,需要 postgres +
+redis 容器就绪(见 `AGENTS.md` 的 E2E 前置)。
+
+## 6. 给 task-18 agent 的警告
+
+- **不要引入 query cursor**。哪怕"顺手支持一下"都是违反 spec 的,
+  task-14 Sparring 轮 2 因此让我加了回归测试,**不要破坏那条回归**
+- **不要用 bare `data:` frame**(没有 id)。这个坑 task-14 Sparring 轮 1
+  catch 过,实现和单测都锁死了
+- **不要加 fixed timeout**。Sparring 轮 1 删掉了 5 分钟 cap,E2E 里
+  也别依赖"N 秒后连接一定 close"这种假设。连接活多久只看 run 活多久
+- **reader 循环务必按 `\n\n` 切分**。直接 `JSON.parse(chunk)` 会踩多条
+  frame 合并 / 单条 frame 拆两次 read 的坑

--- a/docs/execution/progress/agent-b-relay2.md
+++ b/docs/execution/progress/agent-b-relay2.md
@@ -1,0 +1,120 @@
+# Agent-B-relay2 进度
+
+接替 agent-b-relay 完成 M3 尾声的最后一项 — task-14(SSE `/events`)。
+
+## 总览
+
+文件域:
+- `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/` (新增 route + test)
+
+Worktree: `/tmp/agent-wt/b2`(branch `feat/task-14`,基于 main `c109b43`)。
+
+## task-14 ✅(Sparring 待跑)
+
+### 交付
+- `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts` — SSE endpoint
+- `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.test.ts` — 18 单测
+
+### 关键设计决策
+
+1. **Liveness = 轮询 `run_events` 而不是订阅 StreamRegistry**。理由:
+   - `run_events` 已经是单写者权威来源(control-worker 通过
+     `DrizzleEventStore.appendAssignSeq` 写入),API 读端没必要再引一层 Redis
+     pub/sub 作 live channel。
+   - 现有 legacy `/api/runs/[id]/stream` 也用同款轮询策略,保持一致。
+   - 保留 `X-Accel-Buffering: no` + `Cache-Control: no-cache, no-transform`
+     保证 nginx 等代理不缓冲。
+   - StreamRegistry 留给后续如需要严格的"秒级 live"时再加一层扇出
+     (目前 500ms poll 对 P0 足够,且更简单可测)。
+
+2. **Liveness 收尾**:poll tick 检测到 `run.status` 终结时,再 drain 一次捕获
+   "终结前最后写入但本次 tick 未拉到"的事件,然后 close。这避免 race:
+   control-worker 写完 `data-openrush-run-done` 后立刻 transition 到 completed,
+   如果只按 status 判断直接 close 会漏掉那条事件。
+
+3. **Last-Event-ID 容错**:缺省视为 0(= 从头开始);非数字/负数返回 400
+   VALIDATION_ERROR(而非 silent clamp),避免客户端因 proxy bug 吃掉部分 header
+   导致悄悄重放整个流。
+
+3a. **错误路径不发合成 frame**(Sparring 第一轮 MUST-FIX):
+   - 每条 SSE frame 必须有 `id: <seq>`(spec §事件协议 + §断线重连)
+   - 初始 replay / poll tick 抛错时,我们没有 seq 可以附加 → 直接 close stream
+   - 客户端看到 EOF,自动用 `Last-Event-ID` 重连;如果底层错误持续,重连也会
+     EOF,这是游标型传输的正确失败模式
+
+3b. **不设 lifetime cap**(Sparring 第一轮 MUST-FIX):
+   - 曾经加了 `SSE_MAX_LIFETIME_MS = 5 * 60 * 1000`,会在 run 还没 terminal 时
+     主动断开,违反"Live run 持续 poll `run_events` 直到 terminal 再关"的验收
+   - 移除该 timer — 活跃 run 的连接寿命 = run 本身的寿命,由状态机或 client abort
+     决定关闭时机
+
+4. **协议单一**:不支持 query cursor,仅 `Last-Event-ID` header(符合 spec
+   §断线重连)。`afterSeq = 0` 意味着 "seq > 0",即 `appendAssignSeq` 从 1 起始的
+   所有事件都能命中。
+
+5. **Cross-agent probing 404**:与 task-13 一致,`run.taskId !== URL agentId` 返回
+   404,不泄露真实归属。
+
+6. **initial replay 失败 → 直接 close(不发 body frame)**。见 3a:每条 frame 必须
+   有 `id: <seq>`,错误分支没有 seq 可附,所以直接 EOF,客户端靠最近的
+   `Last-Event-ID` 重连。
+
+6a. **Abort 竞态修复**(Sparring 第三轮 MUST-FIX):
+   - `abort` listener 在 route handler 里、`new ReadableStream` 之前就注册
+     (靠闭包共享 `closed` + `pollTimer` + `streamController`),避免
+     "drain 期间 abort 触发但 listener 未装"导致的"幽灵轮询"
+   - 注册前先查 `request.signal.aborted`,预置 `closed = true`,start 里检测到
+     就立即 close 不执行任何 DB 调用
+   - `{ once: true }` 防止 listener 重复触发
+   - `cancel()` 也调用 `cleanup()`,防止 reader 被消费方 cancel 时 setInterval
+     成为孤儿继续打 DB
+
+7. **nodejs runtime**:`export const runtime = 'nodejs'` 强制。Edge runtime
+   不支持 `pg` + DrizzleEventStore。
+
+### 测试策略
+
+- Mock `DrizzleEventStore`、`RunService`、`isTerminal`,不依赖 Redis/Postgres
+- 用 `ReadableStream<Uint8Array>` 的 reader 逐字节读 SSE 帧,按 `\n\n` 切分
+- Fake timers 模拟 polling 节拍(`vi.useFakeTimers()` +
+  `vi.advanceTimersByTimeAsync`)
+- AbortController 模拟客户端断连
+
+### 覆盖场景
+
+- 401 未鉴权 / 403 缺 scope `runs:read` / 403 无 project 访问
+- 400 agentId / runId 非 UUID
+- 400 Last-Event-ID 非数字 / 负数
+- 404 run 不存在 / 404 cross-agent probing
+- 终结 run:replay 后直接 close(completed + failed)
+- Last-Event-ID 从指定 seq 起 replay(不重复不丢失)
+- Last-Event-ID 超大值 → 空 frame + close
+- 活跃 run:initial replay + 两次 poll tick 后终结
+- 活跃 run:空 tick 间隔正常透出后续事件
+- 客户端 abort:stream 关闭 reader 收到 `done`
+- Initial replay 抛错 → stream 直接 close(0 frames,见 3a 决策)
+- Query cursor(`?cursor=/?after=/?seq=`)被忽略(header-only 协议回归测试)
+- Last-Event-ID 空串 / 全空白 → 400(防止 `z.coerce.number()` 默认 0 的 silent replay)
+- abort 在 GET 返回后 start 前触发 → 不进入 polling(6a 竞态回归)
+- reader 主动 cancel → poll interval 立即停(cancel() 调用 cleanup 回归)
+
+### 不要踩的坑
+
+- 测试里 `vi.useFakeTimers()` 必须在 test 内调用,且 `afterEach`
+  `vi.useRealTimers()` 复位,否则污染后续 suite。
+- `await vi.advanceTimersByTimeAsync(0)` 让初始 replay 的微任务有机会 settle。
+
+### 关于前任 waiver(过期信息)
+
+前任 agent-b-relay 的 handoff 最后有一条:"task-9 vault 测试在 origin/main 也失败"。
+那条已过时:coordinator 验证 main 上 `pnpm build` + `pnpm test` 全绿(290/290)。
+实际原因是前任未执行 `pnpm build` 就 `pnpm test`,导致 dist 过时。本次开工时
+coordinator 在 handoff 里明确要求先 `pnpm install && pnpm build`,照做后一切正常。
+
+## 通用门禁结果
+
+- `pnpm build` ✅(workspace packages 全 build,web next build 成功)
+- `pnpm check` ✅
+- `pnpm lint` ✅
+- `pnpm test` ✅(392 passed,含 18 新)
+- `./docs/execution/verify.sh task-14` ✅


### PR DESCRIPTION
## Summary
- Implements `GET /api/v1/agents/:agentId/runs/:runId/events` — Server-Sent Events streaming per-run events with header-only `Last-Event-ID` resume.
- Replays `run_events` where `seq > Last-Event-ID`, then tails the table via 500ms polling until the run reaches a terminal status (polling is transport-free — no Redis dependency for SSE②).
- Every frame carries `id: <seq>` so browser EventSource can auto-reconnect; no query-cursor fallback (spec pins protocol to single source).
- Auth/ownership mirrors task-13: `runs:read` scope + cross-agent probing → 404 + project access → 403.
- Abort lifecycle: `request.signal.aborted`, stream `cancel()`, and the abort listener all converge on a single `cleanup()` — prevents ghost polling if the client disconnects during the initial drain.

## Design notes
- **Liveness via polling** (not StreamRegistry pub/sub): `run_events` is already the single-writer source; subscribing Redis here adds a redundant channel. Matches the legacy `/api/runs/[id]/stream` strategy.
- **No lifetime cap**: the SSE connection lives exactly as long as the run does. The state machine (terminal transition) or caller abort are the only close triggers.
- **Last-Event-ID hardening**: empty / whitespace-only rejected at the route layer because `z.coerce.number()` would otherwise silently coerce to 0.
- **`export const runtime = 'nodejs'`**: pg + DrizzleEventStore are not Edge-safe.

## Sparring
4 rounds with Codex (APPROVE final). Rounds 1–3 surfaced:
- synthetic `data:` error frames without id (removed — close stream instead)
- 5-min `SSE_MAX_LIFETIME_MS` prematurely closing live runs (removed)
- empty `Last-Event-ID` silent-coerce-to-0 (400 at route layer)
- missing regression for query-cursor ignored (added)
- abort race before `start()` ran / reader `cancel()` orphaning the poll interval (hoisted listener out of `start()`, `cancel()` calls cleanup, plus `{ once: true }`)

## Test plan
- [x] `pnpm build` — all workspace packages build
- [x] `pnpm check` — TypeScript
- [x] `pnpm lint` — Biome (warnings only on unrelated files)
- [x] `pnpm test` — 395 passed (23 new SSE tests)
- [x] `./docs/execution/verify.sh task-14` — PASS
- [x] 23 SSE tests cover: auth/scope/ownership, Last-Event-ID validation (incl. empty/whitespace), terminal replay, live polling → terminal, abort before/during start, reader cancel, query-cursor regression

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)