### PR TITLE
chore(docs): align SSE reconnect + live-notification with PR #154 spec

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -170,12 +170,29 @@ Aligned with **AI SDK v6 UIMessageChunk** (wire-level streaming shape used by `u
 Single protocol, `Last-Event-ID` only (no query cursor):
 
 1. Client disconnects at `seq = N`.
-2. Client reconnects with `Last-Event-ID: N`.
+2. Client reconnects with `Last-Event-ID: N` (browsers set this automatically from the last `id:` field).
 3. Server replays `SELECT * FROM run_events WHERE run_id = ? AND seq > N ORDER BY seq`.
-4. Server attaches to the Redis live stream ([`packages/stream`](../packages/stream)) and forwards new events.
-5. Runs in a terminal state (`success`/`failed`/`cancelled`) send the full replay then close the connection.
+4. Server then attaches to the active-run notification path for live events.
+5. When `runs.status` reaches a state-machine terminal (`completed` or `failed`; the wire shows `cancelled` for user-cancels), the server replays any trailing events then closes the connection.
 
-See [`specs/managed-agents-api.md` §断线重连](../specs/managed-agents-api.md) for the binding decision trail.
+**Invariants (hold regardless of handler choice)**:
+
+- `run_events` is the single-writer source of truth (control-worker `EventStore`, see [`packages/control-plane`](../packages/control-plane)).
+- Every SSE frame carries `id: <seq>` — on both replay and live paths.
+- `seq` is strictly monotonic; live `seq` is always greater than the largest replay `seq`.
+- Connection close is driven by `runs.status` reaching state-machine terminal — **not** by the `data-openrush-run-done.status` field, which is a display-layer hint only.
+
+### Live-notification implementation (handler choice, client-transparent)
+
+How the server is notified of new events on an active run is a handler-side decision and does **not** affect the wire protocol:
+
+| Option | Mechanism | When |
+| --- | --- | --- |
+| `run_events` polling | Periodic (~500 ms) query for `seq > lastSentSeq` | **P0 default** — smallest blast radius, no Redis dependency |
+| StreamRegistry pub/sub | Subscribe to Redis channel, publish forwards immediately | P1+ — lower latency on active runs |
+| Hybrid | Polling fallback plus pub/sub fast-path | P2+ — high-load production |
+
+The current `GET /api/v1/agents/:agentId/runs/:runId/events` handler (task-14) uses **polling**. Future swaps to pub/sub or hybrid are transparent to clients because the invariants above remain intact. See [`specs/managed-agents-api.md` §断线重连, §实时通知实现选项](../specs/managed-agents-api.md) for the binding decision trail.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -145,7 +145,7 @@ id: 5
 data: {"type":"data-openrush-run-done","data":{"status":"success"}}
 ```
 
-**Reconnect after disconnection**: pass `Last-Event-ID: <last seq>` header. The server replays `run_events` with `seq > N`, then attaches to the live Redis stream. No query-string cursor is used — single protocol.
+**Reconnect after disconnection**: pass `Last-Event-ID: <last seq>` header. The server replays `run_events` rows with `seq > N`, then attaches to the active-run notification path (handler-side choice — polling by default; pub/sub / hybrid are client-transparent alternatives). No query-string cursor is used — single protocol.
 
 ### 3.4 Append a follow-up message (second Run)
 
@@ -176,7 +176,7 @@ curl -X POST "$OPENRUSH_BASE/api/v1/agents/<agentId>/runs/<runId>/cancel" \
 | `curl` returns `401 UNAUTHORIZED` | Token missing / expired / revoked. Re-issue and export `OPENRUSH_TOKEN`. |
 | `403 FORBIDDEN` with a valid token | Token scopes too narrow. Re-issue with the scope listed in [`specs/managed-agents-api.md` §Scope 矩阵](../specs/managed-agents-api.md). |
 | `503` on every `/api/v1/*` call | Feature flag `OPENRUSH_V1_ENABLED` is off. Set it to `true` in `apps/web/.env.local`. |
-| SSE immediately closes after replay | The run already reached `success`/`failed`/`cancelled`. Spec: terminal runs full-replay then close. |
+| SSE immediately closes after replay | `runs.status` already reached a state-machine terminal (`completed` / `failed`; wire shows `cancelled` for user-cancels). Spec: terminal runs full-replay then close — not a bug. |
 | Agent worker can't reach Claude | Verify `ANTHROPIC_API_KEY` / Bedrock creds in `apps/agent-worker/.env.local`. |
 
 ---


### PR DESCRIPTION
## Summary

Align `docs/api.md` and `docs/quickstart.md` with the spec clarifications that landed in **PR #154** (`chore(spec): clarify SSE live-notification = handler choice; fix status domains`), which was merged to `main` while task-17's PR #155 was also merging.

PR #155 shipped the original README v2 + quickstart + api docs; this follow-up reflects the updated `specs/managed-agents-api.md` §断线重连 + new §实时通知实现选项.

## Scope

- `docs/api.md` §Reconnect protocol:
  - Replace "attaches to Redis live stream (packages/stream)" with "attaches to the active-run notification path".
  - Fix close-condition domain: `runs.status` state-machine terminal (`completed`/`failed`; wire-level `cancelled` for user-cancels), not `data-openrush-run-done.status` (display-only).
  - Add 4 invariants (single-writer `run_events`, `id: <seq>` on every frame, monotonic `seq`, terminal-driven close).
  - New subsection "Live-notification implementation (handler choice, client-transparent)" with 3-option table (polling P0 / pub/sub P1+ / hybrid P2+) noting task-14 uses polling.
- `docs/quickstart.md`:
  - Reconnect paragraph uses handler-transparent wording.
  - Troubleshooting row fixed to correct terminal domains.

No runtime / schema / API / contract change.

## Verification

- Sparring via Codex on the delta → **APPROVE** — "aligned with `specs/managed-agents-api.md §断线重连` and §实时通知实现选项, including header-only resume, replay-first behavior, handler-side live-notification choice, and terminal-status-driven close".
- `./docs/execution/verify.sh task-17` → **PASS**.

## Test plan

- [x] `pnpm build` / `pnpm check` / `pnpm lint` / `pnpm test` via verify.sh
- [x] Markdown relative links resolve
- [x] Doc wording matches `specs/managed-agents-api.md` §断线重连 + §实时通知实现选项 verbatim
- [x] Sparring APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)