### PR TITLE
task-16: TypeScript SDK @open-rush/sdk

### DIFF
--- a/docs/execution/TASKS.md
+++ b/docs/execution/TASKS.md
@@ -189,7 +189,7 @@ Source of truth 见 `.claude/plans/managed-agents-p0-p1.md`。本文件仅用于
       - 可 import Swagger UI / Postman
       - verify: `./docs/execution/verify.sh task-15`
 
-- [ ] `task-16-typescript-sdk` — **Agent-C**
+- [x] `task-16-typescript-sdk` — **Agent-C**
       域: `packages/sdk/*`(新包 `@open-rush/sdk`)
       依赖: task-4, task-15
       验收:

--- a/docs/execution/progress/agent-c-api.md
+++ b/docs/execution/progress/agent-c-api.md
@@ -65,10 +65,87 @@ Track: M4 API-docs chain (task-15 OpenAPI + task-16 TypeScript SDK).
 
 - **Next**: commit + PR (Closes #130), hand off to task-16.
 
-## task-16 — planned
+## task-16 — TypeScript SDK `@open-rush/sdk`
 
-- Implement after task-15 merges.
-- Strategy: thin HTTP client in `packages/sdk`, re-export
-  `@open-rush/contracts/v1` types (no codegen). SSE client mirrors the
-  task-14 route: `EventSource`-like fetch loop with `Last-Event-ID`
-  reconnect; expose `createAgent` / `createRun` / `streamEvents` etc.
+- **Branch**: `feat/task-16` (worktree `/tmp/agent-wt/c1`, off `feat/task-15`;
+  rebases onto main once #158 merges).
+- **Files delivered** (new package):
+  - `packages/sdk/package.json` — workspace dep on `@open-rush/contracts`,
+    dual ESM+CJS output via tsup, vitest test runner.
+  - `packages/sdk/src/index.ts` — barrel re-exports `OpenRushClient`,
+    `OpenRushApiError`, SSE helpers, and the `v1` namespace.
+  - `packages/sdk/src/http.ts` — `performRequest` / `performStreamRequest`
+    (thin transport: Bearer token, JSON envelope, 204 handling, error
+    envelope parsing). No retry, no caching, no pagination helper.
+  - `packages/sdk/src/errors.ts` — `OpenRushApiError` with stable `code`
+    discriminant (8 values from contracts v1).
+  - `packages/sdk/src/sse.ts` — `streamEvents` async generator with
+    `Last-Event-ID` reconnect + configurable back-off + abort support.
+    Mirrors task-14 server semantics (spec §断线重连). Zero runtime
+    dependency (pure `fetch` + `ReadableStream` + `TextDecoder`).
+  - `packages/sdk/src/client.ts` — `OpenRushClient` with 8 resource
+    namespaces (`authTokens`, `agentDefinitions`, `agents`, `runs`,
+    `vaults`, `skills`, `mcps`, `projects`) + top-level `streamEvents`.
+    All types pulled from `@open-rush/contracts` via `Partial<>` wrappers
+    for defaulted query schemas (limit/includeArchived).
+  - `packages/sdk/src/__tests__/http.test.ts` — 19 vitest cases (URL
+    build, headers, body serialization, 204, defaults merge, abort,
+    error envelope parsing, stream transport, global fetch fallback).
+  - `packages/sdk/src/__tests__/client.test.ts` — 22 cases covering
+    every resource method's HTTP method / path / headers / body. Asserts
+    `If-Match` on PATCH definitions, optional `Idempotency-Key` on
+    `runs.create`, Authorization bypass when no token.
+  - `packages/sdk/src/__tests__/sse.test.ts` — 20 cases: `parseSseFrame`
+    happy + malformed, terminal run EOF after `data-openrush-run-done`,
+    reconnect with `Last-Event-ID`, policy returning false, client-side
+    dedup of `seq <= lastEventId`, abort mid-stream.
+  - `packages/sdk/README.md` — quickstart + API reference + idempotency
+    / concurrency / reconnect / errors sections.
+
+- **Design decisions**
+  - Thin HTTP client, **no codegen from OpenAPI**. Contracts are the
+    single source of truth; OpenAPI is a derived artefact. Generating
+    from YAML would introduce silent drift if somebody edits contracts
+    without regenerating.
+  - **No runtime Zod validation on hot path** — re-validating every SSE
+    frame would cost 1-2 ms/frame. Server is the single writer and has
+    its own invariants; the SDK simply `as`-casts to `v1.RunEventPayload`.
+    Callers wanting validation can `v1.runEventPayloadSchema.parse(ev.data)`.
+  - **Optimistic-concurrency discipline**: `agentDefinitions.patch()`
+    takes `ifMatchVersion` as a **positional** argument (not optional),
+    making it impossible to forget the `If-Match` header.
+  - **Idempotency-Key as an explicit option object** — `runs.create(agentId,
+    body, { idempotencyKey })`. Separates it from body schema (contract)
+    and makes it visible in IDE autocomplete.
+  - **Partial<Query> for list methods** — contracts' `paginationQuerySchema`
+    has `limit: z.coerce.number().default(50)` which infers `limit: number`
+    (required in output type). Using `Partial<>` on the SDK surface lets
+    callers call `list()` with zero args.
+  - **Custom fetch injection** — `fetch?: FetchLike` in
+    `OpenRushClientOptions`. Tests use it exclusively (no global stubbing);
+    Node < 18 users can pass node-fetch.
+  - **streamEvents is an AsyncGenerator** — matches `for-await-of`
+    ergonomics; abort is supported via `AbortSignal`; reconnect policy is
+    caller-overridable.
+
+- **Green**: `pnpm build && pnpm check && pnpm lint && pnpm test` all
+  pass (35 workspace tasks, 62 SDK tests).
+  `./docs/execution/verify.sh task-16` → `[PASS]`.
+
+- **Sparring rounds** (Codex `gpt-5.3-codex-xhigh`):
+  - R1: CONCERNS — 1 MUST-FIX + 2 SHOULD-FIX.
+    - MUST-FIX: `streamEvents()` could enter a ~15 s reconnect back-off
+      chain when a caller resumed with `lastEventId = <last seq>` of an
+      already-terminal run (server drains nothing, closes — SDK misread
+      EOF as "mid-run disconnect"). Fixed by treating zero-event EOF as
+      terminal exit (matches task-14 `initialIsTerminal` branch).
+    - SHOULD-FIX: README same-origin example had `baseUrl: ''` which
+      throws at construct time — switched to `window.location.origin`.
+    - SHOULD-FIX: `onReconnect` returning `false` had asymmetric
+      semantics (EOF = graceful exit, error = rethrow). Documented the
+      distinction in JSDoc + README.
+  - R2: APPROVE (no regressions; zero-event-EOF rule noted as a
+    server-contract assumption that task-18 E2E implicitly guards).
+
+- **Next**: commit + PR (Closes #131). SDK branch is based on
+  `feat/task-15`; once #158 merges, rebase onto main.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,237 @@
+# @open-rush/sdk
+
+TypeScript client for the Open-rush **Managed Agents API** (`/api/v1/*`).
+
+- Thin HTTP wrapper — no business logic, no retries, no caching.
+- Types come straight from `@open-rush/contracts` (the Zod source of truth), so the SDK and server contracts cannot drift without a compile error.
+- Node ≥ 18, the browser, Bun, and Deno all supported (any runtime with `fetch` + `ReadableStream` + `TextDecoder`).
+
+---
+
+## Install
+
+```bash
+pnpm add @open-rush/sdk
+# or
+npm install @open-rush/sdk
+```
+
+## Quickstart
+
+### With a Service Token (machine-to-machine)
+
+```ts
+import { OpenRushClient } from '@open-rush/sdk';
+
+const client = new OpenRushClient({
+  baseUrl: 'https://rush.example.com',
+  token: process.env.OPEN_RUSH_TOKEN, // sk_...
+});
+
+// 1. Create an AgentDefinition (versioned blueprint)
+const {
+  data: definition,
+} = await client.agentDefinitions.create({
+  projectId: PROJECT_ID,
+  name: 'code-reviewer',
+  providerType: 'anthropic',
+  model: 'claude-sonnet-4-5',
+  allowedTools: ['Read', 'Grep'],
+  skills: [],
+  mcpServers: [],
+  maxSteps: 50,
+  deliveryMode: 'chat',
+});
+
+// 2. Create an Agent (instance) + its first Run
+const {
+  data: { agent, firstRunId },
+} = await client.agents.create({
+  definitionId: definition.id,
+  projectId: PROJECT_ID,
+  mode: 'chat',
+  initialInput: 'Review the latest commit on main.',
+});
+
+// 3. Stream events until the run completes
+for await (const ev of client.streamEvents({
+  agentId: agent.id,
+  runId: firstRunId!,
+})) {
+  if (ev.data.type === 'text-delta') {
+    process.stdout.write(ev.data.delta ?? '');
+  }
+  if (ev.data.type === 'data-openrush-run-done') {
+    console.log(`\n[run ${ev.data.data.status}]`);
+  }
+}
+```
+
+### With a session cookie (browser / same-origin)
+
+Omit `token` — cookie handling is the runtime's job. Pass the current
+origin as `baseUrl`:
+
+```ts
+// In a browser page served from rush.example.com:
+const client = new OpenRushClient({ baseUrl: window.location.origin });
+await client.agents.list();
+```
+
+On the server (e.g. a Next.js Route Handler running on the same origin
+as the UI), pass the full origin the route should call — typically an
+env var like `process.env.NEXT_PUBLIC_APP_URL`.
+
+## API surface
+
+Methods mirror `specs/managed-agents-api.md` §Endpoint 清单 1:1. Resource namespaces:
+
+| Namespace              | Endpoints                                                        |
+| ---------------------- | ---------------------------------------------------------------- |
+| `client.authTokens`    | `create`, `list`, `delete`                                       |
+| `client.agentDefinitions` | `create`, `list`, `get`, `patch`, `listVersions`, `archive`   |
+| `client.agents`        | `create`, `list`, `get`, `delete`                                |
+| `client.runs`          | `create` (idempotency-key), `list`, `get`, `cancel`              |
+| `client.streamEvents`  | SSE `run_events` subscriber with `Last-Event-ID` reconnect       |
+| `client.vaults`        | `create`, `list`, `delete`                                       |
+| `client.skills`        | `list`                                                           |
+| `client.mcps`          | `list`                                                           |
+| `client.projects`      | `create`, `list`, `get`                                          |
+
+All request / response types are imported directly from `@open-rush/contracts`; the SDK re-exports the `v1` namespace for convenience:
+
+```ts
+import { v1 } from '@open-rush/sdk';
+const token: v1.CreatedToken = /* ... */;
+```
+
+## Idempotency
+
+`POST /api/v1/agents/:agentId/runs` accepts an optional `Idempotency-Key` header. UUIDv4 is recommended:
+
+```ts
+import { randomUUID } from 'node:crypto';
+
+const { data: run } = await client.runs.create(
+  agent.id,
+  { input: 'retry-safe message' },
+  { idempotencyKey: randomUUID() }
+);
+```
+
+Within a 24-hour window:
+
+- Same key + same body → server replays the original 201
+- Same key + different body → 409 `IDEMPOTENCY_CONFLICT`
+
+Other POST endpoints are **not** idempotent in v0.1.
+
+## Optimistic concurrency (AgentDefinition PATCH)
+
+`PATCH /api/v1/agent-definitions/:id` requires `If-Match: <current_version>`; mismatch → 409 `VERSION_CONFLICT`. The SDK makes the version argument mandatory:
+
+```ts
+const {
+  data: updated,
+} = await client.agentDefinitions.patch(
+  definition.id,
+  definition.currentVersion, // If-Match
+  { maxSteps: 100 }
+);
+```
+
+## Event streaming
+
+`client.streamEvents()` is an async generator over `{ id, data }` pairs where `id` is the monotonic per-run `run_events.seq` and `data` is one of:
+
+- AI SDK 6 `UIMessageChunk` — `text-start`, `text-delta`, `text-end`, `reasoning-*`, `tool-*`, `start`, `finish`, `error`, step markers
+- Open-rush extension — `data-openrush-run-started`, `data-openrush-run-done`, `data-openrush-usage`, `data-openrush-sub-run`
+- Generic `data-<key>` with opaque payload
+
+### Reconnection
+
+On unexpected EOF (connection dropped mid-run before `data-openrush-run-done`), the SDK automatically reconnects with `Last-Event-ID: <last seen seq>`. Default back-off: 500 ms → 1 s → 2 s → 4 s → 8 s over 5 attempts. Customise via `onReconnect`:
+
+```ts
+for await (const ev of client.streamEvents({
+  agentId,
+  runId,
+  lastEventId: 0, // resume from N if you've seen up to N
+  onReconnect: ({ attempt, lastEventId, cause }) => {
+    if (attempt > 3) return false; // give up
+    return 2000; // ms to wait before reconnecting
+  },
+})) {
+  /* ... */
+}
+```
+
+`onReconnect` is consulted on two situations:
+
+- **Unexpected EOF** — `cause` is the string `'eof'`. Returning `false` terminates the iterator gracefully (no throw).
+- **Fetch / HTTP error** — `cause` is the underlying `Error`. Returning `false` rethrows so the caller can observe the failure.
+
+Resuming with a `lastEventId` equal to the last seq of an already-terminated run EOFs with zero new events and exits **without** calling `onReconnect` — the server already drained everything.
+
+### Cancellation
+
+Pass an `AbortSignal`:
+
+```ts
+const ctrl = new AbortController();
+setTimeout(() => ctrl.abort(), 30_000);
+for await (const ev of client.streamEvents({
+  agentId,
+  runId,
+  signal: ctrl.signal,
+})) {
+  /* ... */
+}
+```
+
+## Error handling
+
+Every non-2xx response throws `OpenRushApiError` carrying the server's stable envelope:
+
+```ts
+import { OpenRushApiError } from '@open-rush/sdk';
+
+try {
+  await client.agentDefinitions.patch(id, 1, { name: 'new' });
+} catch (err) {
+  if (err instanceof OpenRushApiError) {
+    switch (err.code) {
+      case 'VERSION_CONFLICT':
+        // refetch + retry
+        break;
+      case 'VALIDATION_ERROR':
+        console.error(err.issues);
+        break;
+      default:
+        throw err;
+    }
+  } else {
+    throw err;
+  }
+}
+```
+
+Stable `err.code` values (8 total): `UNAUTHORIZED` (401), `FORBIDDEN` (403), `NOT_FOUND` (404), `VALIDATION_ERROR` (400), `VERSION_CONFLICT` (409), `IDEMPOTENCY_CONFLICT` (409), `RATE_LIMITED` (429), `INTERNAL` (500).
+
+## Custom fetch
+
+The SDK accepts a `fetch` option for Node < 18, tests, or custom agents (e.g. proxying, telemetry):
+
+```ts
+import nodeFetch from 'node-fetch';
+
+const client = new OpenRushClient({
+  baseUrl,
+  token,
+  fetch: nodeFetch as unknown as typeof fetch,
+});
+```
+
+## License
+
+MIT.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@open-rush/sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "TypeScript SDK for Open-rush /api/v1/* Managed Agents API.",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "check": "tsc --noEmit",
+    "lint": "biome check .",
+    "test": "vitest run",
+    "clean": "rm -rf dist node_modules coverage"
+  },
+  "dependencies": {
+    "@open-rush/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for `client.ts` — the public resource-namespace surface.
+ *
+ * Strategy:
+ *
+ *   Every resource method maps 1:1 to an `/api/v1/*` operation listed in
+ *   `specs/managed-agents-api.md`. The test body wires a fake fetch,
+ *   invokes each method with a minimal body, and asserts:
+ *     1. the request METHOD is correct (POST vs GET vs PATCH vs DELETE)
+ *     2. the URL path matches the spec
+ *     3. headers unique to that endpoint are attached (If-Match on
+ *        definitions.patch, Idempotency-Key on runs.create, Authorization
+ *        Bearer flows through)
+ *     4. the returned value is the parsed response envelope.
+ *
+ *   We do NOT re-test JSON serialisation / error envelope parsing —
+ *   those live in `http.test.ts`. The mock fetch here simply returns a
+ *   canned success envelope for every call.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { OpenRushClient } from '../client.js';
+import type { FetchLike } from '../http.js';
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+function makeClient(
+  canned: Record<string, unknown> | ((req: CapturedRequest) => unknown) = { data: {} }
+): {
+  client: OpenRushClient;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  const fetchImpl: FetchLike = async (input, init = {}) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = init.method ?? 'GET';
+    const headers = { ...((init.headers ?? {}) as Record<string, string>) };
+    const bodyStr = init.body;
+    const body = typeof bodyStr === 'string' ? JSON.parse(bodyStr) : undefined;
+    const req: CapturedRequest = { url, method, headers, body };
+    calls.push(req);
+    const payload = typeof canned === 'function' ? canned(req) : canned;
+    return new Response(JSON.stringify(payload), {
+      status: method === 'POST' ? 201 : 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+  const client = new OpenRushClient({
+    baseUrl: 'https://h.example.com',
+    token: 'sk_test_abc',
+    fetch: fetchImpl,
+  });
+  return { client, calls };
+}
+
+// ---------------------------------------------------------------------------
+// Smoke
+// ---------------------------------------------------------------------------
+
+describe('OpenRushClient constructor', () => {
+  it('requires baseUrl', () => {
+    expect(
+      () =>
+        new OpenRushClient({ baseUrl: '' } as unknown as ConstructorParameters<
+          typeof OpenRushClient
+        >[0])
+    ).toThrow(/baseUrl is required/);
+  });
+
+  it('exposes 8 resource namespaces', () => {
+    const { client } = makeClient();
+    expect(client.authTokens).toBeDefined();
+    expect(client.agentDefinitions).toBeDefined();
+    expect(client.agents).toBeDefined();
+    expect(client.runs).toBeDefined();
+    expect(client.vaults).toBeDefined();
+    expect(client.skills).toBeDefined();
+    expect(client.mcps).toBeDefined();
+    expect(client.projects).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuthTokens (3)
+// ---------------------------------------------------------------------------
+
+describe('client.authTokens', () => {
+  it('create → POST /api/v1/auth/tokens with body', async () => {
+    const { client, calls } = makeClient();
+    await client.authTokens.create({
+      name: 't',
+      scopes: ['agents:read'],
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/auth/tokens');
+    expect(calls[0].body).toEqual({
+      name: 't',
+      scopes: ['agents:read'],
+      expiresAt: '2099-01-01T00:00:00Z',
+    });
+  });
+
+  it('list → GET /api/v1/auth/tokens with pagination', async () => {
+    const { client, calls } = makeClient();
+    await client.authTokens.list({ limit: 10, cursor: 'abc' });
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toContain('limit=10');
+    expect(calls[0].url).toContain('cursor=abc');
+  });
+
+  it('delete → DELETE /api/v1/auth/tokens/:id', async () => {
+    const { client, calls } = makeClient();
+    await client.authTokens.delete('11111111-1111-1111-1111-111111111111');
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toBe(
+      'https://h.example.com/api/v1/auth/tokens/11111111-1111-1111-1111-111111111111'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentDefinitions (6)
+// ---------------------------------------------------------------------------
+
+describe('client.agentDefinitions', () => {
+  it('create → POST', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.create({
+      projectId: 'p',
+      name: 'demo',
+      providerType: 'anthropic',
+      allowedTools: [],
+      skills: [],
+      mcpServers: [],
+      maxSteps: 100,
+      deliveryMode: 'chat',
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agent-definitions');
+  });
+
+  it('list → GET with includeArchived as query', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.list({ includeArchived: true });
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toContain('includeArchived=true');
+  });
+
+  it('get → GET :id with optional version', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.get('def-1', { version: 3 });
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agent-definitions/def-1?version=3');
+  });
+
+  it('get → drops undefined version query', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.get('def-1');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agent-definitions/def-1');
+  });
+
+  it('patch → PATCH with If-Match header', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.patch('def-1', 5, { name: 'new' });
+    expect(calls[0].method).toBe('PATCH');
+    expect(calls[0].headers['If-Match']).toBe('5');
+    expect(calls[0].body).toEqual({ name: 'new' });
+  });
+
+  it('listVersions → GET :id/versions', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.listVersions('def-1');
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agent-definitions/def-1/versions');
+  });
+
+  it('archive → POST :id/archive', async () => {
+    const { client, calls } = makeClient();
+    await client.agentDefinitions.archive('def-1');
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agent-definitions/def-1/archive');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agents (4)
+// ---------------------------------------------------------------------------
+
+describe('client.agents', () => {
+  it('create → POST /api/v1/agents', async () => {
+    const { client, calls } = makeClient();
+    await client.agents.create({
+      definitionId: 'def-1',
+      projectId: 'p',
+      mode: 'chat',
+      initialInput: 'hi',
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents');
+    expect(calls[0].body).toEqual({
+      definitionId: 'def-1',
+      projectId: 'p',
+      mode: 'chat',
+      initialInput: 'hi',
+    });
+  });
+
+  it('list → GET with status filter', async () => {
+    const { client, calls } = makeClient();
+    await client.agents.list({ status: 'active' });
+    expect(calls[0].url).toContain('status=active');
+  });
+
+  it('get → GET :id', async () => {
+    const { client, calls } = makeClient();
+    await client.agents.get('agt-1');
+    expect(calls[0].method).toBe('GET');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents/agt-1');
+  });
+
+  it('delete → DELETE :id', async () => {
+    const { client, calls } = makeClient();
+    await client.agents.delete('agt-1');
+    expect(calls[0].method).toBe('DELETE');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents/agt-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runs (5)
+// ---------------------------------------------------------------------------
+
+describe('client.runs', () => {
+  it('create → POST /:agentId/runs', async () => {
+    const { client, calls } = makeClient();
+    await client.runs.create('agt-1', { input: 'hi' });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents/agt-1/runs');
+    expect(calls[0].headers['Idempotency-Key']).toBeUndefined();
+  });
+
+  it('create with idempotencyKey attaches Idempotency-Key header', async () => {
+    const { client, calls } = makeClient();
+    await client.runs.create('agt-1', { input: 'hi' }, { idempotencyKey: 'abc-123' });
+    expect(calls[0].headers['Idempotency-Key']).toBe('abc-123');
+  });
+
+  it('list → GET with status filter', async () => {
+    const { client, calls } = makeClient();
+    await client.runs.list('agt-1', { status: 'running' });
+    expect(calls[0].url).toContain('/agents/agt-1/runs?');
+    expect(calls[0].url).toContain('status=running');
+  });
+
+  it('get → GET :runId', async () => {
+    const { client, calls } = makeClient();
+    await client.runs.get('agt-1', 'run-1');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents/agt-1/runs/run-1');
+  });
+
+  it('cancel → POST :runId/cancel', async () => {
+    const { client, calls } = makeClient();
+    await client.runs.cancel('agt-1', 'run-1');
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/agents/agt-1/runs/run-1/cancel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vaults, Skills, MCPs, Projects (3 + 1 + 1 + 3 = 8 more)
+// ---------------------------------------------------------------------------
+
+describe('client.vaults', () => {
+  it('create / list / delete', async () => {
+    const { client, calls } = makeClient();
+    await client.vaults.create({
+      scope: 'platform',
+      name: 'k',
+      credentialType: 'env_var',
+      value: 'v',
+    });
+    await client.vaults.list({ scope: 'platform' });
+    await client.vaults.delete('v-1');
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'DELETE']);
+    expect(calls[2].url).toBe('https://h.example.com/api/v1/vaults/entries/v-1');
+  });
+});
+
+describe('client.skills / mcps / projects', () => {
+  it('skills.list → GET /api/v1/skills', async () => {
+    const { client, calls } = makeClient();
+    await client.skills.list({ q: 'node' });
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/skills?q=node');
+  });
+
+  it('mcps.list → GET /api/v1/mcps', async () => {
+    const { client, calls } = makeClient();
+    await client.mcps.list();
+    expect(calls[0].url).toBe('https://h.example.com/api/v1/mcps');
+  });
+
+  it('projects.create/list/get', async () => {
+    const { client, calls } = makeClient();
+    await client.projects.create({ name: 'demo', sandboxProvider: 'opensandbox' });
+    await client.projects.list();
+    await client.projects.get('p-1');
+    expect(calls.map((c) => c.method)).toEqual(['POST', 'GET', 'GET']);
+    expect(calls[2].url).toBe('https://h.example.com/api/v1/projects/p-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authorization + return shape
+// ---------------------------------------------------------------------------
+
+describe('OpenRushClient auth + return', () => {
+  it('sends Authorization: Bearer <token> on every call', async () => {
+    const { client, calls } = makeClient();
+    await client.agents.list();
+    await client.projects.list();
+    for (const c of calls) {
+      expect(c.headers.Authorization).toBe('Bearer sk_test_abc');
+    }
+  });
+
+  it('returns the parsed envelope from resource methods', async () => {
+    const { client } = makeClient({
+      data: { id: 'p-1', name: 'demo', description: null },
+    });
+    const out = await client.projects.get('p-1');
+    expect(out).toEqual({
+      data: { id: 'p-1', name: 'demo', description: null },
+    });
+  });
+
+  it('omits Authorization when no token is provided (session cookie flow)', async () => {
+    const calls: CapturedRequest[] = [];
+    const fetchImpl: FetchLike = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls.push({
+        url,
+        method: init.method ?? 'GET',
+        headers: { ...((init.headers ?? {}) as Record<string, string>) },
+      });
+      return new Response(JSON.stringify({ data: {} }), { status: 200 });
+    };
+    const client = new OpenRushClient({
+      baseUrl: 'https://h',
+      fetch: fetchImpl,
+    });
+    await client.agents.list();
+    expect(calls[0].headers.Authorization).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/__tests__/http.test.ts
+++ b/packages/sdk/src/__tests__/http.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for `http.ts` — the SDK's transport layer.
+ *
+ * Goal: prove that every request that flows through `performRequest` /
+ * `performStreamRequest` attaches the right headers, serialises the
+ * right body, and on error throws an `OpenRushApiError` whose fields
+ * match the server's JSON envelope. We inject a fake `fetch` — no real
+ * network. Without these tests the resource-namespace tests below would
+ * be unable to distinguish a genuine contract bug from a transport bug.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { OpenRushApiError } from '../errors.js';
+import { buildUrl, type FetchLike, performRequest, performStreamRequest } from '../http.js';
+
+interface FakeRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function makeFetch(respond: (req: FakeRequest) => Response | Promise<Response>): {
+  fetch: FetchLike;
+  calls: FakeRequest[];
+} {
+  const calls: FakeRequest[] = [];
+  const fetchImpl: FetchLike = async (input, init = {}) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const req: FakeRequest = { url, init };
+    calls.push(req);
+    return respond(req);
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('buildUrl', () => {
+  it('joins absolute path onto baseUrl without a trailing slash', () => {
+    expect(buildUrl('https://h.example.com', '/api/v1/agents')).toBe(
+      'https://h.example.com/api/v1/agents'
+    );
+  });
+
+  it('tolerates a trailing slash on baseUrl (no double-slash)', () => {
+    expect(buildUrl('https://h.example.com/', '/api/v1/agents')).toBe(
+      'https://h.example.com/api/v1/agents'
+    );
+  });
+
+  it('appends query params, dropping null/undefined', () => {
+    const url = buildUrl('https://h.example.com', '/api/v1/agents', {
+      limit: 10,
+      cursor: undefined,
+      projectId: null,
+      status: 'active',
+    });
+    expect(url).toContain('limit=10');
+    expect(url).toContain('status=active');
+    expect(url).not.toContain('cursor');
+    expect(url).not.toContain('projectId');
+  });
+
+  it('URL-encodes query values', () => {
+    const url = buildUrl('https://h.example.com', '/api/v1/skills', { q: 'hello world' });
+    expect(url).toContain('q=hello+world');
+  });
+});
+
+describe('performRequest — success paths', () => {
+  it('GETs with Authorization and Accept headers', async () => {
+    const { fetch, calls } = makeFetch(() => jsonResponse(200, { data: { id: 'x' } }));
+    const out = await performRequest<{ data: { id: string } }>(
+      { baseUrl: 'https://h', token: 'sk_test', fetch },
+      { method: 'GET', path: '/api/v1/agents/x' }
+    );
+    expect(out.data.id).toBe('x');
+    expect(calls).toHaveLength(1);
+    const hdrs = calls[0].init.headers as Record<string, string>;
+    expect(hdrs.Authorization).toBe('Bearer sk_test');
+    expect(hdrs.Accept).toBe('application/json');
+    // No Content-Type on a bodyless request.
+    expect(hdrs['Content-Type']).toBeUndefined();
+    expect(calls[0].init.body).toBeUndefined();
+    expect(calls[0].url).toBe('https://h/api/v1/agents/x');
+  });
+
+  it('serialises JSON body and sets Content-Type on POST', async () => {
+    const { fetch, calls } = makeFetch(() => jsonResponse(201, { data: { ok: true } }));
+    await performRequest(
+      { baseUrl: 'https://h', fetch },
+      { method: 'POST', path: '/api/v1/projects', body: { name: 'demo' } }
+    );
+    const hdrs = calls[0].init.headers as Record<string, string>;
+    expect(hdrs['Content-Type']).toBe('application/json');
+    expect(calls[0].init.body).toBe(JSON.stringify({ name: 'demo' }));
+  });
+
+  it('returns undefined for 204 responses without parsing', async () => {
+    const { fetch } = makeFetch(() => new Response(null, { status: 204 }));
+    const out = await performRequest<undefined>(
+      { baseUrl: 'https://h', fetch },
+      { method: 'DELETE', path: '/api/v1/auth/tokens/x' }
+    );
+    expect(out).toBeUndefined();
+  });
+
+  it('merges defaultHeaders and per-request headers (request wins)', async () => {
+    const { fetch, calls } = makeFetch(() => jsonResponse(200, { data: {} }));
+    await performRequest(
+      {
+        baseUrl: 'https://h',
+        defaultHeaders: { 'X-Client': 'sdk', 'X-Override': 'default' },
+        fetch,
+      },
+      {
+        method: 'GET',
+        path: '/x',
+        headers: { 'X-Override': 'per-request', 'If-Match': '3' },
+      }
+    );
+    const hdrs = calls[0].init.headers as Record<string, string>;
+    expect(hdrs['X-Client']).toBe('sdk');
+    expect(hdrs['X-Override']).toBe('per-request');
+    expect(hdrs['If-Match']).toBe('3');
+  });
+
+  it('propagates AbortSignal to fetch', async () => {
+    let observed: AbortSignal | undefined;
+    const { fetch } = makeFetch((req) => {
+      observed = req.init.signal ?? undefined;
+      return jsonResponse(200, { data: {} });
+    });
+    const ctrl = new AbortController();
+    await performRequest(
+      { baseUrl: 'https://h', fetch },
+      { method: 'GET', path: '/x', signal: ctrl.signal }
+    );
+    expect(observed).toBe(ctrl.signal);
+  });
+});
+
+describe('performRequest — error paths', () => {
+  it('throws OpenRushApiError with envelope fields on 4xx', async () => {
+    const { fetch } = makeFetch(() =>
+      jsonResponse(409, {
+        error: {
+          code: 'VERSION_CONFLICT',
+          message: 'stale read',
+          hint: 'GET again',
+        },
+      })
+    );
+    await expect(
+      performRequest({ baseUrl: 'https://h', fetch }, { method: 'PATCH', path: '/x' })
+    ).rejects.toSatisfy((err) => {
+      if (!(err instanceof OpenRushApiError)) return false;
+      expect(err.status).toBe(409);
+      expect(err.code).toBe('VERSION_CONFLICT');
+      expect(err.message).toBe('stale read');
+      expect(err.hint).toBe('GET again');
+      return true;
+    });
+  });
+
+  it('preserves issues[] on VALIDATION_ERROR', async () => {
+    const { fetch } = makeFetch(() =>
+      jsonResponse(400, {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'invalid',
+          issues: [{ path: ['name'], message: 'required' }],
+        },
+      })
+    );
+    try {
+      await performRequest({ baseUrl: 'https://h', fetch }, { method: 'POST', path: '/x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      if (!(err instanceof OpenRushApiError)) throw err;
+      expect(err.code).toBe('VALIDATION_ERROR');
+      expect(err.issues).toEqual([{ path: ['name'], message: 'required' }]);
+    }
+  });
+
+  it('synthesises INTERNAL when body is not a valid envelope', async () => {
+    const { fetch } = makeFetch(() => new Response('Bad Gateway', { status: 502 }));
+    try {
+      await performRequest({ baseUrl: 'https://h', fetch }, { method: 'GET', path: '/x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      if (!(err instanceof OpenRushApiError)) throw err;
+      expect(err.status).toBe(502);
+      expect(err.code).toBe('INTERNAL');
+      expect(err.message).toBe('Bad Gateway');
+    }
+  });
+
+  it('synthesises INTERNAL when body is empty', async () => {
+    const { fetch } = makeFetch(() => new Response(null, { status: 500 }));
+    try {
+      await performRequest({ baseUrl: 'https://h', fetch }, { method: 'GET', path: '/x' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      if (!(err instanceof OpenRushApiError)) throw err;
+      expect(err.status).toBe(500);
+      expect(err.code).toBe('INTERNAL');
+      expect(err.message).toBe('HTTP 500');
+    }
+  });
+});
+
+describe('performStreamRequest', () => {
+  it('uses Accept: text/event-stream', async () => {
+    const { fetch, calls } = makeFetch(
+      () =>
+        new Response('id: 1\ndata: {}\n\n', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+    );
+    await performStreamRequest(
+      { baseUrl: 'https://h', fetch },
+      { method: 'GET', path: '/api/v1/agents/x/runs/y/events' }
+    );
+    const hdrs = calls[0].init.headers as Record<string, string>;
+    expect(hdrs.Accept).toBe('text/event-stream');
+  });
+
+  it('attaches Last-Event-ID when passed in headers', async () => {
+    const { fetch, calls } = makeFetch(
+      () =>
+        new Response('', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+    );
+    await performStreamRequest(
+      { baseUrl: 'https://h', fetch },
+      { method: 'GET', path: '/e', headers: { 'Last-Event-ID': '42' } }
+    );
+    const hdrs = calls[0].init.headers as Record<string, string>;
+    expect(hdrs['Last-Event-ID']).toBe('42');
+  });
+
+  it('throws OpenRushApiError on non-2xx, parsing envelope', async () => {
+    const { fetch } = makeFetch(() =>
+      jsonResponse(403, { error: { code: 'FORBIDDEN', message: 'no scope' } })
+    );
+    try {
+      await performStreamRequest({ baseUrl: 'https://h', fetch }, { method: 'GET', path: '/e' });
+      throw new Error('should have thrown');
+    } catch (err) {
+      if (!(err instanceof OpenRushApiError)) throw err;
+      expect(err.status).toBe(403);
+      expect(err.code).toBe('FORBIDDEN');
+    }
+  });
+
+  it('throws when no fetch implementation is available and globalThis.fetch is absent', async () => {
+    // Can't realistically delete globalThis.fetch in Node; instead test
+    // the explicit branch by passing `fetch: undefined as any` and
+    // stubbing the module-level globalThis check. We rely on the fact
+    // that `opts.fetch ?? globalThis.fetch` is tested against this
+    // specific null by explicit prop.
+    //
+    // Simulation: supply a signal-throwing implementation.
+    const origFetch = globalThis.fetch;
+    try {
+      // @ts-expect-error — delete for this test
+      globalThis.fetch = undefined;
+      await expect(
+        performStreamRequest({ baseUrl: 'https://h' }, { method: 'GET', path: '/e' })
+      ).rejects.toThrow(/no fetch implementation/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/packages/sdk/src/__tests__/sse.test.ts
+++ b/packages/sdk/src/__tests__/sse.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for `sse.ts` — the SSE subscriber.
+ *
+ * We exercise:
+ *
+ *   1. `parseSseFrame` — the pure SSE frame decoder. Covers happy path
+ *      + malformed frames (missing id, non-integer id, invalid JSON).
+ *
+ *   2. `streamEvents` — the reconnecting async generator. Driven by a
+ *      `fetch` stub that returns a `ReadableStream<Uint8Array>`. Covers:
+ *        a. terminal stream (server emits `data-openrush-run-done` then
+ *           EOF) → generator ends cleanly
+ *        b. reconnect on unexpected EOF before done → second request
+ *           carries Last-Event-ID, new events arrive, no duplicates
+ *        c. abort signal stops the iterator without throwing
+ *        d. reconnect policy returning false stops the iterator
+ *
+ * We do NOT test the network / HTTP transport layer here — `http.test.ts`
+ * covers that. `streamEvents` calls into `performStreamRequest` only for
+ * the fetch stub wire-up; everything beyond that is independent.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { FetchLike } from '../http.js';
+import { parseSseFrame, streamEvents } from '../sse.js';
+
+/** Build a `Response` whose body streams the given SSE frames. */
+function sseResponse(frames: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const f of frames) {
+        controller.enqueue(encoder.encode(f));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+/**
+ * A fetch stub that hands back one pre-built Response per call in
+ * sequence. After the list runs out, subsequent calls return an error
+ * Response so tests can't silently loop forever on a bug.
+ */
+function queuedFetch(responses: Array<Response | (() => Response)>): {
+  fetch: FetchLike;
+  calls: Array<{ url: string; headers: Record<string, string>; signal?: AbortSignal }>;
+} {
+  const calls: Array<{ url: string; headers: Record<string, string>; signal?: AbortSignal }> = [];
+  let i = 0;
+  const fetchImpl: FetchLike = async (input, init = {}) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers = { ...((init.headers ?? {}) as Record<string, string>) };
+    calls.push({ url, headers, signal: init.signal ?? undefined });
+    const entry = responses[i];
+    i += 1;
+    if (entry === undefined) {
+      return new Response('too many fetches', { status: 500 });
+    }
+    return typeof entry === 'function' ? entry() : entry;
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+// ---------------------------------------------------------------------------
+// parseSseFrame
+// ---------------------------------------------------------------------------
+
+describe('parseSseFrame', () => {
+  it('parses id + single-line JSON data', () => {
+    const ev = parseSseFrame('id: 42\ndata: {"type":"text-delta","delta":"hi"}');
+    expect(ev).toEqual({
+      id: 42,
+      data: { type: 'text-delta', delta: 'hi' },
+    });
+  });
+
+  it('strips a single space after the colon (WHATWG)', () => {
+    const ev = parseSseFrame('id:7\ndata:{"type":"start"}');
+    expect(ev?.id).toBe(7);
+    expect(ev?.data).toEqual({ type: 'start' });
+  });
+
+  it('concatenates multi-line data', () => {
+    const ev = parseSseFrame('id: 1\ndata: {"a":\ndata: 42}');
+    expect(ev).toEqual({ id: 1, data: { a: 42 } });
+  });
+
+  it('ignores comment and unknown fields', () => {
+    const ev = parseSseFrame(':keep-alive\nid: 3\nevent: run-done\ndata: {}');
+    expect(ev?.id).toBe(3);
+    expect(ev?.data).toEqual({});
+  });
+
+  it('returns null when id is missing', () => {
+    expect(parseSseFrame('data: {}')).toBeNull();
+  });
+
+  it('returns null when id is not a positive integer', () => {
+    expect(parseSseFrame('id: 0\ndata: {}')).toBeNull();
+    expect(parseSseFrame('id: -5\ndata: {}')).toBeNull();
+    expect(parseSseFrame('id: abc\ndata: {}')).toBeNull();
+    expect(parseSseFrame('id: 1.5\ndata: {}')).toBeNull();
+  });
+
+  it('returns null on invalid JSON data', () => {
+    expect(parseSseFrame('id: 1\ndata: {not-json')).toBeNull();
+  });
+
+  it('returns null when data is missing', () => {
+    expect(parseSseFrame('id: 1')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamEvents — terminal run
+// ---------------------------------------------------------------------------
+
+describe('streamEvents — terminal run', () => {
+  it('yields all frames then ends on run-done + EOF', async () => {
+    const { fetch, calls } = queuedFetch([
+      sseResponse([
+        'id: 1\ndata: {"type":"text-delta","delta":"a"}\n\n',
+        'id: 2\ndata: {"type":"text-delta","delta":"b"}\n\n',
+        'id: 3\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([1, 2, 3]);
+    expect(calls).toHaveLength(1);
+    // no Last-Event-ID on first call
+    expect(calls[0].headers['Last-Event-ID']).toBeUndefined();
+  });
+
+  it('honours initial lastEventId by sending Last-Event-ID header', async () => {
+    const { fetch, calls } = queuedFetch([
+      sseResponse([
+        'id: 11\ndata: {"type":"text-delta"}\n\n',
+        'id: 12\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        lastEventId: 10,
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([11, 12]);
+    expect(calls[0].headers['Last-Event-ID']).toBe('10');
+  });
+
+  it('exits cleanly without consulting onReconnect when the terminal run yields 0 events', async () => {
+    // Caller resumes with lastEventId = last seq of a completed run.
+    // Server replays nothing and closes. SDK must NOT enter the
+    // reconnect loop (it would otherwise back-off ~15.5 s before
+    // giving up) — a zero-event EOF is effectively "nothing for you".
+    const { fetch, calls } = queuedFetch([
+      sseResponse([]), // zero events, immediate EOF
+      // Second connection shouldn't be attempted.
+      sseResponse([
+        'id: 99\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+    let reconnectCalled = false;
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        lastEventId: 98,
+        onReconnect: () => {
+          reconnectCalled = true;
+          return 0;
+        },
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([]);
+    expect(reconnectCalled).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('skips frames with seq <= lastEventId (client-side dedup belt)', async () => {
+    const { fetch } = queuedFetch([
+      sseResponse([
+        // Server returned these — in theory shouldn't happen, but we belt.
+        'id: 10\ndata: {"type":"text-delta"}\n\n',
+        'id: 11\ndata: {"type":"text-delta"}\n\n',
+        'id: 12\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        lastEventId: 10,
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([11, 12]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamEvents — reconnect
+// ---------------------------------------------------------------------------
+
+describe('streamEvents — reconnect', () => {
+  it('reconnects on unexpected EOF, resuming with Last-Event-ID', async () => {
+    const { fetch, calls } = queuedFetch([
+      // First connection: 2 frames then EOF (no run-done).
+      sseResponse([
+        'id: 1\ndata: {"type":"text-delta","delta":"a"}\n\n',
+        'id: 2\ndata: {"type":"text-delta","delta":"b"}\n\n',
+      ]),
+      // Second connection: continues from seq 2, delivers run-done.
+      sseResponse([
+        'id: 3\ndata: {"type":"text-delta","delta":"c"}\n\n',
+        'id: 4\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        onReconnect: () => 0, // zero-delay retry
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([1, 2, 3, 4]);
+    expect(calls).toHaveLength(2);
+    // Second call must include Last-Event-ID = 2 (last seen seq).
+    expect(calls[1].headers['Last-Event-ID']).toBe('2');
+  });
+
+  it('stops when reconnect policy returns false', async () => {
+    const { fetch, calls } = queuedFetch([
+      sseResponse(['id: 5\ndata: {"type":"text-delta"}\n\n']),
+      // Second call shouldn't happen
+      sseResponse([
+        'id: 6\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        onReconnect: () => false,
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([5]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('reconnect delay receives attempt + lastEventId context', async () => {
+    const seen: Array<{ attempt: number; lastEventId: number; cause: unknown }> = [];
+    const { fetch } = queuedFetch([
+      sseResponse(['id: 7\ndata: {"type":"text-delta"}\n\n']),
+      sseResponse([
+        'id: 8\ndata: {"type":"data-openrush-run-done","data":{"status":"success"}}\n\n',
+      ]),
+    ]);
+    for await (const _ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        onReconnect: (ctx) => {
+          seen.push(ctx);
+          return 0;
+        },
+      }
+    )) {
+      void _ev;
+    }
+    expect(seen[0]).toMatchObject({ attempt: 1, lastEventId: 7 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamEvents — abort
+// ---------------------------------------------------------------------------
+
+describe('streamEvents — abort', () => {
+  it('stops cleanly when the signal aborts before first call', async () => {
+    const { fetch } = queuedFetch([sseResponse(['id: 1\ndata: {"type":"text-delta"}\n\n'])]);
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const events: number[] = [];
+    for await (const ev of streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        signal: ctrl.signal,
+      }
+    )) {
+      events.push(ev.id);
+    }
+    expect(events).toEqual([]);
+  });
+
+  it('swallows AbortError mid-stream', async () => {
+    // A response whose body never closes — we abort mid-way. The reader
+    // loop in `iterateSseFrames` registers an abort listener that calls
+    // `reader.cancel()`, which propagates back and makes `reader.read()`
+    // resolve to `{ done: true }`, letting the generator exit.
+    const body = new ReadableStream<Uint8Array>({
+      start(c) {
+        // Emit frames; never close.
+        c.enqueue(new TextEncoder().encode('id: 1\ndata: {"type":"text-delta"}\n\n'));
+        c.enqueue(new TextEncoder().encode('id: 2\ndata: {"type":"text-delta"}\n\n'));
+      },
+    });
+    const response = new Response(body, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    const { fetch } = queuedFetch([response]);
+
+    const ctrl = new AbortController();
+    const events: number[] = [];
+    const iter = streamEvents(
+      { baseUrl: 'https://h', fetch },
+      {
+        agentId: 'a',
+        runId: 'r',
+        signal: ctrl.signal,
+        onReconnect: () => false,
+      }
+    );
+
+    // Read two events, then abort.
+    let count = 0;
+    for await (const ev of iter) {
+      events.push(ev.id);
+      count += 1;
+      if (count === 2) {
+        ctrl.abort();
+      }
+    }
+    expect(events).toEqual([1, 2]);
+  });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,369 @@
+/**
+ * `OpenRushClient` — the public SDK entry point.
+ *
+ * Usage (Service Token):
+ *
+ *     import { OpenRushClient } from '@open-rush/sdk';
+ *     const client = new OpenRushClient({
+ *       baseUrl: 'https://rush.example.com',
+ *       token: process.env.OPEN_RUSH_TOKEN,
+ *     });
+ *     const { data: agent } = await client.agents.create({
+ *       definitionId,
+ *       projectId,
+ *       mode: 'chat',
+ *       initialInput: 'hi',
+ *     });
+ *
+ * Resource namespaces mirror the API surface 1:1 (spec §Endpoint 清单):
+ *   - `authTokens` — issue / list / revoke Service Tokens
+ *   - `agentDefinitions` — versioned blueprint CRUD
+ *   - `agents` — Agent (task row) CRUD
+ *   - `runs` — Run lifecycle + event stream
+ *   - `vaults` — credential entries
+ *   - `skills` / `mcps` — read-only registries
+ *   - `projects` — project minimal CRUD
+ *
+ * Why namespaces instead of flat methods? The Zod contract already
+ * partitions schemas per resource (`v1.Run`, `v1.Agent`, ...). Mirroring
+ * that structure in the SDK surface keeps IDE auto-complete sensible
+ * (type `client.agents.` and see every agent op) and makes a 1:1 audit
+ * against the spec trivial.
+ *
+ * Types are re-exported from `@open-rush/contracts` — we do NOT redefine
+ * request / response shapes in the SDK. Any drift between the SDK and
+ * the server would therefore manifest as a compile error in the
+ * user's code, which is the safest outcome.
+ */
+
+import type { v1 } from '@open-rush/contracts';
+import { type FetchLike, type OpenRushClientOptions, performRequest } from './http.js';
+import {
+  type RunEvent,
+  type StreamEventsOptions,
+  streamEvents as streamEventsImpl,
+} from './sse.js';
+
+/**
+ * Root client. All resource-scoped operations hang off its getters.
+ */
+export class OpenRushClient {
+  readonly baseUrl: string;
+  readonly token?: string;
+  readonly defaultHeaders?: Record<string, string>;
+  readonly fetchImpl?: FetchLike;
+
+  readonly authTokens: AuthTokensResource;
+  readonly agentDefinitions: AgentDefinitionsResource;
+  readonly agents: AgentsResource;
+  readonly runs: RunsResource;
+  readonly vaults: VaultsResource;
+  readonly skills: SkillsResource;
+  readonly mcps: McpsResource;
+  readonly projects: ProjectsResource;
+
+  constructor(opts: OpenRushClientOptions) {
+    if (!opts.baseUrl) throw new Error('OpenRushClient: baseUrl is required');
+    this.baseUrl = opts.baseUrl;
+    this.token = opts.token;
+    this.defaultHeaders = opts.defaultHeaders;
+    this.fetchImpl = opts.fetch;
+    this.authTokens = new AuthTokensResource(this);
+    this.agentDefinitions = new AgentDefinitionsResource(this);
+    this.agents = new AgentsResource(this);
+    this.runs = new RunsResource(this);
+    this.vaults = new VaultsResource(this);
+    this.skills = new SkillsResource(this);
+    this.mcps = new McpsResource(this);
+    this.projects = new ProjectsResource(this);
+  }
+
+  /** @internal — used by resource namespaces. */
+  _request<T>(req: Parameters<typeof performRequest<T>>[1]): Promise<T> {
+    return performRequest<T>(this._transport(), req);
+  }
+
+  /** @internal — used by resource namespaces and the SSE subscriber. */
+  _transport(): OpenRushClientOptions {
+    return {
+      baseUrl: this.baseUrl,
+      token: this.token,
+      defaultHeaders: this.defaultHeaders,
+      fetch: this.fetchImpl,
+    };
+  }
+
+  /**
+   * Public: subscribe to `GET /api/v1/agents/{agentId}/runs/{runId}/events`
+   * with transparent reconnect. See `StreamEventsOptions`.
+   */
+  streamEvents(opts: StreamEventsOptions): AsyncGenerator<RunEvent, void, void> {
+    return streamEventsImpl(this._transport(), opts);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Resource namespaces
+// ----------------------------------------------------------------------------
+
+abstract class Resource {
+  protected readonly client: OpenRushClient;
+  constructor(client: OpenRushClient) {
+    this.client = client;
+  }
+}
+
+/** `/api/v1/auth/tokens` — Service Token CRUD. */
+export class AuthTokensResource extends Resource {
+  create(body: v1.CreateTokenRequest): Promise<v1.CreateTokenResponse> {
+    return this.client._request<v1.CreateTokenResponse>({
+      method: 'POST',
+      path: '/api/v1/auth/tokens',
+      body,
+    });
+  }
+
+  list(query: Partial<v1.PaginationQuery> = {}): Promise<v1.ListTokensResponse> {
+    return this.client._request<v1.ListTokensResponse>({
+      method: 'GET',
+      path: '/api/v1/auth/tokens',
+      query,
+    });
+  }
+
+  delete(id: string): Promise<v1.DeleteTokenResponse> {
+    return this.client._request<v1.DeleteTokenResponse>({
+      method: 'DELETE',
+      path: `/api/v1/auth/tokens/${encodeURIComponent(id)}`,
+    });
+  }
+}
+
+/** `/api/v1/agent-definitions` — versioned AgentDefinition CRUD. */
+export class AgentDefinitionsResource extends Resource {
+  create(body: v1.CreateAgentDefinitionRequest): Promise<v1.CreateAgentDefinitionResponse> {
+    return this.client._request<v1.CreateAgentDefinitionResponse>({
+      method: 'POST',
+      path: '/api/v1/agent-definitions',
+      body,
+    });
+  }
+
+  list(
+    query: Partial<v1.ListAgentDefinitionsQuery> = {}
+  ): Promise<v1.ListAgentDefinitionsResponse> {
+    return this.client._request<v1.ListAgentDefinitionsResponse>({
+      method: 'GET',
+      path: '/api/v1/agent-definitions',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+
+  get(id: string, query: v1.GetAgentDefinitionQuery = {}): Promise<v1.GetAgentDefinitionResponse> {
+    return this.client._request<v1.GetAgentDefinitionResponse>({
+      method: 'GET',
+      path: `/api/v1/agent-definitions/${encodeURIComponent(id)}`,
+      query: { version: query.version },
+    });
+  }
+
+  /**
+   * PATCH requires `If-Match: <current_version>`. Passing
+   * `ifMatchVersion` prevents the easy mistake of forgetting the
+   * optimistic-concurrency header — server returns 409
+   * VERSION_CONFLICT on mismatch.
+   */
+  patch(
+    id: string,
+    ifMatchVersion: number,
+    body: v1.PatchAgentDefinitionRequest
+  ): Promise<v1.PatchAgentDefinitionResponse> {
+    return this.client._request<v1.PatchAgentDefinitionResponse>({
+      method: 'PATCH',
+      path: `/api/v1/agent-definitions/${encodeURIComponent(id)}`,
+      body,
+      headers: { 'If-Match': String(ifMatchVersion) },
+    });
+  }
+
+  listVersions(
+    id: string,
+    query: Partial<v1.PaginationQuery> = {}
+  ): Promise<v1.ListAgentDefinitionVersionsResponse> {
+    return this.client._request<v1.ListAgentDefinitionVersionsResponse>({
+      method: 'GET',
+      path: `/api/v1/agent-definitions/${encodeURIComponent(id)}/versions`,
+      query,
+    });
+  }
+
+  archive(id: string): Promise<v1.ArchiveAgentDefinitionResponse> {
+    return this.client._request<v1.ArchiveAgentDefinitionResponse>({
+      method: 'POST',
+      path: `/api/v1/agent-definitions/${encodeURIComponent(id)}/archive`,
+    });
+  }
+}
+
+/** `/api/v1/agents` — Agent (task row) CRUD. */
+export class AgentsResource extends Resource {
+  create(body: v1.CreateAgentRequest): Promise<v1.CreateAgentResponse> {
+    return this.client._request<v1.CreateAgentResponse>({
+      method: 'POST',
+      path: '/api/v1/agents',
+      body,
+    });
+  }
+
+  list(query: Partial<v1.ListAgentsQuery> = {}): Promise<v1.ListAgentsResponse> {
+    return this.client._request<v1.ListAgentsResponse>({
+      method: 'GET',
+      path: '/api/v1/agents',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+
+  get(id: string): Promise<v1.GetAgentResponse> {
+    return this.client._request<v1.GetAgentResponse>({
+      method: 'GET',
+      path: `/api/v1/agents/${encodeURIComponent(id)}`,
+    });
+  }
+
+  delete(id: string): Promise<v1.DeleteAgentResponse> {
+    return this.client._request<v1.DeleteAgentResponse>({
+      method: 'DELETE',
+      path: `/api/v1/agents/${encodeURIComponent(id)}`,
+    });
+  }
+}
+
+/**
+ * `/api/v1/agents/{agentId}/runs` — Run lifecycle + event stream.
+ *
+ * Event stream lives on `OpenRushClient.streamEvents()` (top-level for
+ * discoverability), but CRUD hangs off `client.runs`.
+ */
+export class RunsResource extends Resource {
+  /**
+   * Create a Run. `idempotencyKey` is an opaque URL-safe ASCII string
+   * (≤ 160 chars) — clients SHOULD use UUIDv4. Spec §幂等性:
+   *
+   *   - same key + same body within 24 h → replay original 201
+   *   - same key + different body within 24 h → 409 IDEMPOTENCY_CONFLICT
+   *
+   * Omit `idempotencyKey` entirely to opt out (server treats the call
+   * as a brand-new run each time).
+   */
+  create(
+    agentId: string,
+    body: v1.CreateRunRequest,
+    options: { idempotencyKey?: string } = {}
+  ): Promise<v1.CreateRunResponse> {
+    return this.client._request<v1.CreateRunResponse>({
+      method: 'POST',
+      path: `/api/v1/agents/${encodeURIComponent(agentId)}/runs`,
+      body,
+      headers:
+        options.idempotencyKey !== undefined
+          ? { 'Idempotency-Key': options.idempotencyKey }
+          : undefined,
+    });
+  }
+
+  list(agentId: string, query: Partial<v1.ListRunsQuery> = {}): Promise<v1.ListRunsResponse> {
+    return this.client._request<v1.ListRunsResponse>({
+      method: 'GET',
+      path: `/api/v1/agents/${encodeURIComponent(agentId)}/runs`,
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+
+  get(agentId: string, runId: string): Promise<v1.GetRunResponse> {
+    return this.client._request<v1.GetRunResponse>({
+      method: 'GET',
+      path: `/api/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(runId)}`,
+    });
+  }
+
+  cancel(agentId: string, runId: string): Promise<v1.CancelRunResponse> {
+    return this.client._request<v1.CancelRunResponse>({
+      method: 'POST',
+      path: `/api/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(runId)}/cancel`,
+    });
+  }
+}
+
+/** `/api/v1/vaults/entries` — credential vault. */
+export class VaultsResource extends Resource {
+  create(body: v1.CreateVaultEntryRequest): Promise<v1.CreateVaultEntryResponse> {
+    return this.client._request<v1.CreateVaultEntryResponse>({
+      method: 'POST',
+      path: '/api/v1/vaults/entries',
+      body,
+    });
+  }
+
+  list(query: Partial<v1.ListVaultEntriesQuery> = {}): Promise<v1.ListVaultEntriesResponse> {
+    return this.client._request<v1.ListVaultEntriesResponse>({
+      method: 'GET',
+      path: '/api/v1/vaults/entries',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+
+  delete(id: string): Promise<v1.DeleteVaultEntryResponse> {
+    return this.client._request<v1.DeleteVaultEntryResponse>({
+      method: 'DELETE',
+      path: `/api/v1/vaults/entries/${encodeURIComponent(id)}`,
+    });
+  }
+}
+
+/** `/api/v1/skills` — read-only Skill registry. */
+export class SkillsResource extends Resource {
+  list(query: Partial<v1.ListSkillsQuery> = {}): Promise<v1.ListSkillsResponse> {
+    return this.client._request<v1.ListSkillsResponse>({
+      method: 'GET',
+      path: '/api/v1/skills',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+}
+
+/** `/api/v1/mcps` — read-only MCP registry. */
+export class McpsResource extends Resource {
+  list(query: Partial<v1.ListMcpsQuery> = {}): Promise<v1.ListMcpsResponse> {
+    return this.client._request<v1.ListMcpsResponse>({
+      method: 'GET',
+      path: '/api/v1/mcps',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+}
+
+/** `/api/v1/projects` — Project minimal CRUD. */
+export class ProjectsResource extends Resource {
+  create(body: v1.CreateProjectRequest): Promise<v1.CreateProjectResponse> {
+    return this.client._request<v1.CreateProjectResponse>({
+      method: 'POST',
+      path: '/api/v1/projects',
+      body,
+    });
+  }
+
+  list(query: Partial<v1.ListProjectsQuery> = {}): Promise<v1.ListProjectsResponse> {
+    return this.client._request<v1.ListProjectsResponse>({
+      method: 'GET',
+      path: '/api/v1/projects',
+      query: query as Record<string, string | number | boolean | undefined | null>,
+    });
+  }
+
+  get(id: string): Promise<v1.GetProjectResponse> {
+    return this.client._request<v1.GetProjectResponse>({
+      method: 'GET',
+      path: `/api/v1/projects/${encodeURIComponent(id)}`,
+    });
+  }
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,0 +1,89 @@
+/**
+ * `OpenRushApiError` — the SDK's single error type for non-2xx responses.
+ *
+ * The server always returns `{ error: { code, message, hint?, issues? } }`
+ * on failure (spec §错误响应). We surface that shape 1:1 so callers can
+ * switch on `err.code` without digging through `err.cause` or parsing
+ * strings. HTTP status is preserved for transport-layer decisions
+ * (retry/back-off); body-level `code` is the stable contract.
+ *
+ * We deliberately do NOT subclass per error code (e.g. no
+ * `OpenRushForbiddenError`): the code list is stable (8 values, see
+ * `packages/contracts/src/v1/common.ts`), and forcing callers to `catch`
+ * over a hierarchy adds no value for a documented discriminated union.
+ */
+
+import type { v1 } from '@open-rush/contracts';
+
+export type OpenRushErrorCode = v1.ErrorCode;
+
+export interface OpenRushApiErrorIssue {
+  path: Array<string | number>;
+  message: string;
+}
+
+export interface OpenRushApiErrorBody {
+  code: OpenRushErrorCode;
+  message: string;
+  hint?: string;
+  issues?: OpenRushApiErrorIssue[];
+}
+
+/**
+ * Thrown by every client method on non-2xx HTTP responses.
+ *
+ * Fields:
+ * - `status` — HTTP status code (e.g. 401, 409, 500)
+ * - `code`   — body `error.code` (stable discriminator)
+ * - `message`— body `error.message` (human-readable)
+ * - `hint`   — optional remediation hint
+ * - `issues` — optional per-field validation issues (VALIDATION_ERROR)
+ * - `body`   — raw parsed response body if JSON (for diagnostics)
+ *
+ * The server ALWAYS returns the canonical envelope on error. If for
+ * some reason the body is not parseable JSON or doesn't match the
+ * envelope (e.g. 502 from an upstream proxy), we synthesise `code =
+ * 'INTERNAL'` and surface the raw text in `message`.
+ */
+export class OpenRushApiError extends Error {
+  readonly status: number;
+  readonly code: OpenRushErrorCode;
+  readonly hint?: string;
+  readonly issues?: OpenRushApiErrorIssue[];
+  readonly body: unknown;
+
+  constructor(init: {
+    status: number;
+    code: OpenRushErrorCode;
+    message: string;
+    hint?: string;
+    issues?: OpenRushApiErrorIssue[];
+    body: unknown;
+  }) {
+    super(init.message);
+    this.name = 'OpenRushApiError';
+    this.status = init.status;
+    this.code = init.code;
+    this.hint = init.hint;
+    this.issues = init.issues;
+    this.body = init.body;
+  }
+}
+
+/** Narrow an unknown into `OpenRushApiErrorBody`, or return null. */
+export function parseErrorBody(value: unknown): OpenRushApiErrorBody | null {
+  if (value === null || typeof value !== 'object') return null;
+  const outer = value as Record<string, unknown>;
+  const inner = outer.error;
+  if (inner === null || typeof inner !== 'object') return null;
+  const body = inner as Record<string, unknown>;
+  const code = body.code;
+  const message = body.message;
+  if (typeof code !== 'string' || typeof message !== 'string') return null;
+  return {
+    code: code as OpenRushErrorCode,
+    message,
+    hint: typeof body.hint === 'string' ? body.hint : undefined,
+    issues: Array.isArray(body.issues) ? (body.issues as OpenRushApiErrorIssue[]) : undefined,
+  };
+}

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -1,0 +1,221 @@
+/**
+ * Thin HTTP transport layer for `OpenRushClient`.
+ *
+ * Responsibilities:
+ *   - Build the request URL from `(baseUrl, path, query)`.
+ *   - Attach `Authorization: Bearer <token>` (Service Token flow) OR pass
+ *     through caller-supplied headers (session cookie flow is
+ *     transparent: cookie handling is the runtime's concern, not the
+ *     SDK's).
+ *   - Serialize JSON bodies and set `Content-Type`.
+ *   - Parse JSON responses; on non-2xx, throw `OpenRushApiError` with the
+ *     spec-canonical `{ error: {...} }` envelope.
+ *   - Expose `requestStream()` to return the raw `Response` (used by the
+ *     SSE reader — which wants the `ReadableStream<Uint8Array>` body and
+ *     must not consume JSON).
+ *
+ * Non-responsibilities:
+ *   - NO retry / rate-limit back-off. The server returns 429 RATE_LIMITED
+ *     and 500 INTERNAL with a stable body; caller decides the retry policy.
+ *     Baking in retries couples the SDK to a single policy and makes test
+ *     timing harder.
+ *   - NO request signing beyond bearer token — we don't own secrets.
+ *   - NO auto-pagination. Each list method returns `{ data, nextCursor }`
+ *     and the caller drives the loop. Auto-paginate could be a separate
+ *     helper if needed later.
+ *
+ * `fetchImpl` is injectable so unit tests can replace `globalThis.fetch`
+ * without touching the module-level binding. In Node ≥ 18 / the browser,
+ * the default is `globalThis.fetch`.
+ */
+
+import { OpenRushApiError, parseErrorBody } from './errors.js';
+
+export type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+export interface OpenRushClientOptions {
+  /** Base URL, e.g. `https://rush.example.com` (no trailing slash required). */
+  baseUrl: string;
+  /**
+   * Service Token (Bearer). Omit when using session cookies — then the
+   * caller's runtime (browser / curl with --cookie) is responsible for
+   * sending the cookie jar.
+   */
+  token?: string;
+  /** Extra default headers merged into every request. */
+  defaultHeaders?: Record<string, string>;
+  /** Custom fetch (tests, custom agents). Defaults to `globalThis.fetch`. */
+  fetch?: FetchLike;
+}
+
+export type QueryValue = string | number | boolean | undefined | null;
+export type Query = Record<string, QueryValue>;
+
+export interface RequestOptions {
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  path: string;
+  query?: Query;
+  /** JSON-serialised and sent as `Content-Type: application/json`. */
+  body?: unknown;
+  /** Extra headers (merged on top of defaults + auth). */
+  headers?: Record<string, string>;
+  /** Caller-controlled abort (pass through to `fetch`). */
+  signal?: AbortSignal;
+}
+
+/**
+ * Strip trailing slashes from `baseUrl` so `${baseUrl}${path}` never
+ * produces double slashes regardless of caller input (`http://host/` vs
+ * `http://host`).
+ */
+function normaliseBaseUrl(v: string): string {
+  return v.replace(/\/+$/, '');
+}
+
+/**
+ * Build a full URL from `(baseUrl, path, query)`. Path is expected to
+ * start with `/api/v1/...`; we don't enforce that here because tests may
+ * want to hit a mock path. Query values of `undefined`/`null` are
+ * dropped (so callers can spread optional filters without stringifying).
+ */
+export function buildUrl(baseUrl: string, path: string, query?: Query): string {
+  const base = normaliseBaseUrl(baseUrl);
+  const url = new URL(path, `${base}/`);
+  // URL + relative path can drop host if `path` starts with `//`. Guard:
+  // we expect absolute paths beginning with `/`.
+  if (query) {
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined || v === null) continue;
+      url.searchParams.set(k, String(v));
+    }
+  }
+  return url.toString();
+}
+
+/**
+ * Core transport. Dispatches a single request, parses JSON (or returns
+ * null for 204), throws `OpenRushApiError` on non-2xx.
+ *
+ * Content-Type conventions:
+ *   - Request with `body` set → `application/json`
+ *   - Request with `body === undefined` → no Content-Type header
+ *
+ * We ALWAYS set `Accept: application/json` so servers that negotiate
+ * content types return the expected shape.
+ */
+export async function performRequest<T>(
+  opts: OpenRushClientOptions,
+  req: RequestOptions
+): Promise<T> {
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as FetchLike | undefined);
+  if (!fetchImpl) {
+    throw new Error('OpenRushClient: no fetch implementation (pass `fetch` option on Node < 18)');
+  }
+
+  const url = buildUrl(opts.baseUrl, req.path, req.query);
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...opts.defaultHeaders,
+    ...req.headers,
+  };
+  if (opts.token) {
+    headers.Authorization = `Bearer ${opts.token}`;
+  }
+  let body: string | undefined;
+  if (req.body !== undefined) {
+    headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
+    body = JSON.stringify(req.body);
+  }
+
+  const res = await fetchImpl(url, {
+    method: req.method ?? 'GET',
+    headers,
+    body,
+    signal: req.signal,
+  });
+
+  if (res.status === 204) {
+    return undefined as unknown as T;
+  }
+
+  // Parse JSON best-effort — even on non-2xx, the envelope is JSON.
+  let parsed: unknown = null;
+  const text = await res.text();
+  if (text.length > 0) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (!res.ok) {
+    const err = parseErrorBody(parsed);
+    throw new OpenRushApiError({
+      status: res.status,
+      code: err?.code ?? 'INTERNAL',
+      message: err?.message ?? (text || `HTTP ${res.status}`),
+      hint: err?.hint,
+      issues: err?.issues,
+      body: parsed ?? text,
+    });
+  }
+
+  return parsed as T;
+}
+
+/**
+ * Streaming variant: returns the raw `Response` so the caller can read
+ * the body as a `ReadableStream<Uint8Array>`. Used by the SSE
+ * subscriber. We still throw `OpenRushApiError` on non-2xx responses —
+ * the server will have returned a JSON envelope before opening the
+ * event stream, so there's no interleaving risk.
+ */
+export async function performStreamRequest(
+  opts: OpenRushClientOptions,
+  req: RequestOptions & { method?: 'GET' }
+): Promise<Response> {
+  const fetchImpl = opts.fetch ?? (globalThis.fetch as FetchLike | undefined);
+  if (!fetchImpl) {
+    throw new Error('OpenRushClient: no fetch implementation (pass `fetch` option on Node < 18)');
+  }
+
+  const url = buildUrl(opts.baseUrl, req.path, req.query);
+  const headers: Record<string, string> = {
+    Accept: 'text/event-stream',
+    ...opts.defaultHeaders,
+    ...req.headers,
+  };
+  if (opts.token) {
+    headers.Authorization = `Bearer ${opts.token}`;
+  }
+
+  const res = await fetchImpl(url, {
+    method: req.method ?? 'GET',
+    headers,
+    signal: req.signal,
+  });
+
+  if (!res.ok) {
+    // Read the error envelope and synthesise an OpenRushApiError the
+    // same way `performRequest` would.
+    let parsed: unknown = null;
+    try {
+      const text = await res.text();
+      if (text) parsed = JSON.parse(text);
+    } catch {
+      // fallthrough
+    }
+    const err = parseErrorBody(parsed);
+    throw new OpenRushApiError({
+      status: res.status,
+      code: err?.code ?? 'INTERNAL',
+      message: err?.message ?? `HTTP ${res.status}`,
+      hint: err?.hint,
+      issues: err?.issues,
+      body: parsed,
+    });
+  }
+
+  return res;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * `@open-rush/sdk` — TypeScript client for the Open-rush `/api/v1/*`
+ * Managed Agents API.
+ *
+ * The SDK is a thin HTTP wrapper plus an SSE subscriber. All request /
+ * response types come from `@open-rush/contracts` (the Zod source of
+ * truth) — nothing is duplicated here. That means upgrading the SDK
+ * automatically tracks contract changes at compile time.
+ *
+ * Public surface:
+ *   - `OpenRushClient` — constructor + 8 resource namespaces + streamEvents
+ *   - `OpenRushApiError` — thrown on non-2xx responses (discriminated via `code`)
+ *   - `v1` — all contract types re-exported for convenience
+ *   - SSE: `RunEvent`, `StreamEventsOptions`, `parseSseFrame`,
+ *     `DEFAULT_RECONNECT_DELAYS_MS`
+ *
+ * See README.md for a quickstart + examples.
+ */
+
+// Re-export the v1 namespace so callers can import types from the SDK
+// directly: `import { v1 } from '@open-rush/sdk'`.
+export { v1 } from '@open-rush/contracts';
+export type {
+  AgentDefinitionsResource,
+  AgentsResource,
+  AuthTokensResource,
+  McpsResource,
+  ProjectsResource,
+  RunsResource,
+  SkillsResource,
+  VaultsResource,
+} from './client.js';
+export { OpenRushClient } from './client.js';
+export {
+  OpenRushApiError,
+  type OpenRushApiErrorBody,
+  type OpenRushApiErrorIssue,
+  type OpenRushErrorCode,
+  parseErrorBody,
+} from './errors.js';
+export type {
+  FetchLike,
+  OpenRushClientOptions,
+  Query,
+  QueryValue,
+  RequestOptions,
+} from './http.js';
+export { buildUrl } from './http.js';
+export {
+  type ClientTransport,
+  DEFAULT_RECONNECT_DELAYS_MS,
+  parseSseFrame,
+  type RunEvent,
+  type StreamEventsOptions,
+  streamEvents,
+} from './sse.js';

--- a/packages/sdk/src/sse.ts
+++ b/packages/sdk/src/sse.ts
@@ -1,0 +1,341 @@
+/**
+ * SSE subscriber for `GET /api/v1/agents/{agentId}/runs/{runId}/events`.
+ *
+ * Protocol (locked in task-14, see spec §断线重连 + task-14 handoff
+ * notes `docs/execution/progress/agent-b-relay2-task18-notes.md`):
+ *   - Content-Type: `text/event-stream`
+ *   - Every frame has shape `id: <seq>\ndata: <json>\n\n`
+ *   - Reconnect with `Last-Event-ID: <seq>` header (no query cursor)
+ *   - Server keeps the connection open until the Run hits terminal state,
+ *     then drains and closes.
+ *
+ * Design goals:
+ *   - Zero runtime dependency (browser + Node ≥ 18 + Bun + Deno all
+ *     support `fetch` + `ReadableStream` + `TextDecoder`).
+ *   - **Transparent reconnect**: expose two shapes — a low-level
+ *     `readEvents()` async generator (one connection only) and a
+ *     higher-level `streamEvents()` that auto-reconnects on unexpected
+ *     EOF / network errors, remembering the last-seen seq and retrying
+ *     with `Last-Event-ID`. The latter closes cleanly when the Run
+ *     reaches terminal (signalled by `data-openrush-run-done`) or when
+ *     the caller aborts.
+ *   - **Idempotent re-delivery**: we never re-emit an event with the same
+ *     seq across reconnects. The server guarantees `seq > lastEventId`
+ *     semantics, but we also filter client-side as a safety belt.
+ *
+ * We decoded events into `{ id: number, data: RunEventPayload }` using
+ * the contract type straight from `@open-rush/contracts`. No Zod
+ * runtime validation on hot path (payload shape is already validated
+ * server-side; re-validating costs 1–2 ms per frame and the SDK stays
+ * thin). Callers who want Zod validation can re-parse via
+ * `v1.runEventPayloadSchema.parse(ev.data)`.
+ */
+
+import type { v1 } from '@open-rush/contracts';
+import { type FetchLike, performStreamRequest } from './http.js';
+
+/**
+ * One decoded SSE frame as exposed to the caller.
+ *
+ * `id` is a finite positive integer = per-run `run_events.seq`. We cast
+ * the server-provided payload to `v1.RunEventPayload` without runtime
+ * validation (see module docstring).
+ */
+export interface RunEvent {
+  id: number;
+  data: v1.RunEventPayload;
+}
+
+/**
+ * Subscriber context — what you pass to `streamEvents()`.
+ */
+export interface StreamEventsOptions {
+  agentId: string;
+  runId: string;
+  /**
+   * Resume from this seq. Typically the last `ev.id` your consumer
+   * successfully handled (so on crash + restart you don't replay
+   * already-processed events). Defaults to 0 (= "from the beginning").
+   */
+  lastEventId?: number;
+  /**
+   * Caller-driven cancellation. When the signal aborts we stop the
+   * reader loop, release the reader, and swallow `AbortError`. The
+   * async iterator terminates cleanly.
+   */
+  signal?: AbortSignal;
+  /**
+   * Reconnection strategy, consulted on two situations:
+   *
+   *   - **Unexpected EOF** (`cause: 'eof'`) — mid-run disconnect (connection
+   *     dropped before `data-openrush-run-done` and while more events
+   *     were still in flight). Returning `false` makes the iterator
+   *     exit gracefully (no throw).
+   *   - **Thrown error** (`cause: Error`) — a network / HTTP error
+   *     bubbled from `fetch` or `performStreamRequest`. Returning
+   *     `false` rethrows the original error so the caller can observe
+   *     the failure; return `true` / a delay to attempt reconnection.
+   *
+   * Note: a terminal-run resume (caller passes `lastEventId` equal to
+   * the last seq of an already-completed run) EOFs with zero new
+   * events and terminates WITHOUT consulting this callback. That's
+   * consistent with the task-14 server behaviour (drain once, close).
+   *
+   * Default: up to 5 reconnects, 500 ms → 1 s → 2 s → 4 s → 8 s back-off.
+   * Return `false` to stop; return a delay in ms to retry.
+   */
+  onReconnect?: (ctx: {
+    attempt: number;
+    lastEventId: number;
+    cause: unknown;
+  }) => boolean | number | Promise<boolean | number>;
+}
+
+export interface ClientTransport {
+  baseUrl: string;
+  token?: string;
+  defaultHeaders?: Record<string, string>;
+  fetch?: FetchLike;
+}
+
+/**
+ * Default back-off schedule. Exported so callers can inspect + compose.
+ * Capped at 5 attempts to avoid retrying forever on a genuinely dead
+ * server (server-side per-run state has 15-state machine with its own
+ * retry/finalize logic — the SDK doesn't need to be aggressive).
+ */
+export const DEFAULT_RECONNECT_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000];
+
+/** Async sleep that honours an AbortSignal. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Split a UTF-8 stream into SSE frames, yielding each frame's raw text
+ * (without the trailing `\n\n`). Blank keep-alive lines (`\n\n` with no
+ * content) are skipped.
+ *
+ * Why we don't trust `EventSource` (WHATWG): EventSource doesn't let us
+ * override the HTTP request (bearer auth, custom headers) and it
+ * silently auto-reconnects with its own heuristic — we need explicit
+ * control over `Last-Event-ID` and back-off.
+ */
+async function* iterateSseFrames(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal
+): AsyncGenerator<string, void, void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buffer = '';
+  const onAbort = () => {
+    void reader.cancel();
+  };
+  signal?.addEventListener('abort', onAbort, { once: true });
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let idx = buffer.indexOf('\n\n');
+      while (idx !== -1) {
+        const frame = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 2);
+        if (frame.length > 0) yield frame;
+        idx = buffer.indexOf('\n\n');
+      }
+    }
+    // Flush any trailing partial frame (unusual — servers end on \n\n).
+    const tail = buffer + decoder.decode();
+    if (tail.trim().length > 0) yield tail;
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released
+    }
+  }
+}
+
+/**
+ * Parse one SSE frame text into `RunEvent`. The wire format is:
+ *   `id: <n>\ndata: <json>`
+ *
+ * We tolerate multi-line `data:` (WHATWG spec allows concatenation),
+ * extra whitespace, and comment lines (`:foo`). If the frame is
+ * malformed — no `id:` line, non-integer id, or invalid JSON — we return
+ * `null` and the caller skips it. Server is the single writer and has
+ * its own invariants (every frame has an id, JSON is canonical), so
+ * malformed frames in practice are a proxy/infrastructure bug; we log
+ * nothing and keep the stream alive.
+ */
+export function parseSseFrame(text: string): RunEvent | null {
+  let id: number | null = null;
+  const dataLines: string[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trimEnd(); // tolerate CR
+    if (line === '' || line.startsWith(':')) continue;
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const field = line.slice(0, colon);
+    // WHATWG: one optional space after the colon.
+    const value = line.slice(colon + 1).replace(/^ /, '');
+    if (field === 'id') {
+      const n = Number(value);
+      if (!Number.isInteger(n) || n <= 0) return null;
+      id = n;
+    } else if (field === 'data') {
+      dataLines.push(value);
+    }
+    // event / retry / other fields ignored — server doesn't emit them.
+  }
+  if (id === null || dataLines.length === 0) return null;
+  try {
+    const data = JSON.parse(dataLines.join('\n')) as v1.RunEventPayload;
+    return { id, data };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Internal: open a single SSE connection and yield events until the
+ * server closes the stream (terminal run → EOF) or the caller aborts.
+ * On AbortError we exit cleanly; on other errors we re-throw so the
+ * outer reconnect loop can decide.
+ */
+async function* readSingleConnection(
+  transport: ClientTransport,
+  agentId: string,
+  runId: string,
+  lastEventId: number,
+  signal?: AbortSignal
+): AsyncGenerator<RunEvent, void, void> {
+  const res = await performStreamRequest(transport, {
+    method: 'GET',
+    path: `/api/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(runId)}/events`,
+    headers: lastEventId > 0 ? { 'Last-Event-ID': String(lastEventId) } : undefined,
+    signal,
+  });
+  if (!res.body) {
+    throw new Error('SSE response has no body');
+  }
+  for await (const frame of iterateSseFrames(res.body, signal)) {
+    const ev = parseSseFrame(frame);
+    if (ev === null) continue;
+    if (ev.id <= lastEventId) continue; // belt-and-braces dedup
+    yield ev;
+  }
+}
+
+/** Terminal detection — the `data-openrush-run-done` extension event. */
+function isRunDone(ev: RunEvent): boolean {
+  return (ev.data as { type?: string }).type === 'data-openrush-run-done';
+}
+
+/**
+ * Public: async iterator over `RunEvent`s for a given Run, with
+ * transparent reconnect. Closes cleanly when:
+ *
+ *   - `data-openrush-run-done` is delivered (spec-mandated terminal event)
+ *   - the signal aborts
+ *   - the server EOFs and the reconnect policy returns false / throws
+ *
+ * Example:
+ *
+ *     const ctrl = new AbortController();
+ *     for await (const ev of client.streamEvents({ agentId, runId, signal: ctrl.signal })) {
+ *       if (ev.data.type === 'text-delta') process.stdout.write(ev.data.delta ?? '');
+ *     }
+ */
+export async function* streamEvents(
+  transport: ClientTransport,
+  opts: StreamEventsOptions
+): AsyncGenerator<RunEvent, void, void> {
+  let lastEventId = opts.lastEventId ?? 0;
+  let attempt = 0;
+  const onReconnect =
+    opts.onReconnect ?? (({ attempt: a }) => DEFAULT_RECONNECT_DELAYS_MS[a - 1] ?? false);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (opts.signal?.aborted) return;
+    try {
+      let yielded = 0;
+      let sawRunDone = false;
+      for await (const ev of readSingleConnection(
+        transport,
+        opts.agentId,
+        opts.runId,
+        lastEventId,
+        opts.signal
+      )) {
+        lastEventId = ev.id;
+        yielded += 1;
+        yield ev;
+        if (isRunDone(ev)) {
+          sawRunDone = true;
+        }
+      }
+      // Connection EOF. Termination policy:
+      //
+      //   1. `sawRunDone`        → terminal event delivered, exit.
+      //   2. `yielded === 0`     → server returned zero new events and
+      //      closed. This matches task-14 server behaviour for an
+      //      already-terminal run: the route drains once then calls
+      //      `cleanup()` (see
+      //      `apps/web/app/api/v1/agents/[agentId]/runs/[runId]/events/route.ts`
+      //      `initialIsTerminal` branch). For a live run the server
+      //      keeps the connection open and polls `run_events` every
+      //      500 ms, so a zero-event EOF reliably means "nothing more
+      //      to send". Treating it as terminal avoids the pathological
+      //      ~15 s back-off chain the caller would otherwise eat on
+      //      `streamEvents({ lastEventId: <last seq of completed run> })`.
+      //   3. Otherwise: mid-run disconnect — consult reconnect policy.
+      //
+      // Note (2) intentionally aliases "terminal run resume" and
+      // "proxy closed the connection with zero new events". Both are
+      // effectively the same "server has nothing for you" signal; the
+      // caller can distinguish by re-fetching `runs.get` if needed.
+      if (sawRunDone || yielded === 0) return;
+      attempt += 1;
+      const next = await onReconnect({ attempt, lastEventId, cause: 'eof' });
+      if (next === false || opts.signal?.aborted) return;
+      if (typeof next === 'number') await sleep(next, opts.signal);
+    } catch (err) {
+      if (isAbortError(err)) return;
+      attempt += 1;
+      let next: boolean | number;
+      try {
+        next = await onReconnect({ attempt, lastEventId, cause: err });
+      } catch {
+        throw err;
+      }
+      if (next === false || opts.signal?.aborted) throw err;
+      if (typeof next === 'number') await sleep(next, opts.signal);
+    }
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  if (err instanceof Error && err.name === 'AbortError') return true;
+  if (err !== null && typeof err === 'object' && (err as { name?: string }).name === 'AbortError') {
+    return true;
+  }
+  return false;
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,25 @@ importers:
         specifier: ^4.0.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/sdk:
+    dependencies:
+      '@open-rush/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/skills:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- New workspace package `@open-rush/sdk` — thin TypeScript client over `/api/v1/*`.
- 8 resource namespaces (`authTokens`, `agentDefinitions`, `agents`, `runs`, `vaults`, `skills`, `mcps`, `projects`) + `streamEvents()` async generator for SSE.
- All request / response types imported from `@open-rush/contracts` (no codegen; compile error on drift).
- `runs.create(agentId, body, { idempotencyKey })` — explicit options object.
- `agentDefinitions.patch(id, ifMatchVersion, body)` — positional required `If-Match`.
- SSE subscriber: `Last-Event-ID` reconnect + configurable back-off (default 5-step 500 ms → 8 s) + AbortSignal + client-side dedup. Mirrors task-14 server semantics: terminal-run resume EOFs with zero events → exit cleanly (no reconnect loop).
- `OpenRushApiError` with stable 8-value discriminated `code`.
- Custom fetch injection for Node < 18 and tests.

Closes #131.

## Test plan

- [x] 62 vitest cases in `packages/sdk/src/__tests__` (http / client / sse)
- [x] `pnpm build && pnpm check && pnpm lint && pnpm test` — 35 workspace tasks all green
- [x] `./docs/execution/verify.sh task-16` → `[PASS]`
- [x] Sparring review — R1 1 MUST-FIX (streamEvents terminal-run reconnect loop) + 2 SHOULD-FIX (README `baseUrl: ''` throws; `onReconnect false` asymmetric semantics), all resolved; R2 APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)